### PR TITLE
fix: patch ControlKeel setup and SQLite migration recovery

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -35,5 +35,5 @@
   "repository": "https://github.com/aryaminus/controlkeel.git",
   "rules": "./rules/",
   "skills": "./skills/",
-  "version": "0.3.47"
+  "version": "0.3.48"
 }

--- a/lib/controlkeel/cli.ex
+++ b/lib/controlkeel/cli.ex
@@ -307,7 +307,8 @@ defmodule ControlKeel.CLI do
     case mode do
       "full" ->
         rule_files = result["rule_files"] || []
-        skills = result["skills"] || []
+        skills = result["effective_skills"] || result["skills"] || []
+        installed_skill_copies = result["installed_skill_copies"] || length(skills)
         duplicates = result["skill_duplicates"] || result["duplicates"] || []
 
         recommendations =
@@ -320,7 +321,8 @@ defmodule ControlKeel.CLI do
           "Project root: #{result["project_root"]}",
           "Total estimated tokens: #{result["estimated_tokens"]}",
           "Rule files: #{length(rule_files)}",
-          "Skills: #{length(skills)}",
+          "Effective skills: #{length(skills)}",
+          "Installed skill copies: #{installed_skill_copies}",
           "Skill tokens: #{result["total_skill_tokens"] || 0}",
           "Duplicate skill groups: #{length(duplicates)}",
           "Duplicate skill tokens: #{result["duplicate_token_count"] || 0}",
@@ -359,7 +361,8 @@ defmodule ControlKeel.CLI do
           Enum.map(rule_files, fn rf -> "  - #{rf["path"]} (#{token_count(rf)} tokens)" end)
 
       "skills" ->
-        skills = result["skills"] || []
+        skills = result["effective_skills"] || result["skills"] || []
+        installed_skill_copies = result["installed_skill_copies"] || length(skills)
         duplicates = result["duplicates"] || []
 
         [
@@ -369,7 +372,8 @@ defmodule ControlKeel.CLI do
           "Project root: #{result["project_root"]}",
           "Total skill tokens: #{result["total_skill_tokens"] || result["estimated_tokens"] || 0}",
           "Duplicate skill tokens: #{result["duplicate_token_count"] || 0}",
-          "Skills: #{length(skills)}",
+          "Effective skills: #{length(skills)}",
+          "Installed skill copies: #{installed_skill_copies}",
           "Duplicate skill groups: #{length(duplicates)}",
           ""
         ] ++

--- a/lib/controlkeel/cli/dispatch/core.ex
+++ b/lib/controlkeel/cli/dispatch/core.ex
@@ -142,6 +142,8 @@ defmodule ControlKeel.CLI.Dispatch.Core do
   end
 
   def run_command(%{command: :status, options: options}, project_root) do
+    project_root = resolve_project_root(options, project_root)
+
     with {:ok, format} <- effective_cli_format(options),
          {:ok, binding, session, _mode} <- ensure_local_project(project_root) do
       metrics = Analytics.session_metrics(session.id) || %{}

--- a/lib/controlkeel/cli/dispatch/governance.ex
+++ b/lib/controlkeel/cli/dispatch/governance.ex
@@ -25,10 +25,11 @@ defmodule ControlKeel.CLI.Dispatch.Governance do
   end
 
   def run_command(%{command: :context, options: options}, project_root) do
+    project_root_resolved = resolve_project_root(options, project_root)
+
     with {:ok, format} <- effective_cli_format(options),
-         {:ok, _binding, default_session, _mode} <- ensure_local_project(project_root) do
+         {:ok, _binding, default_session, _mode} <- ensure_local_project(project_root_resolved) do
       session_id = options[:session_id] || default_session.id
-      project_root_resolved = options[:project_root] || project_root
 
       args =
         %{

--- a/lib/controlkeel/cli/parser.ex
+++ b/lib/controlkeel/cli/parser.ex
@@ -25,7 +25,7 @@ defmodule ControlKeel.CLI.Parser do
     scope: :string,
     json: :boolean
   ]
-  @status_switches [format: :string, json: :boolean]
+  @status_switches [format: :string, json: :boolean, project_root: :string]
   @doctor_switches [project_root: :string, format: :string, json: :boolean]
   @capabilities_switches [format: :string, json: :boolean]
   @update_switches [

--- a/lib/controlkeel/mcp/tools/ck_token_audit.ex
+++ b/lib/controlkeel/mcp/tools/ck_token_audit.ex
@@ -182,19 +182,41 @@ defmodule ControlKeel.MCP.Tools.CkTokenAudit do
     # Find duplicates by skill name
     duplicates = find_duplicate_skills(all_skills)
 
-    # Calculate token cost
-    total_skill_words = Enum.sum(Enum.map(all_skills, & &1["word_count"]))
+    # Deduplicate for token counting: each unique skill counted once.
+    # MCP hosts load skills from their native dir (e.g. .claude/skills/) first,
+    # so duplicate copies in .agents/skills/ or user-level dirs are wasted tokens.
+    # Prefer project-level agent-specific dirs over compat/user dirs.
+    deduplicated_skills =
+      all_skills
+      |> Enum.sort_by(fn skill ->
+        # Prefer project-level agent-specific dirs, then project compat, then user-level
+        cond do
+          String.starts_with?(skill["location"], "project:.claude/") -> 0
+          String.starts_with?(skill["location"], "project:.opencode/") -> 0
+          String.starts_with?(skill["location"], "project:.codex/") -> 0
+          String.starts_with?(skill["location"], "project:.cursor/") -> 0
+          String.starts_with?(skill["location"], "project:") -> 1
+          true -> 2
+        end
+      end)
+      |> Enum.uniq_by(& &1["name"])
+
+    # Calculate token cost using deduplicated set
+    total_skill_words = Enum.sum(Enum.map(deduplicated_skills, & &1["word_count"]))
     total_skill_tokens = estimate_tokens_from_words(total_skill_words)
-    duplicate_words = Enum.sum(Enum.map(duplicates, & &1["total_word_count"]))
+    duplicate_words = Enum.sum(Enum.map(duplicates, & &1["duplicate_word_count"]))
     duplicate_tokens = estimate_tokens_from_words(duplicate_words)
 
-    recommendations = build_skill_recommendations(all_skills, duplicates)
+    recommendations = build_skill_recommendations(all_skills, duplicates, deduplicated_skills)
 
     {:ok,
      %{
        "project_root" => project_root,
        "estimated_tokens" => total_skill_tokens,
        "skills" => all_skills,
+       "effective_skills" => deduplicated_skills,
+       "installed_skill_copies" => length(all_skills),
+       "effective_skill_count" => length(deduplicated_skills),
        "duplicates" => duplicates,
        "total_skill_words" => total_skill_words,
        "total_skill_tokens" => total_skill_tokens,
@@ -469,21 +491,38 @@ defmodule ControlKeel.MCP.Tools.CkTokenAudit do
     |> Enum.group_by(& &1["name"])
     |> Enum.filter(fn {_name, skills} -> length(skills) > 1 end)
     |> Enum.map(fn {name, skills} ->
-      total_word_count = Enum.sum(Enum.map(skills, & &1["word_count"]))
-      total_tokens = estimate_tokens_from_words(total_word_count)
+      sorted_skills =
+        Enum.sort_by(skills, fn skill ->
+          cond do
+            String.starts_with?(skill["location"], "project:.claude/") -> 0
+            String.starts_with?(skill["location"], "project:.opencode/") -> 0
+            String.starts_with?(skill["location"], "project:.codex/") -> 0
+            String.starts_with?(skill["location"], "project:.cursor/") -> 0
+            String.starts_with?(skill["location"], "project:") -> 1
+            true -> 2
+          end
+        end)
+
+      retained_word_count = sorted_skills |> List.first() |> Map.get("word_count", 0)
+      total_word_count = Enum.sum(Enum.map(sorted_skills, & &1["word_count"]))
+      duplicate_word_count = max(total_word_count - retained_word_count, 0)
+      duplicate_tokens = estimate_tokens_from_words(duplicate_word_count)
 
       %{
         "name" => name,
-        "instances" => skills,
-        "count" => length(skills),
+        "instances" => sorted_skills,
+        "count" => length(sorted_skills),
         "total_word_count" => total_word_count,
-        "total_tokens" => total_tokens,
-        "locations" => Enum.map(skills, & &1["location"])
+        "retained_word_count" => retained_word_count,
+        "duplicate_word_count" => duplicate_word_count,
+        "total_tokens" => duplicate_tokens,
+        "duplicate_tokens" => duplicate_tokens,
+        "locations" => Enum.map(sorted_skills, & &1["location"])
       }
     end)
   end
 
-  defp build_skill_recommendations(all_skills, duplicates) do
+  defp build_skill_recommendations(all_skills, duplicates, effective_skills) do
     recommendations = []
 
     # Check for duplicates
@@ -514,7 +553,7 @@ defmodule ControlKeel.MCP.Tools.CkTokenAudit do
 
     # Check for oversized individual skills
     recommendations =
-      all_skills
+      effective_skills
       |> Enum.filter(&(&1["word_count"] > 500))
       |> Enum.reduce(recommendations, fn skill, acc ->
         [

--- a/lib/controlkeel/project_binding.ex
+++ b/lib/controlkeel/project_binding.ex
@@ -430,7 +430,31 @@ defmodule ControlKeel.ProjectBinding do
         _ -> "controlkeel"
       end
 
-    System.find_executable(candidate) || candidate
+    found = System.find_executable(candidate) || candidate
+    unwrap_burrito_path(found)
+  end
+
+  # When running inside a Burrito-wrapped binary, System.find_executable/1
+  # resolves to the extracted ERTS shim (<dir>/.burrito/controlkeel_erts-*/bin/controlkeel)
+  # which only understands mix release commands — not the native CLI surface like `mcp`.
+  # The actual native binary sits at <dir>/controlkeel (one directory up from the ERTS bin/).
+  defp unwrap_burrito_path(path) do
+    if String.contains?(path, ".burrito") and String.contains?(path, "erts-") do
+      # Path layout: <base>/.burrito/controlkeel_erts-<vsn>/bin/controlkeel
+      # We want:  <base>/controlkeel
+      bin_dir = Path.dirname(path)
+      erts_dir = Path.dirname(bin_dir)
+      base_dir = Path.dirname(erts_dir)
+      native = Path.join(base_dir, Path.basename(path))
+
+      if File.exists?(native) do
+        native
+      else
+        path
+      end
+    else
+      path
+    end
   end
 
   defp source_repo_mcp_launcher_path do

--- a/lib/controlkeel/project_root.ex
+++ b/lib/controlkeel/project_root.ex
@@ -40,6 +40,11 @@ defmodule ControlKeel.ProjectRoot do
     |> realpath()
   end
 
+  def project_root?(path \\ File.cwd!()) do
+    resolve(path)
+    |> has_project_marker?()
+  end
+
   defp normalize_start_path(path) do
     expanded = Path.expand(path)
 

--- a/lib/controlkeel/runtime_defaults.ex
+++ b/lib/controlkeel/runtime_defaults.ex
@@ -24,7 +24,9 @@ defmodule ControlKeel.RuntimeDefaults do
   end
 
   def database_path do
-    System.get_env("DATABASE_PATH") || Path.join(app_data_dir(), "controlkeel.db")
+    System.get_env("DATABASE_PATH") ||
+      project_database_path(File.cwd!()) ||
+      Path.join(app_data_dir(), "controlkeel.db")
   end
 
   def secret_key_base do
@@ -95,6 +97,14 @@ defmodule ControlKeel.RuntimeDefaults do
 
   defp default_home do
     System.user_home!()
+  end
+
+  defp project_database_path(cwd) do
+    root = ControlKeel.ProjectRoot.resolve(cwd)
+
+    if ControlKeel.ProjectRoot.project_root?(root) do
+      Path.join([root, "controlkeel", "controlkeel.db"])
+    end
   end
 
   defp ensure_dir!(path) do

--- a/lib/controlkeel/skills/installer.ex
+++ b/lib/controlkeel/skills/installer.ex
@@ -193,7 +193,10 @@ defmodule ControlKeel.Skills.Installer do
         do: Path.join(user_home(), ".codex/agents"),
         else: Path.join(project_root, ".codex/agents")
 
-    copy_skills(skills, compat_skill_root)
+    unless compat_skills_already_populated?(compat_skill_root, skills) do
+      copy_skills(skills, compat_skill_root)
+    end
+
     copy_skills(skills, native_skill_root)
     File.mkdir_p!(agent_root)
 
@@ -293,6 +296,13 @@ defmodule ControlKeel.Skills.Installer do
     {:ok, plan} = Exporter.export("claude-standalone", project_root, scope: scope)
     copy_tree_contents(Path.join(plan.output_dir, ".claude/agents"), agent_root)
 
+    hooks_src = Path.join(plan.output_dir, ".claude/hooks")
+    hooks_dst = Path.join(base, "hooks")
+
+    if File.dir?(hooks_src) do
+      copy_tree_contents(hooks_src, hooks_dst)
+    end
+
     settings_path = Path.join(base, "settings.json")
     merge_claude_settings(settings_path, Exporter.claude_manual_settings())
 
@@ -348,7 +358,10 @@ defmodule ControlKeel.Skills.Installer do
     copy_tree_contents(Path.join(plan.output_dir, ".devin/skills"), native_skill_root)
     copy_tree_contents(Path.join(plan.output_dir, ".devin/agents"), agent_root)
     copy_tree_contents(Path.join(plan.output_dir, ".devin/hooks"), hooks_root)
-    copy_tree_contents(Path.join(plan.output_dir, ".agents/skills"), compat_root)
+
+    unless compat_dir_populated?(compat_root) do
+      copy_tree_contents(Path.join(plan.output_dir, ".agents/skills"), compat_root)
+    end
 
     merge_json_file!(
       Path.join(plan.output_dir, ".devin/config.json"),
@@ -628,7 +641,10 @@ defmodule ControlKeel.Skills.Installer do
     File.mkdir_p!(compat_root)
 
     copy_tree_contents(Path.join(plan.output_dir, ".warp/skills"), native_skill_root)
-    copy_tree_contents(Path.join(plan.output_dir, ".agents/skills"), compat_root)
+
+    unless compat_dir_populated?(compat_root) do
+      copy_tree_contents(Path.join(plan.output_dir, ".agents/skills"), compat_root)
+    end
 
     File.cp!(
       Path.join(plan.output_dir, ".warp/controlkeel-mcp.json"),
@@ -683,7 +699,11 @@ defmodule ControlKeel.Skills.Installer do
     commands_root = Path.join(opencode_root, "commands")
 
     copy_skills(skills, native_skills_root)
-    copy_skills(skills, compat_skills_root)
+    # Only write compat .agents/skills/ if not already populated by another
+    # agent with native skill support — avoids redundant copies wasting tokens.
+    unless compat_skills_already_populated?(compat_skills_root, skills) do
+      copy_skills(skills, compat_skills_root)
+    end
 
     File.mkdir_p!(plugins_root)
     File.mkdir_p!(agents_root)
@@ -1067,6 +1087,22 @@ defmodule ControlKeel.Skills.Installer do
       end)
 
     File.write!(path, Jason.encode!(merged, pretty: true) <> "\n")
+  end
+
+  # Check whether .agents/skills/ already has all the skills we'd write,
+  # meaning another agent with native skill support already populated it.
+  # Avoids redundant copies that waste MCP host context tokens.
+  defp compat_skills_already_populated?(compat_root, skills) do
+    manifest = read_skills_manifest(compat_root)
+    current_names = Enum.map(skills, & &1.name)
+    Enum.all?(current_names, &(&1 in manifest))
+  end
+
+  # Variant for copy_tree_contents-based flows that don't have a skills list.
+  # Checks if the compat dir already has any CK-managed skill directories.
+  defp compat_dir_populated?(compat_root) do
+    manifest = read_skills_manifest(compat_root)
+    length(manifest) > 0
   end
 
   defp copy_skills(skills, destination_root) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ControlKeel.MixProject do
   def project do
     [
       app: :controlkeel,
-      version: "0.3.47",
+      version: "0.3.48",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/packages/npm/controlkeel/package.json
+++ b/packages/npm/controlkeel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aryaminus/controlkeel",
-  "version": "0.3.47",
+  "version": "0.3.48",
   "description": "Bootstrap installer for the ControlKeel native CLI - a control plane for agent-generated software delivery.",
   "license": "Apache-2.0",
   "author": {

--- a/packages/npm/controlkeel/server.json
+++ b/packages/npm/controlkeel/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/aryaminus/controlkeel.git",
     "source": "github"
   },
-  "version": "0.3.47",
+  "version": "0.3.48",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aryaminus/controlkeel",
-      "version": "0.3.47",
+      "version": "0.3.48",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "controlkeel-companion",
   "description": "ControlKeel governance bundle for Copilot custom agents, skills, hooks, and MCP",
-  "version": "0.3.47",
+  "version": "0.3.48",
   "author": {
     "name": "ControlKeel"
   },

--- a/priv/repo/migrations/20260530051232_increase_benchmark_scenarios_content_size.exs
+++ b/priv/repo/migrations/20260530051232_increase_benchmark_scenarios_content_size.exs
@@ -25,9 +25,19 @@ defmodule ControlKeel.Repo.Migrations.IncreaseBenchmarkScenariosContentSize do
       )
       """)
 
+      # Explicit column list rather than a positional `SELECT *`: if the live
+      # table's column order ever diverges from this fresh-schema order (later
+      # ALTER ADD COLUMN migrations append at the end), a positional copy would
+      # misalign columns and violate NOT NULL constraints.
       execute("""
-      INSERT INTO benchmark_scenarios_new
-      SELECT * FROM benchmark_scenarios
+      INSERT INTO benchmark_scenarios_new (
+        id, suite_id, slug, name, category, incident_label, path, kind, content,
+        expected_rules, expected_decision, position, split, metadata, inserted_at, updated_at
+      )
+      SELECT
+        id, suite_id, slug, name, category, incident_label, path, kind, content,
+        expected_rules, expected_decision, position, split, metadata, inserted_at, updated_at
+      FROM benchmark_scenarios
       """)
 
       execute("DROP TABLE benchmark_scenarios")

--- a/priv/repo/migrations/20260530052757_increase_memory_records_text_fields.exs
+++ b/priv/repo/migrations/20260530052757_increase_memory_records_text_fields.exs
@@ -29,8 +29,16 @@ defmodule ControlKeel.Repo.Migrations.IncreaseMemoryRecordsTextFields do
       """)
 
       execute("""
-      INSERT INTO memory_records_new
-      SELECT * FROM memory_records
+      INSERT INTO memory_records_new (
+        id, workspace_id, session_id, task_id, external_id, record_type, title, summary, body, tags,
+        source_type, source_id, metadata, archived_at, visibility, shared_org_id, synced_at,
+        inserted_at, updated_at
+      )
+      SELECT
+        id, workspace_id, session_id, task_id, external_id, record_type, title, summary, body, tags,
+        source_type, source_id, metadata, archived_at, visibility, shared_org_id, synced_at,
+        inserted_at, updated_at
+      FROM memory_records
       """)
 
       execute("DROP TABLE memory_records")
@@ -118,8 +126,16 @@ defmodule ControlKeel.Repo.Migrations.IncreaseMemoryRecordsTextFields do
       """)
 
       execute("""
-      INSERT INTO memory_records_old
-      SELECT * FROM memory_records
+      INSERT INTO memory_records_old (
+        id, workspace_id, session_id, task_id, external_id, record_type, title, summary, body, tags,
+        source_type, source_id, metadata, archived_at, visibility, shared_org_id, synced_at,
+        inserted_at, updated_at
+      )
+      SELECT
+        id, workspace_id, session_id, task_id, external_id, record_type, title, summary, body, tags,
+        source_type, source_id, metadata, archived_at, visibility, shared_org_id, synced_at,
+        inserted_at, updated_at
+      FROM memory_records
       """)
 
       execute("DROP TABLE memory_records")

--- a/priv/repo/migrations/20260530054002_increase_session_events_text_fields.exs
+++ b/priv/repo/migrations/20260530054002_increase_session_events_text_fields.exs
@@ -20,9 +20,19 @@ defmodule ControlKeel.Repo.Migrations.IncreaseSessionEventsTextFields do
       )
       """)
 
+      # Explicit column list: the live session_events column order has diverged
+      # from this fresh-schema order (later ALTER ADD COLUMN migrations append at
+      # the end), so a positional `SELECT *` would misalign columns and violate
+      # NOT NULL on whichever column lands in a nullable source slot.
       execute("""
-      INSERT INTO session_events_new
-      SELECT * FROM session_events
+      INSERT INTO session_events_new (
+        id, session_id, task_id, event_type, actor, summary, body, payload, metadata,
+        inserted_at, updated_at
+      )
+      SELECT
+        id, session_id, task_id, event_type, actor, summary, body, payload, metadata,
+        inserted_at, updated_at
+      FROM session_events
       """)
 
       execute("DROP TABLE session_events")

--- a/test/controlkeel/project_root_test.exs
+++ b/test/controlkeel/project_root_test.exs
@@ -33,4 +33,32 @@ defmodule ControlKeel.ProjectRootTest do
 
     assert ProjectRoot.resolve(tmp_dir) == ProjectRoot.resolve(Path.expand(tmp_dir))
   end
+
+  test "project_root? reflects whether the resolved directory has a project marker" do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "controlkeel-project-root-flag-#{System.unique_integer([:positive])}"
+      )
+
+    File.rm_rf!(tmp_dir)
+    File.mkdir_p!(Path.join(tmp_dir, "lib/trial"))
+    File.write!(Path.join(tmp_dir, "mix.exs"), "defmodule Trial.MixProject do\nend\n")
+
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+    assert ProjectRoot.project_root?(Path.join(tmp_dir, "lib/trial"))
+
+    other_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "controlkeel-project-root-flag-other-#{System.unique_integer([:positive])}"
+      )
+
+    File.rm_rf!(other_dir)
+    File.mkdir_p!(other_dir)
+    on_exit(fn -> File.rm_rf!(other_dir) end)
+
+    refute ProjectRoot.project_root?(other_dir)
+  end
 end

--- a/test/controlkeel/runtime_defaults_test.exs
+++ b/test/controlkeel/runtime_defaults_test.exs
@@ -18,11 +18,45 @@ defmodule ControlKeel.RuntimeDefaultsTest do
   end
 
   test "database_path falls back to a local app-data directory", %{tmp_home: tmp_home} do
-    with_envs(%{"DATABASE_PATH" => nil, "HOME" => tmp_home}, fn ->
-      path = RuntimeDefaults.database_path()
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "controlkeel-runtime-defaults-cwd-#{System.unique_integer([:positive])}"
+      )
 
-      assert String.ends_with?(path, "controlkeel.db")
-      assert File.dir?(Path.dirname(path))
+    File.rm_rf!(tmp_dir)
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+    with_envs(%{"DATABASE_PATH" => nil, "HOME" => tmp_home}, fn ->
+      File.cd!(tmp_dir, fn ->
+        path = RuntimeDefaults.database_path()
+
+        refute String.starts_with?(path, tmp_dir)
+        assert String.ends_with?(path, "controlkeel.db")
+        assert File.dir?(Path.dirname(path))
+      end)
+    end)
+  end
+
+  test "database_path prefers a project-local sqlite db when inside a repo", %{tmp_home: tmp_home} do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "controlkeel-runtime-defaults-project-#{System.unique_integer([:positive])}"
+      )
+
+    File.rm_rf!(tmp_dir)
+    File.mkdir_p!(Path.join(tmp_dir, "lib/trial"))
+    File.write!(Path.join(tmp_dir, "mix.exs"), "defmodule Trial.MixProject do\nend\n")
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+    with_envs(%{"DATABASE_PATH" => nil, "HOME" => tmp_home}, fn ->
+      File.cd!(tmp_dir, fn ->
+        path = RuntimeDefaults.database_path()
+
+        assert path == Path.join([File.cwd!(), "controlkeel", "controlkeel.db"])
+      end)
     end)
   end
 


### PR DESCRIPTION
## Summary\n- Fix SQLite table rebuild migrations by using explicit column lists, preventing the 0.3.47 startup crash.\n- Isolate fresh-project runtime state and unwrap Burrito executable paths so MCP wrappers target the native binary.\n- Deploy Claude hooks during native attach.\n- Reduce skill token overhead by counting effective skills once and avoiding redundant compat skill copies when native skill dirs are already populated.\n- Add --project-root support for status/context CLI flows.\n- Bump release manifests to 0.3.48.\n\n## DB recovery note\n- Live global DB remains untouched because CK writer processes were active.\n- Verified restore artifacts:\n  - /tmp/restore-candidate.db: migrated backup, integrity OK, preserves 295 memory records.\n  - /tmp/controlkeel-merged-candidate.db: offline merged candidate, integrity OK, preserves old history plus remapped live reset rows.\n- Safe restore still requires stopping CK/Claude/Cursor writers before replacing the live DB.\n\n## Validation\n- mix precommit (1937 tests, 0 failures)\n- CK CLI status/context verified against fresh project root\n- CK CLI status verified against /tmp/controlkeel-merged-candidate.db\n