### PR TITLE
Refactor Proofs page web view

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -38,10 +38,6 @@ body.ck-body {
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-h1, h2, h3, .ck-display {
-  font-family: Georgia, Cambria, "Times New Roman", Times, serif;
-  letter-spacing: -0.03em;
-}
 
 .ck-shell {
   width: min(1180px, calc(100% - 2rem));

--- a/lib/controlkeel_web/components/core_components.ex
+++ b/lib/controlkeel_web/components/core_components.ex
@@ -289,6 +289,8 @@ defmodule ControlKeelWeb.CoreComponents do
 
   slot :action, doc: "the slot for showing user actions in the last table column"
 
+  slot :footer, doc: "the slot for rendering footer content in a table footer row"
+
   def table(assigns) do
     assigns =
       with %{rows: %Phoenix.LiveView.LiveStream{}} <- assigns do
@@ -323,6 +325,15 @@ defmodule ControlKeelWeb.CoreComponents do
           </td>
         </tr>
       </tbody>
+      <tfoot :if={@footer != []}>
+        <tr>
+          <td colspan={length(@col) + if(@action != [], do: 1, else: 0)}>
+            <%= for footer <- @footer do %>
+              {render_slot(footer)}
+            <% end %>
+          </td>
+        </tr>
+      </tfoot>
     </table>
     """
   end

--- a/lib/controlkeel_web/components/core_components.ex
+++ b/lib/controlkeel_web/components/core_components.ex
@@ -289,8 +289,6 @@ defmodule ControlKeelWeb.CoreComponents do
 
   slot :action, doc: "the slot for showing user actions in the last table column"
 
-  slot :footer, doc: "the slot for rendering footer content in a table footer row"
-
   def table(assigns) do
     assigns =
       with %{rows: %Phoenix.LiveView.LiveStream{}} <- assigns do
@@ -325,15 +323,6 @@ defmodule ControlKeelWeb.CoreComponents do
           </td>
         </tr>
       </tbody>
-      <tfoot :if={@footer != []}>
-        <tr>
-          <td colspan={length(@col) + if(@action != [], do: 1, else: 0)}>
-            <%= for footer <- @footer do %>
-              {render_slot(footer)}
-            <% end %>
-          </td>
-        </tr>
-      </tfoot>
     </table>
     """
   end

--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -145,27 +145,6 @@ defmodule ControlKeelWeb.Layouts do
       </aside>
 
       <div class="lg:pl-64">
-        <header class="sticky top-0 z-30 border-b border-white/10 bg-zinc-950/85 backdrop-blur-xl">
-          <div class="flex h-16 items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
-            <div class="flex min-w-0 items-center gap-3">
-              <a href={~p"/"} class="flex items-center gap-2 lg:hidden">
-                <span class="flex size-9 items-center justify-center rounded-xl bg-lime-300 text-zinc-950">
-                  <.icon name="hero-bolt-solid" class="size-5" />
-                </span>
-                <span class="text-sm font-semibold text-white">ControlKeel</span>
-              </a>
-              <div class="hidden min-w-0 lg:block">
-                <p class="text-xs font-semibold uppercase tracking-[0.18em] text-lime-300">
-                  Mission Control
-                </p>
-                <p class="truncate text-sm text-zinc-400">
-                  Live governance, proof, and delivery telemetry
-                </p>
-              </div>
-            </div>
-          </div>
-        </header>
-
         <main class="min-h-[calc(100vh-4rem)] bg-[radial-gradient(circle_at_top_left,rgba(190,242,100,0.12),transparent_28rem),linear-gradient(180deg,#0a0a0a_0%,#111113_48%,#18181b_100%)] px-4 py-6 sm:px-6 lg:px-8">
           {render_slot(@inner_block)}
         </main>

--- a/lib/controlkeel_web/live/proof_browser_live.ex
+++ b/lib/controlkeel_web/live/proof_browser_live.ex
@@ -68,70 +68,94 @@ defmodule ControlKeelWeb.ProofBrowserLive do
   def render(%{live_action: :show} = assigns) do
     ~H"""
     <Layouts.app flash={@flash}>
-      <section class="ck-shell ck-shell-tight">
-        <div class="ck-section-header">
+      <section class="mx-auto w-[min(1180px,calc(100%-2rem))] pt-8 pb-16">
+        <div class="mt-6 mb-4 flex items-center justify-between gap-4">
           <div>
-            <p class="ck-kicker">Proof browser</p>
-            <h1 class="ck-section-title">Immutable proof snapshot</h1>
-            <p class="ck-lead ck-lead-tight">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+              Proof browser
+            </p>
+            <h1 class="text-[clamp(2rem,4vw,3.4rem)] leading-tight">Immutable proof snapshot</h1>
+            <p class="max-w-3xl text-base leading-relaxed text-[var(--ck-muted)]">
               Every proof bundle is a frozen audit artifact for a single task version.
             </p>
           </div>
-          <div class="ck-badge-stack">
-            <.link navigate={~p"/proofs"} class="ck-link">Back to proofs</.link>
-            <.link navigate={~p"/missions/#{@proof.session_id}"} class="ck-link">Open mission</.link>
+          <div class="flex flex-wrap gap-2">
+            <.link
+              navigate={~p"/proofs"}
+              class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]"
+            >
+              Back to proofs
+            </.link>
+            <.link
+              navigate={~p"/missions/#{@proof.session_id}"}
+              class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]"
+            >
+              Open mission
+            </.link>
           </div>
         </div>
 
-        <div class="ck-stat-grid">
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Task</p>
+        <div class="mt-5 grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-4">
+          <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+              Task
+            </p>
             <strong>{@proof.task.title}</strong>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Version</p>
+          <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+              Version
+            </p>
             <strong>v{@proof.version}</strong>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Risk score</p>
+          <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+              Risk score
+            </p>
             <strong>{@proof.risk_score}</strong>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Deploy ready</p>
+          <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+              Deploy ready
+            </p>
             <strong>{if @proof.deploy_ready, do: "Yes", else: "No"}</strong>
           </div>
         </div>
 
-        <div class="ck-grid ck-grid-dashboard">
-          <div class="ck-card">
-            <p class="ck-mini-label">Snapshot</p>
-            <div class="ck-brief-grid">
+        <div class="mt-6 grid grid-cols-[minmax(0,1.35fr)_minmax(280px,0.75fr)] gap-6 max-[900px]:grid-cols-1">
+          <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+              Snapshot
+            </p>
+            <div class="grid grid-cols-2 gap-4 max-[900px]:grid-cols-1">
               <div>
                 <h3>Mission</h3>
-                <p class="ck-note">{@proof.session.title}</p>
+                <p class="text-[var(--ck-muted)]">{@proof.session.title}</p>
               </div>
               <div>
                 <h3>Generated</h3>
-                <p class="ck-note">{format_datetime(@proof.generated_at)}</p>
+                <p class="text-[var(--ck-muted)]">{format_datetime(@proof.generated_at)}</p>
               </div>
               <div>
                 <h3>Open findings</h3>
-                <p class="ck-note">{@proof.open_findings_count}</p>
+                <p class="text-[var(--ck-muted)]">{@proof.open_findings_count}</p>
               </div>
               <div>
                 <h3>Blocked findings</h3>
-                <p class="ck-note">{@proof.blocked_findings_count}</p>
+                <p class="text-[var(--ck-muted)]">{@proof.blocked_findings_count}</p>
               </div>
               <div>
                 <h3>Domain pack</h3>
-                <p class="ck-note">
+                <p class="text-[var(--ck-muted)]">
                   {format_domain_pack(get_in(@proof.session.execution_brief || %{}, ["domain_pack"]))}
                 </p>
               </div>
             </div>
 
-            <p class="ck-mini-label" style="margin-top: 1.5rem;">Compliance attestations</p>
-            <ul class="ck-mini-list">
+            <p class="mt-6 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+              Compliance attestations
+            </p>
+            <ul class="m-0 grid gap-4 p-0 list-none">
               <%= for attestation <- List.wrap(@proof.bundle["compliance_attestations"]) do %>
                 <li>
                   {format_domain_pack(attestation["pack"])}: {attestation["status"]} ({attestation[
@@ -141,53 +165,69 @@ defmodule ControlKeelWeb.ProofBrowserLive do
               <% end %>
             </ul>
 
-            <p class="ck-mini-label" style="margin-top: 1.5rem;">Rollback instructions</p>
-            <pre class="ck-code-block">{@proof.bundle["rollback_instructions"]}</pre>
+            <p class="mt-6 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+              Rollback instructions
+            </p>
+            <pre class="m-0 rounded-2xl border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.03)] p-4 font-mono text-sm leading-relaxed text-[var(--ck-sand)] whitespace-pre-wrap break-words">{@proof.bundle["rollback_instructions"]}</pre>
 
-            <p class="ck-mini-label" style="margin-top: 1.5rem;">Proof payload</p>
-            <pre class="ck-code-block">{Jason.encode!(@proof.bundle, pretty: true)}</pre>
+            <p class="mt-6 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+              Proof payload
+            </p>
+            <pre class="m-0 rounded-2xl border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.03)] p-4 font-mono text-sm leading-relaxed text-[var(--ck-sand)] whitespace-pre-wrap break-words">{Jason.encode!(@proof.bundle, pretty: true)}</pre>
           </div>
 
-          <div class="ck-side-stack">
-            <div class="ck-card">
-              <p class="ck-mini-label">Related memory</p>
+          <div class="grid gap-4">
+            <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+              <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                Related memory
+              </p>
               <%= if @memory_hits == [] do %>
-                <p class="ck-note">No related memory hits for this task yet.</p>
+                <p class="text-[var(--ck-muted)]">No related memory hits for this task yet.</p>
               <% else %>
-                <ul class="ck-mini-list">
+                <ul class="m-0 grid gap-4 p-0 list-none">
                   <%= for hit <- @memory_hits do %>
                     <li>
                       <strong>{hit.title}</strong>
-                      <p class="ck-note">{hit.summary}</p>
+                      <p class="text-[var(--ck-muted)]">{hit.summary}</p>
                     </li>
                   <% end %>
                 </ul>
               <% end %>
             </div>
 
-            <div class="ck-card">
-              <p class="ck-mini-label">Finding resolution summary</p>
-              <div class="ck-stat-grid">
-                <div class="ck-stat-card">
-                  <p class="ck-mini-label">Approved</p>
+            <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+              <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                Finding resolution summary
+              </p>
+              <div class="mt-5 grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-4">
+                <div>
+                  <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                    Approved
+                  </p>
                   <strong>
                     {get_in(@proof.bundle, ["finding_resolution_summary", "approved"]) || 0}
                   </strong>
                 </div>
-                <div class="ck-stat-card">
-                  <p class="ck-mini-label">Resolved</p>
+                <div>
+                  <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                    Resolved
+                  </p>
                   <strong>
                     {get_in(@proof.bundle, ["finding_resolution_summary", "resolved"]) || 0}
                   </strong>
                 </div>
-                <div class="ck-stat-card">
-                  <p class="ck-mini-label">Open</p>
+                <div>
+                  <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                    Open
+                  </p>
                   <strong>
                     {get_in(@proof.bundle, ["finding_resolution_summary", "open"]) || 0}
                   </strong>
                 </div>
-                <div class="ck-stat-card">
-                  <p class="ck-mini-label">Blocked</p>
+                <div>
+                  <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                    Blocked
+                  </p>
                   <strong>
                     {get_in(@proof.bundle, ["finding_resolution_summary", "blocked"]) || 0}
                   </strong>
@@ -204,7 +244,7 @@ defmodule ControlKeelWeb.ProofBrowserLive do
   def render(assigns) do
     ~H"""
     <Layouts.app flash={@flash}>
-      <section class="ck-shell ck-shell-tight">
+      <section class="mx-auto w-[min(1180px,calc(100%-2rem))] pt-8 pb-16">
         <div class="space-y-1">
           <h2 class="text-2xl font-semibold text-[var(--ck-lime)] leading-6 tracking-wide uppercase">
             Proof browser

--- a/lib/controlkeel_web/live/proof_browser_live.ex
+++ b/lib/controlkeel_web/live/proof_browser_live.ex
@@ -205,120 +205,293 @@ defmodule ControlKeelWeb.ProofBrowserLive do
     ~H"""
     <Layouts.app flash={@flash}>
       <section class="ck-shell ck-shell-tight">
-        <div class="ck-section-header">
-          <div>
-            <p class="ck-kicker">Proof browser</p>
-            <h1 class="ck-section-title">Search proof bundles across missions</h1>
-            <p class="ck-lead ck-lead-tight">
-              Review immutable task evidence, filter by readiness and risk, and jump back to the mission that generated each bundle.
+        <div class="space-y-1">
+          <h2 class="text-2xl font-semibold text-[var(--ck-lime)] leading-6 tracking-wide uppercase">
+            Proof browser
+          </h2>
+          <p class="text-[var(--ck-muted)]">
+            Review immutable task evidence, filter by readiness and risk, and jump back to the mission that generated each bundle.
+          </p>
+        </div>
+
+        <div class="mt-8 rounded-lg border border-[var(--ck-stroke)] bg-neutral-900">
+          <div class="space-y-4 p-4">
+            <form id="proof-filters" phx-change="filter" class="grid gap-4 xl:grid-cols-5">
+              <div class="space-y-4">
+                <label
+                  for="filters-q"
+                  class="text-xs uppercase tracking-[0.28em]"
+                >
+                  Search
+                </label>
+                <input
+                  id="filters-q"
+                  name="filters[q]"
+                  type="text"
+                  value={@form[:q].value}
+                  placeholder="Mission or task..."
+                  phx-debounce="300"
+                  class="w-full rounded-md border border-white/10 bg-black/40 px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:border-[var(--ck-lime)] focus:ring-2 focus:ring-[rgba(196,240,66,0.15)] focus:outline-none"
+                />
+              </div>
+
+              <div class="space-y-2">
+                <label
+                  for="filters-session_id"
+                  class="text-xs uppercase tracking-[0.28em]"
+                >
+                  Mission
+                </label>
+                <select
+                  id="filters-session_id"
+                  name="filters[session_id]"
+                  class="w-full rounded-md border border-white/10 bg-black/40 px-4 py-3 text-sm text-white focus:border-[var(--ck-lime)] focus:ring-2 focus:ring-[rgba(196,240,66,0.15)] focus:outline-none"
+                >
+                  <option value="">All missions</option>
+                  <%= for session_option <- @session_options do %>
+                    <option
+                      value={session_option.id}
+                      selected={to_string(@form[:session_id].value) == to_string(session_option.id)}
+                    >
+                      {session_option.title}
+                    </option>
+                  <% end %>
+                </select>
+              </div>
+
+              <div class="space-y-2">
+                <label
+                  for="filters-task_id"
+                  class="text-xs uppercase tracking-[0.28em]"
+                >
+                  Task ID
+                </label>
+                <input
+                  id="filters-task_id"
+                  name="filters[task_id]"
+                  type="text"
+                  value={@form[:task_id].value}
+                  placeholder="Task id"
+                  class="w-full rounded-md border border-white/10 bg-black/40 px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:border-[var(--ck-lime)] focus:ring-2 focus:ring-[rgba(196,240,66,0.15)] focus:outline-none"
+                />
+              </div>
+
+              <div class="space-y-2">
+                <label
+                  for="filters-deploy_ready"
+                  class="text-xs uppercase tracking-[0.28em]"
+                >
+                  Deploy ready
+                </label>
+                <select
+                  id="filters-deploy_ready"
+                  name="filters[deploy_ready]"
+                  class="w-full rounded-md border border-white/10 bg-black/40 px-4 py-3 text-sm text-white focus:border-[var(--ck-lime)] focus:ring-2 focus:ring-[rgba(196,240,66,0.15)] focus:outline-none"
+                >
+                  <option value="">All</option>
+                  <option value="true" selected={@form[:deploy_ready].value == "true"}>Yes</option>
+                  <option value="false" selected={@form[:deploy_ready].value == "false"}>No</option>
+                </select>
+              </div>
+
+              <div class="space-y-2">
+                <label
+                  for="filters-risk_tier"
+                  class="text-xs uppercase tracking-[0.28em]"
+                >
+                  Risk tier
+                </label>
+                <select
+                  id="filters-risk_tier"
+                  name="filters[risk_tier]"
+                  class="w-full rounded-md border border-white/10 bg-black/40 px-4 py-3 text-sm text-white focus:border-[var(--ck-lime)] focus:ring-2 focus:ring-[rgba(196,240,66,0.15)] focus:outline-none"
+                >
+                  <option value="">All tiers</option>
+                  <%= for tier <- @risk_tiers do %>
+                    <option value={tier} selected={@form[:risk_tier].value == tier}>
+                      {String.capitalize(tier)}
+                    </option>
+                  <% end %>
+                </select>
+              </div>
+            </form>
+
+            <p class="text-neutral-400 tracking-tight">
+              <span class="text-[var(--ck-lime)] mr-1">{@browser.total_count}</span>
+              total proof bundles found
             </p>
           </div>
-          <.link navigate={~p"/"} class="ck-link">Back home</.link>
-        </div>
 
-        <div class="ck-card ck-browser-filters">
-          <.form for={@form} id="proof-filters" phx-change="filter">
-            <div class="ck-filter-grid">
-              <.input
-                field={@form[:q]}
-                type="text"
-                label="Search"
-                placeholder="Mission or task..."
-                phx-debounce="300"
-              />
-              <.input
-                field={@form[:session_id]}
-                type="select"
-                label="Mission"
-                prompt="All missions"
-                options={Enum.map(@session_options, &{&1.title, &1.id})}
-              />
-              <.input
-                field={@form[:task_id]}
-                type="text"
-                label="Task ID"
-                placeholder="Task id"
-              />
-              <.input
-                field={@form[:deploy_ready]}
-                type="select"
-                label="Deploy ready"
-                prompt="All"
-                options={[{"Yes", "true"}, {"No", "false"}]}
-              />
-              <.input
-                field={@form[:risk_tier]}
-                type="select"
-                label="Risk tier"
-                prompt="All tiers"
-                options={Enum.map(@risk_tiers, &{String.capitalize(&1), &1})}
-              />
+          <div class="overflow-x-auto w-full">
+            <div class="overflow-hidden border border-white/10 bg-black/30">
+              <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-white/10">
+                  <thead class="bg-white/5">
+                    <tr>
+                      <th class="px-8 py-6 text-left text-xs font-semibold uppercase tracking-[0.15em] text-zinc-300">
+                        Task
+                      </th>
+
+                      <th class="px-8 py-6 text-left text-xs font-semibold uppercase tracking-[0.15em] text-zinc-300">
+                        Version
+                      </th>
+
+                      <th class="px-8 py-6 text-left text-xs font-semibold uppercase tracking-[0.15em] text-zinc-300">
+                        Risk
+                      </th>
+
+                      <th class="px-8 py-6 text-left text-xs font-semibold uppercase tracking-[0.15em] text-zinc-300">
+                        Readiness
+                      </th>
+
+                      <th class="px-8 py-6 text-right text-xs font-semibold uppercase tracking-[0.15em] text-zinc-300">
+                        Actions
+                      </th>
+                    </tr>
+                  </thead>
+
+                  <tbody class="divide-y divide-white/5">
+                    <tr :if={@browser.entries == []}>
+                      <td colspan="5" class="px-8 py-12 text-center text-sm text-zinc-500">
+                        No proof bundles match the current filters.
+                      </td>
+                    </tr>
+                    <tr
+                      :for={proof <- @browser.entries}
+                      class="transition hover:bg-white/[0.02]"
+                    >
+                      <td class="px-8 py-6 align-top">
+                        <div>
+                          <p class="font-bold text-white">
+                            {proof.task.title}
+                          </p>
+
+                          <p class="mt-2 max-w-md text-sm text-zinc-400">
+                            {proof.session.title}
+                          </p>
+                        </div>
+                      </td>
+
+                      <td class="px-8 py-6 align-top">
+                        <div>
+                          <p class="font-semibold text-white">
+                            v{proof.version}
+                          </p>
+
+                          <p class="mt-2 text-xs uppercase tracking-wider text-lime-400">
+                            {proof.status}
+                          </p>
+                        </div>
+                      </td>
+
+                      <td class="px-8 py-6 align-top">
+                        <div class="flex items-center gap-3">
+                          <span class={[
+                            "inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wider",
+                            proof.session.risk_tier == "low" &&
+                              "border-lime-500/40 bg-lime-500/10 text-lime-400",
+                            proof.session.risk_tier == "moderate" &&
+                              "border-cyan-500/40 bg-cyan-500/10 text-cyan-400",
+                            proof.session.risk_tier == "high" &&
+                              "border-red-500/40 bg-red-500/10 text-red-400"
+                          ]}>
+                            {proof.session.risk_tier}
+                          </span>
+
+                          <span class="inline-flex rounded-full border border-white/10 px-4 py-2 text-sm text-zinc-300">
+                            {proof.risk_score}
+                          </span>
+                        </div>
+                      </td>
+
+                      <td class="px-8 py-6 align-top">
+                        <div class="flex items-center gap-4">
+                          <span class={[
+                            "inline-flex h-8 w-8 items-center justify-center rounded-full border text-xs",
+                            proof.deploy_ready &&
+                              "border-lime-500/40 text-lime-400",
+                            !proof.deploy_ready &&
+                              "border-yellow-500/40 text-yellow-400"
+                          ]}>
+                            {proof.risk_score}
+                          </span>
+
+                          <span class={[
+                            "text-sm",
+                            proof.deploy_ready &&
+                              "text-white",
+                            !proof.deploy_ready &&
+                              "text-zinc-300"
+                          ]}>
+                            {if proof.deploy_ready,
+                              do: "Certified ready",
+                              else: "Review required"}
+                          </span>
+                        </div>
+                      </td>
+
+                      <td class="px-2 py-6 text-right align-top">
+                        <div class="flex justify-end gap-4 font-semibold text-sm">
+                          <.link
+                            navigate={~p"/missions/#{proof.session_id}"}
+                            class="text-zinc-400 transition hover:text-white border px-2 py-1 rounded-md"
+                          >
+                            Mission
+                          </.link>
+
+                          <.link
+                            navigate={~p"/proofs/#{proof.id}"}
+                            class="text-lime-400 transition hover:text-lime-300 border px-2 py-1 rounded-md"
+                          >
+                            View
+                          </.link>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <div class="border-t border-white/10 bg-black/40 px-6 py-4">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+                  <div class="text-xs uppercase tracking-[0.15em] text-zinc-400">
+                    Page {@browser.page} of {@browser.total_pages}
+                  </div>
+
+                  <div class="flex gap-3">
+                    <%= if @browser.page > 1 do %>
+                      <.link
+                        patch={
+                          ~p"/proofs?#{Map.merge(browser_form_params(@browser.filters), %{"page" => @browser.page - 1})}"
+                        }
+                        class="rounded-md border border-white/10 bg-black px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-lime-400 transition hover:border-lime-400"
+                      >
+                        Previous
+                      </.link>
+                    <% else %>
+                      <span class="cursor-not-allowed rounded-md border border-white/10 bg-white/5 px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-zinc-600">
+                        Previous
+                      </span>
+                    <% end %>
+
+                    <%= if @browser.page < @browser.total_pages do %>
+                      <.link
+                        patch={
+                          ~p"/proofs?#{Map.merge(browser_form_params(@browser.filters), %{"page" => @browser.page + 1})}"
+                        }
+                        class="rounded-md border border-white/10 bg-black px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-lime-400 transition hover:border-lime-400"
+                      >
+                        Next
+                      </.link>
+                    <% else %>
+                      <span class="cursor-not-allowed rounded-md border border-white/10 bg-white/5 px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-zinc-600">
+                        Next
+                      </span>
+                    <% end %>
+                  </div>
+                </div>
+              </div>
             </div>
-          </.form>
-
-          <div class="ck-metric-row">
-            <span>{@browser.total_count} total proof bundles</span>
-            <span>Page {@browser.page} of {@browser.total_pages}</span>
-          </div>
-        </div>
-
-        <div class="ck-card">
-          <div class="ck-table-wrap">
-            <.table id="proofs-browser" rows={@browser.entries}>
-              <:col :let={proof} label="Task">
-                <div>
-                  <strong>{proof.task.title}</strong>
-                  <p class="ck-note">{proof.session.title}</p>
-                </div>
-              </:col>
-              <:col :let={proof} label="Version">
-                <div>
-                  <strong>v{proof.version}</strong>
-                  <p class="ck-note">{proof.status}</p>
-                </div>
-              </:col>
-              <:col :let={proof} label="Risk">
-                <div class="ck-badge-stack">
-                  <span class={["ck-pill", "ck-pill-#{proof.session.risk_tier}"]}>
-                    {proof.session.risk_tier}
-                  </span>
-                  <span class="ck-pill ck-pill-neutral">{proof.risk_score}</span>
-                </div>
-              </:col>
-              <:col :let={proof} label="Readiness">
-                <span class="ck-note">
-                  {if proof.deploy_ready, do: "Deploy ready", else: "Review required"}
-                </span>
-              </:col>
-              <:action :let={proof}>
-                <.link navigate={~p"/missions/#{proof.session_id}"} class="ck-link">Mission</.link>
-              </:action>
-              <:action :let={proof}>
-                <.link navigate={~p"/proofs/#{proof.id}"} class="ck-link">View proof</.link>
-              </:action>
-            </.table>
-          </div>
-
-          <div class="ck-action-row" style="margin-top: 1rem;">
-            <.link
-              :if={@browser.page > 1}
-              patch={
-                ~p"/proofs?#{Map.merge(browser_form_params(@browser.filters), %{"page" => @browser.page - 1})}"
-              }
-              class="ck-link"
-            >
-              Previous page
-            </.link>
-            <div />
-            <.link
-              :if={@browser.page < @browser.total_pages}
-              patch={
-                ~p"/proofs?#{Map.merge(browser_form_params(@browser.filters), %{"page" => @browser.page + 1})}"
-              }
-              class="ck-link"
-            >
-              Next page
-            </.link>
           </div>
         </div>
       </section>

--- a/lib/controlkeel_web/live/proof_browser_live.ex
+++ b/lib/controlkeel_web/live/proof_browser_live.ex
@@ -90,7 +90,7 @@ defmodule ControlKeelWeb.ProofBrowserLive do
     ~H"""
     <Layouts.app flash={@flash}>
       <section class="mx-auto w-[min(1180px,calc(100%-2rem))]">
-        <div :if={@proof} class="space-y-8">
+        <div :if={@proof} class="space-y-8 mb-12">
           <.link
             navigate={~p"/proofs"}
             class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400 hover:text-neutral-200"
@@ -99,17 +99,18 @@ defmodule ControlKeelWeb.ProofBrowserLive do
           </.link>
 
           <div class="flex items-center justify-between gap-4">
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+            <div class="space-y-1">
+              <h2 class="text-2xl font-semibold text-[var(--ck-lime)] leading-6 tracking-wide uppercase">
                 Immutable proof snapshot
-              </p>
-              <p class="max-w-3xl text-base leading-relaxed text-[var(--ck-muted)]">
+              </h2>
+              <p class="text-[var(--ck-muted)]">
                 Every proof bundle is a frozen audit artifact for a single task version.
               </p>
             </div>
+
             <.link
               navigate={~p"/missions/#{@proof.session_id}"}
-              class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]"
+              class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)] border-[var(--ck-muted)] border rounded-md px-3 py-2 hover:bg-[var(--ck-lime)]/10"
             >
               Open mission
             </.link>
@@ -134,26 +135,26 @@ defmodule ControlKeelWeb.ProofBrowserLive do
           </.link>
         </div>
 
-        <div :if={@proof} class="mt-5 grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-4">
-          <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+        <div :if={@proof} class="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-4">
+          <div class="rounded-2xl border border-[var(--ck-stroke)]  p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
             <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
               Task
             </p>
             <strong>{@proof.task.title}</strong>
           </div>
-          <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+          <div class="rounded-2xl border border-[var(--ck-stroke)]  p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
             <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
               Version
             </p>
             <strong>v{@proof.version}</strong>
           </div>
-          <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+          <div class="rounded-2xl border border-[var(--ck-stroke)]  p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
             <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
               Risk score
             </p>
             <strong>{@proof.risk_score}</strong>
           </div>
-          <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+          <div class="rounded-2xl border border-[var(--ck-stroke)]  p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
             <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
               Deploy ready
             </p>
@@ -163,10 +164,10 @@ defmodule ControlKeelWeb.ProofBrowserLive do
 
         <div
           :if={@proof}
-          class="mt-6 grid grid-cols-[minmax(0,1.35fr)_minmax(280px,0.75fr)] gap-6 max-[900px]:grid-cols-1"
+          class="mt-6"
         >
-          <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
-            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+          <div class="rounded-2xl border border-[var(--ck-stroke)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)] mb-2">
               Snapshot
             </p>
             <div class="grid grid-cols-2 gap-4 max-[900px]:grid-cols-1">
@@ -207,75 +208,311 @@ defmodule ControlKeelWeb.ProofBrowserLive do
               <% end %>
             </ul>
 
-            <p class="mt-6 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
-              Rollback instructions
-            </p>
-            <pre class="m-0 rounded-2xl border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.03)] p-4 font-mono text-sm leading-relaxed text-[var(--ck-sand)] whitespace-pre-wrap break-words">{@proof.bundle["rollback_instructions"]}</pre>
-
-            <p class="mt-6 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
-              Proof payload
-            </p>
-            <pre class="m-0 rounded-2xl border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.03)] p-4 font-mono text-sm leading-relaxed text-[var(--ck-sand)] whitespace-pre-wrap break-words">{Jason.encode!(@proof.bundle, pretty: true)}</pre>
-          </div>
-
-          <div class="grid gap-4">
-            <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
+            <div class="mt-6 space-y-2">
               <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
-                Related memory
+                Rollback instructions
               </p>
-              <%= if @memory_hits == [] do %>
-                <p class="text-[var(--ck-muted)]">No related memory hits for this task yet.</p>
-              <% else %>
-                <ul class="m-0 grid gap-4 p-0 list-none">
-                  <%= for hit <- @memory_hits do %>
-                    <li>
-                      <strong>{hit.title}</strong>
-                      <p class="text-[var(--ck-muted)]">{hit.summary}</p>
-                    </li>
-                  <% end %>
-                </ul>
-              <% end %>
+
+              <pre class="m-0 rounded-2xl border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.03)] w-fit p-4 font-mono text-sm leading-relaxed text-[var(--ck-sand)] whitespace-pre-wrap break-words">{@proof.bundle["rollback_instructions"]}</pre>
             </div>
 
-            <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
-              <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
-                Finding resolution summary
-              </p>
-              <div class="mt-5 grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-4">
-                <div>
-                  <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
-                    Approved
-                  </p>
-                  <strong>
-                    {get_in(@proof.bundle, ["finding_resolution_summary", "approved"]) || 0}
-                  </strong>
+            <div class="grid grid-cols-1 lg:grid-cols-2 mt-6 gap-4">
+              <div class="space-y-2">
+                <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                  Related memory
+                </p>
+
+                <div class="rounded-2xl border border-[var(--ck-stroke)] p-4">
+                  <%= if @memory_hits == [] do %>
+                    <p class="text-[var(--ck-muted)]">No related memory hits for this task yet.</p>
+                  <% else %>
+                    <ul class="m-0 grid gap-4 p-0 list-none">
+                      <%= for hit <- @memory_hits do %>
+                        <li>
+                          <strong>{hit.title}</strong>
+                          <p class="text-[var(--ck-muted)]">{hit.summary}</p>
+                        </li>
+                      <% end %>
+                    </ul>
+                  <% end %>
                 </div>
-                <div>
-                  <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
-                    Resolved
-                  </p>
-                  <strong>
-                    {get_in(@proof.bundle, ["finding_resolution_summary", "resolved"]) || 0}
-                  </strong>
-                </div>
-                <div>
-                  <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
-                    Open
-                  </p>
-                  <strong>
-                    {get_in(@proof.bundle, ["finding_resolution_summary", "open"]) || 0}
-                  </strong>
-                </div>
-                <div>
-                  <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
-                    Blocked
-                  </p>
-                  <strong>
-                    {get_in(@proof.bundle, ["finding_resolution_summary", "blocked"]) || 0}
-                  </strong>
+              </div>
+
+              <div class="space-y-2">
+                <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                  Finding resolution summary
+                </p>
+
+                <div class="rounded-2xl border border-[var(--ck-stroke)] p-6 grid grid-cols-2 gap-4">
+                  <div>
+                    <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                      Approved
+                    </p>
+                    <strong>
+                      {get_in(@proof.bundle, ["finding_resolution_summary", "approved"]) || 0}
+                    </strong>
+                  </div>
+                  <div>
+                    <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                      Resolved
+                    </p>
+                    <strong>
+                      {get_in(@proof.bundle, ["finding_resolution_summary", "resolved"]) || 0}
+                    </strong>
+                  </div>
+                  <div>
+                    <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                      Open
+                    </p>
+                    <strong>
+                      {get_in(@proof.bundle, ["finding_resolution_summary", "open"]) || 0}
+                    </strong>
+                  </div>
+                  <div>
+                    <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                      Blocked
+                    </p>
+                    <strong>
+                      {get_in(@proof.bundle, ["finding_resolution_summary", "blocked"]) || 0}
+                    </strong>
+                  </div>
                 </div>
               </div>
             </div>
+
+            <p class="mt-6 text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+              Assessment summary
+            </p>
+            <div class="mt-4 grid grid-cols-2 gap-4 max-[900px]:grid-cols-1">
+              <div class="rounded-xl border border-[var(--ck-stroke)] p-5">
+                <div class="flex items-center justify-between mb-4">
+                  <p class="text-xs font-semibold uppercase tracking-[0.14em]">
+                    Surface verification
+                  </p>
+                  <% ver_status = bundle_get(@proof, ["verification_assessment", "status"]) %>
+                  <span
+                    :if={ver_status}
+                    class={[
+                      "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wider",
+                      verification_status_color(ver_status)
+                    ]}
+                  >
+                    {ver_status}
+                  </span>
+                </div>
+                <div class="flex items-baseline gap-2 mb-4">
+                  <% ver_score = bundle_get(@proof, ["verification_assessment", "score"]) %>
+                  <span class={[
+                    "text-3xl font-bold tabular-nums",
+                    verification_score_color(ver_score)
+                  ]}>
+                    {ver_score || "—"}
+                  </span>
+                  <span :if={ver_score} class="text-sm text-zinc-500">/ 100</span>
+                  <span
+                    :if={
+                      bundle_get(@proof, ["verification_assessment", "verification_ready"]) == true
+                    }
+                    class="ml-auto inline-flex items-center gap-1 rounded-full border border-lime-500/40 bg-lime-500/10 px-2.5 py-0.5 text-xs font-semibold text-lime-400"
+                  >
+                    <.icon name="hero-check-circle" class="w-3.5 h-3.5" /> Ready
+                  </span>
+                </div>
+                <% ver_evidence = bundle_get(@proof, ["verification_assessment", "evidence"], %{}) %>
+                <div class="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm">
+                  <span class="text-zinc-400">Passed checks</span>
+                  <span class="text-right font-medium tabular-nums text-white">
+                    {ver_evidence["passed_checks"] || 0}
+                  </span>
+                  <span class="text-zinc-400">Task checks (strong)</span>
+                  <span class="text-right font-medium tabular-nums text-white">
+                    {ver_evidence["passed_task_checks"] || 0} / {ver_evidence[
+                      "passed_strong_task_checks"
+                    ] || 0}
+                  </span>
+                  <span class="text-zinc-400">Failed checks</span>
+                  <span class="text-right font-medium tabular-nums text-red-400">
+                    {ver_evidence["failed_task_checks"] || 0}
+                  </span>
+                  <span class="text-zinc-400">External regressions</span>
+                  <span class="text-right font-medium tabular-nums text-white">
+                    {ver_evidence["external_regressions"] || 0}
+                  </span>
+                </div>
+              </div>
+
+              <div class="rounded-xl border border-[var(--ck-stroke)] p-5">
+                <p class="text-xs font-semibold uppercase tracking-[0.14em] mb-4">
+                  Task check counts
+                </p>
+                <% task_checks = bundle_get(@proof, ["task_checks"], %{}) %>
+                <% ch_total = task_checks["total"] || 0 %>
+                <% ch_passed = task_checks["passed"] || 0 %>
+                <% ch_failed = task_checks["failed"] || 0 %>
+                <% ch_warn = task_checks["warn"] || 0 %>
+                <div class="flex items-baseline gap-2 mb-4">
+                  <span class="text-3xl font-bold tabular-nums text-white">{ch_total}</span>
+                  <span class="text-sm text-zinc-500">total</span>
+                  <span class="ml-auto flex gap-3 text-sm tabular-nums">
+                    <span class="text-lime-400">{ch_passed} passed</span>
+                    <span class="text-red-400">{ch_failed} failed</span>
+                    <span class="text-amber-400">{ch_warn} warn</span>
+                  </span>
+                </div>
+                <% passed_pct = if ch_total > 0, do: round(ch_passed / ch_total * 100), else: 0 %>
+                <% failed_pct = if ch_total > 0, do: round(ch_failed / ch_total * 100), else: 0 %>
+                <div class="h-2 rounded-full bg-zinc-800 overflow-hidden mb-4">
+                  <div class="h-full flex">
+                    <div
+                      style={"width: #{passed_pct}%"}
+                      class="bg-lime-500 transition-all rounded-l-full"
+                    >
+                    </div>
+                    <div style={"width: #{failed_pct}%"} class="bg-red-500 transition-all"></div>
+                  </div>
+                </div>
+                <div class="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm">
+                  <span class="text-zinc-400">Passed strong</span>
+                  <span class="text-right font-medium tabular-nums text-white">
+                    {task_checks["passed_strong"] || 0}
+                  </span>
+                  <span class="text-zinc-400">Strongest proof</span>
+                  <span class="text-right font-medium tabular-nums text-white">
+                    {task_checks["strongest_proof_strength"] || "—"}
+                  </span>
+                  <span class="text-zinc-400">Hashed outputs</span>
+                  <span class="text-right font-medium tabular-nums text-white">
+                    {task_checks["hashed_outputs"] || 0}
+                  </span>
+                  <span class="text-zinc-400">Git refs</span>
+                  <span class="text-right font-medium tabular-nums text-white">
+                    {length(task_checks["git_shas"] || [])}
+                  </span>
+                </div>
+              </div>
+
+              <div class="rounded-xl border border-[var(--ck-stroke)] p-5">
+                <div class="flex items-center justify-between mb-4">
+                  <p class="text-xs font-semibold uppercase tracking-[0.14em]">
+                    Context integrity
+                  </p>
+                  <% ctx = bundle_get(@proof, ["runtime_context_integrity"], %{}) %>
+                  <span class={[
+                    "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wider",
+                    context_status_color(ctx["status"])
+                  ]}>
+                    <.icon
+                      name={
+                        if ctx["status"] == "clean",
+                          do: "hero-check-circle",
+                          else: "hero-exclamation-triangle"
+                      }
+                      class="w-3.5 h-3.5"
+                    />
+                    {ctx["status"] || "Unknown"}
+                  </span>
+                </div>
+                <div class="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm">
+                  <span class="text-zinc-400">Partial reads</span>
+                  <span class="text-right font-medium tabular-nums text-white">
+                    {ctx["partial_read_count"] || 0}
+                  </span>
+                  <span class="text-zinc-400">Compactions</span>
+                  <span class="text-right font-medium tabular-nums text-white">
+                    {ctx["compaction_count"] || 0}
+                  </span>
+                  <span :if={ctx["compaction_source"]} class="text-zinc-400">Compaction source</span>
+                  <span
+                    :if={ctx["compaction_source"]}
+                    class="text-right font-medium tabular-nums text-white"
+                  >
+                    {ctx["compaction_source"]}
+                  </span>
+                </div>
+                <div :if={ctx["latest_compaction_reason"]} class="mt-3 rounded-lg bg-zinc-900/50 p-3">
+                  <p class="text-xs text-zinc-400 mb-1">Latest compaction</p>
+                  <p class="text-sm text-zinc-300">{ctx["latest_compaction_reason"]}</p>
+                </div>
+              </div>
+
+              <div class="rounded-xl border border-[var(--ck-stroke)] p-5">
+                <div class="flex items-center justify-between mb-4">
+                  <p class="text-xs font-semibold uppercase tracking-[0.14em]">
+                    Deploy readiness
+                  </p>
+                  <span class={[
+                    "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wider",
+                    deploy_badge_class(@proof.deploy_ready)
+                  ]}>
+                    <.icon
+                      name={if @proof.deploy_ready, do: "hero-check-circle", else: "hero-x-circle"}
+                      class="w-3.5 h-3.5"
+                    />
+                    {if @proof.deploy_ready, do: "Ready", else: "Not ready"}
+                  </span>
+                </div>
+                <div class="flex items-center gap-3 mb-4">
+                  <div class="flex-1">
+                    <div class="flex justify-between text-sm mb-1">
+                      <span class="text-zinc-400">Risk score</span>
+                      <span class="font-medium tabular-nums">{@proof.risk_score}</span>
+                    </div>
+                    <div class="h-2 rounded-full bg-zinc-800 overflow-hidden">
+                      <div
+                        style={"width: #{risk_bar_width(@proof.risk_score)}%"}
+                        class={[
+                          "h-full rounded-full transition-all",
+                          @proof.risk_score <= 0.3 && "bg-lime-500",
+                          @proof.risk_score > 0.3 && @proof.risk_score <= 0.6 && "bg-amber-500",
+                          @proof.risk_score > 0.6 && "bg-red-500"
+                        ]}
+                      >
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm">
+                  <span class="text-zinc-400">Validation gate</span>
+                  <span class="text-right font-medium tabular-nums text-white">
+                    {@proof.bundle["validation_gate"] || "—"}
+                  </span>
+                  <span class="text-zinc-400">Open findings</span>
+                  <span class="text-right font-medium tabular-nums text-amber-400">
+                    {@proof.open_findings_count}
+                  </span>
+                  <span class="text-zinc-400">Blocked findings</span>
+                  <span class="text-right font-medium tabular-nums text-red-400">
+                    {@proof.blocked_findings_count}
+                  </span>
+                  <span class="text-zinc-400">Compliance packs</span>
+                  <span class="text-right font-medium tabular-nums text-white">
+                    {length(List.wrap(@proof.bundle["compliance_attestations"]))}
+                  </span>
+                </div>
+                <div
+                  :if={gate = bundle_get(@proof, ["security_workflow", "release_gate_decision"])}
+                  class="mt-3"
+                >
+                  <span class={[
+                    "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wider",
+                    gate == "ready" && "border-lime-500/40 bg-lime-500/10 text-lime-400",
+                    gate == "blocked" && "border-red-500/40 bg-red-500/10 text-red-400"
+                  ]}>
+                    Release gate: {gate}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <details class="mt-6 group">
+              <summary class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)] cursor-pointer hover:text-lime-300 transition-colors list-none flex items-center gap-2">
+                <.icon
+                  name="hero-chevron-right"
+                  class="w-3.5 h-3.5 group-open:rotate-90 transition-transform"
+                /> Raw proof payload
+              </summary>
+              <pre class="m-0 mt-3 rounded-2xl border border-[var(--ck-stroke)] p-4 font-mono text-xs leading-relaxed text-[var(--ck-sand)] whitespace-pre-wrap break-words overflow-auto h-100">{Jason.encode!(@proof.bundle, pretty: true)}</pre>
+            </details>
           </div>
         </div>
       </section>
@@ -287,7 +524,7 @@ defmodule ControlKeelWeb.ProofBrowserLive do
     ~H"""
     <Layouts.app flash={@flash}>
       <section class="mx-auto w-[min(1180px,calc(100%-2rem))]">
-        <div class="space-y-1">
+        <div class="space-y-1 mb-12">
           <h2 class="text-2xl font-semibold text-[var(--ck-lime)] leading-6 tracking-wide uppercase">
             Proof browser
           </h2>
@@ -296,7 +533,7 @@ defmodule ControlKeelWeb.ProofBrowserLive do
           </p>
         </div>
 
-        <div class="mt-8 rounded-lg border border-[var(--ck-stroke)] bg-neutral-900">
+        <div class="rounded-lg border border-[var(--ck-stroke)] bg-neutral-900">
           <div class="space-y-4 p-4">
             <form id="proof-filters" phx-change="filter" class="grid gap-4 xl:grid-cols-5">
               <div class="space-y-4">
@@ -493,6 +730,21 @@ defmodule ControlKeelWeb.ProofBrowserLive do
                             {proof.risk_score}
                           </span>
                         </div>
+                        <% ver = bundle_get(proof, ["verification_assessment"], %{}) %>
+                        <div :if={ver["score"] || ver["status"]} class="mt-2 flex items-center gap-2">
+                          <span class={[
+                            "text-sm font-semibold tabular-nums",
+                            verification_score_color(ver["score"])
+                          ]}>
+                            {ver["score"] || "—"}
+                          </span>
+                          <span class={[
+                            "inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
+                            verification_status_color(ver["status"])
+                          ]}>
+                            {ver["status"] || "n/a"}
+                          </span>
+                        </div>
                       </td>
 
                       <td class="px-8 py-6 align-top">
@@ -518,6 +770,22 @@ defmodule ControlKeelWeb.ProofBrowserLive do
                               do: "Certified ready",
                               else: "Review required"}
                           </span>
+                        </div>
+                        <% tc = bundle_get(proof, ["task_checks"], %{}) %>
+                        <% t_total = tc["total"] || 0 %>
+                        <% t_passed = tc["passed"] || 0 %>
+                        <div :if={t_total > 0} class="mt-2">
+                          <div class="flex items-center justify-between text-[11px] text-zinc-500 mb-1">
+                            <span>Checks</span>
+                            <span>{t_passed}/{t_total} passed</span>
+                          </div>
+                          <div class="h-1.5 rounded-full bg-zinc-800 overflow-hidden">
+                            <div
+                              style={"width: #{if t_total > 0, do: round(t_passed / t_total * 100), else: 0}%"}
+                              class="bg-lime-500 h-full rounded-full transition-all"
+                            >
+                            </div>
+                          </div>
                         </div>
                       </td>
 
@@ -640,6 +908,39 @@ defmodule ControlKeelWeb.ProofBrowserLive do
   defp format_domain_pack(pack), do: Intent.pack_label(pack)
   defp format_datetime(nil), do: "Not recorded"
   defp format_datetime(value), do: Calendar.strftime(value, "%Y-%m-%d %H:%M:%S UTC")
+
+  defp bundle_get(proof, keys, default \\ nil) do
+    get_in(proof.bundle || %{}, keys) || default
+  end
+
+  defp verification_score_color(score) when is_integer(score) do
+    cond do
+      score >= 80 -> "text-lime-400"
+      score >= 50 -> "text-amber-400"
+      true -> "text-red-400"
+    end
+  end
+
+  defp verification_score_color(_), do: "text-zinc-400"
+
+  defp verification_status_color("strong"), do: "border-lime-500/40 bg-lime-500/10 text-lime-400"
+
+  defp verification_status_color("moderate"),
+    do: "border-amber-500/40 bg-amber-500/10 text-amber-400"
+
+  defp verification_status_color("weak"), do: "border-red-500/40 bg-red-500/10 text-red-400"
+  defp verification_status_color(_), do: "border-zinc-500/40 bg-zinc-500/10 text-zinc-400"
+
+  defp context_status_color("clean"), do: "border-lime-500/40 bg-lime-500/10 text-lime-400"
+  defp context_status_color("degraded"), do: "border-red-500/40 bg-red-500/10 text-red-400"
+  defp context_status_color(_), do: "border-zinc-500/40 bg-zinc-500/10 text-zinc-400"
+
+  defp deploy_badge_class(true), do: "border-lime-500/40 bg-lime-500/10 text-lime-400"
+  defp deploy_badge_class(_), do: "border-yellow-500/40 bg-yellow-500/10 text-yellow-400"
+
+  defp risk_bar_width(nil), do: 0
+  defp risk_bar_width(score) when is_float(score), do: min(round(score * 100), 100)
+  defp risk_bar_width(_), do: 0
 
   defp org_workspace_ids(nil), do: []
 

--- a/lib/controlkeel_web/live/proof_browser_live.ex
+++ b/lib/controlkeel_web/live/proof_browser_live.ex
@@ -22,21 +22,42 @@ defmodule ControlKeelWeb.ProofBrowserLive do
 
   @impl true
   def handle_params(%{"id" => id}, _uri, socket) do
-    case Mission.get_proof_bundle_with_context(String.to_integer(id)) do
+    case parse_int(id) do
       nil ->
         {:noreply,
          socket
-         |> put_flash(:error, "Proof bundle not found.")
-         |> push_navigate(to: ~p"/proofs")}
+         |> assign(:page_title, "Proof not found")
+         |> assign(:proof, nil)
+         |> assign(:memory_hits, [])}
 
-      proof ->
-        memory_hits = related_memory_hits(proof)
+      parsed_id ->
+        case Mission.get_proof_bundle_with_context(parsed_id) do
+          nil ->
+            {:noreply,
+             socket
+             |> assign(:page_title, "Proof not found")
+             |> assign(:proof, nil)
+             |> assign(:memory_hits, [])}
 
-        {:noreply,
-         socket
-         |> assign(:page_title, "Proof #{proof.id}")
-         |> assign(:proof, proof)
-         |> assign(:memory_hits, memory_hits)}
+          proof ->
+            workspace_ids = org_workspace_ids(socket.assigns[:current_org_id])
+
+            if workspace_ids != [] and proof.session.workspace_id not in workspace_ids do
+              {:noreply,
+               socket
+               |> assign(:page_title, "Proof not found")
+               |> assign(:proof, nil)
+               |> assign(:memory_hits, [])}
+            else
+              memory_hits = related_memory_hits(proof)
+
+              {:noreply,
+               socket
+               |> assign(:page_title, "Proof #{proof.id}")
+               |> assign(:proof, proof)
+               |> assign(:memory_hits, memory_hits)}
+            end
+        end
     end
   end
 
@@ -68,24 +89,24 @@ defmodule ControlKeelWeb.ProofBrowserLive do
   def render(%{live_action: :show} = assigns) do
     ~H"""
     <Layouts.app flash={@flash}>
-      <section class="mx-auto w-[min(1180px,calc(100%-2rem))] pt-8 pb-16">
-        <div class="mt-6 mb-4 flex items-center justify-between gap-4">
-          <div>
-            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
-              Proof browser
-            </p>
-            <h1 class="text-[clamp(2rem,4vw,3.4rem)] leading-tight">Immutable proof snapshot</h1>
-            <p class="max-w-3xl text-base leading-relaxed text-[var(--ck-muted)]">
-              Every proof bundle is a frozen audit artifact for a single task version.
-            </p>
-          </div>
-          <div class="flex flex-wrap gap-2">
-            <.link
-              navigate={~p"/proofs"}
-              class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]"
-            >
-              Back to proofs
-            </.link>
+      <section class="mx-auto w-[min(1180px,calc(100%-2rem))]">
+        <div :if={@proof} class="space-y-8">
+          <.link
+            navigate={~p"/proofs"}
+            class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400 hover:text-neutral-200"
+          >
+            <.icon name="hero-arrow-left" class="w-3 h-3" /> Back to proofs
+          </.link>
+
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
+                Immutable proof snapshot
+              </p>
+              <p class="max-w-3xl text-base leading-relaxed text-[var(--ck-muted)]">
+                Every proof bundle is a frozen audit artifact for a single task version.
+              </p>
+            </div>
             <.link
               navigate={~p"/missions/#{@proof.session_id}"}
               class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]"
@@ -95,7 +116,25 @@ defmodule ControlKeelWeb.ProofBrowserLive do
           </div>
         </div>
 
-        <div class="mt-5 grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-4">
+        <div :if={!@proof} class="flex flex-col mt-28 items-center gap-4 text-center">
+          <div>
+            <h1 class="text-[clamp(2rem,4vw,3.4rem)] leading-tight font-sans font-semibold">
+              Proof not found
+            </h1>
+          </div>
+
+          <p class="text-lg text-zinc-400">
+            No proof bundle exists with this identifier.
+          </p>
+          <.link
+            navigate={~p"/proofs"}
+            class="rounded-md border border-white/10 bg-black/40 px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-lime-400 transition hover:border-lime-400 inline-flex items-center gap-2"
+          >
+            <.icon name="hero-arrow-left" class="w-4 h-4" /> Browse proofs
+          </.link>
+        </div>
+
+        <div :if={@proof} class="mt-5 grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-4">
           <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
             <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
               Task
@@ -122,7 +161,10 @@ defmodule ControlKeelWeb.ProofBrowserLive do
           </div>
         </div>
 
-        <div class="mt-6 grid grid-cols-[minmax(0,1.35fr)_minmax(280px,0.75fr)] gap-6 max-[900px]:grid-cols-1">
+        <div
+          :if={@proof}
+          class="mt-6 grid grid-cols-[minmax(0,1.35fr)_minmax(280px,0.75fr)] gap-6 max-[900px]:grid-cols-1"
+        >
           <div class="rounded-2xl border border-[var(--ck-stroke)] bg-[var(--ck-panel)] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.22)] backdrop-blur-[18px]">
             <p class="text-xs font-semibold uppercase tracking-[0.14em] text-[var(--ck-lime)]">
               Snapshot
@@ -244,7 +286,7 @@ defmodule ControlKeelWeb.ProofBrowserLive do
   def render(assigns) do
     ~H"""
     <Layouts.app flash={@flash}>
-      <section class="mx-auto w-[min(1180px,calc(100%-2rem))] pt-8 pb-16">
+      <section class="mx-auto w-[min(1180px,calc(100%-2rem))]">
         <div class="space-y-1">
           <h2 class="text-2xl font-semibold text-[var(--ck-lime)] leading-6 tracking-wide uppercase">
             Proof browser
@@ -573,6 +615,15 @@ defmodule ControlKeelWeb.ProofBrowserLive do
     |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
     |> Enum.into(%{})
   end
+
+  defp parse_int(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {parsed, ""} when parsed > 0 -> parsed
+      _ -> nil
+    end
+  end
+
+  defp parse_int(_), do: nil
 
   defp filter_params(filters) do
     filters

--- a/lib/controlkeel_web/live/proof_browser_live.ex
+++ b/lib/controlkeel_web/live/proof_browser_live.ex
@@ -356,10 +356,19 @@ defmodule ControlKeelWeb.ProofBrowserLive do
               </div>
             </form>
 
-            <p class="text-neutral-400 tracking-tight">
-              <span class="text-[var(--ck-lime)] mr-1">{@browser.total_count}</span>
-              total proof bundles found
-            </p>
+            <div class="flex items-center justify-between">
+              <p class="text-neutral-400 tracking-tight">
+                <span class="text-[var(--ck-lime)] mr-1">{@browser.total_count}</span>
+                total proof bundles found
+              </p>
+
+              <.link
+                patch={~p"/proofs"}
+                class="self-end rounded-md border border-white/10 bg-black/40 px-4 py-3 text-xs font-semibold uppercase tracking-[0.1em] text-zinc-400 transition hover:border-red-500/40 hover:text-red-400 text-center"
+              >
+                Reset all
+              </.link>
+            </div>
           </div>
 
           <div class="overflow-x-auto w-full">
@@ -471,7 +480,7 @@ defmodule ControlKeelWeb.ProofBrowserLive do
                       </td>
 
                       <td class="px-2 py-6 text-right align-top">
-                        <div class="flex justify-end gap-4 font-semibold text-sm">
+                        <div class="flex justify-end gap-2 font-semibold text-sm">
                           <.link
                             navigate={~p"/missions/#{proof.session_id}"}
                             class="text-zinc-400 transition hover:text-white border px-2 py-1 rounded-md"
@@ -558,7 +567,7 @@ defmodule ControlKeelWeb.ProofBrowserLive do
       "q" => filters.q,
       "session_id" => filters.session_id,
       "task_id" => filters.task_id,
-      "deploy_ready" => filters.deploy_ready,
+      "deploy_ready" => if(filters.deploy_ready != nil, do: to_string(filters.deploy_ready)),
       "risk_tier" => filters.risk_tier
     }
     |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)

--- a/lib/controlkeel_web/live/proof_browser_live.ex
+++ b/lib/controlkeel_web/live/proof_browser_live.ex
@@ -40,9 +40,10 @@ defmodule ControlKeelWeb.ProofBrowserLive do
              |> assign(:memory_hits, [])}
 
           proof ->
-            workspace_ids = org_workspace_ids(socket.assigns[:current_org_id])
+            current_org_id = socket.assigns[:current_org_id]
+            workspace_ids = org_workspace_ids(current_org_id)
 
-            if workspace_ids != [] and proof.session.workspace_id not in workspace_ids do
+            if current_org_id && proof.session.workspace_id not in workspace_ids do
               {:noreply,
                socket
                |> assign(:page_title, "Proof not found")
@@ -910,7 +911,7 @@ defmodule ControlKeelWeb.ProofBrowserLive do
   defp format_datetime(value), do: Calendar.strftime(value, "%Y-%m-%d %H:%M:%S UTC")
 
   defp bundle_get(proof, keys, default \\ nil) do
-    get_in(proof.bundle || %{}, keys) || default
+    if proof, do: get_in(proof.bundle || %{}, keys) || default, else: default
   end
 
   defp verification_score_color(score) when is_integer(score) do

--- a/test/controlkeel_web/live/proof_browser_live_test.exs
+++ b/test/controlkeel_web/live/proof_browser_live_test.exs
@@ -4,6 +4,9 @@ defmodule ControlKeelWeb.ProofBrowserLiveTest do
   import Phoenix.LiveViewTest
   import ControlKeel.MissionFixtures
 
+  alias ControlKeel.Repo
+  alias ControlKeel.Accounts.Org
+
   test "proof browser filters and paginates proof bundles", %{conn: conn} do
     session = session_fixture(%{title: "Proof mission"})
     task = task_fixture(%{session: session, status: "done", title: "Ship proof"})
@@ -13,7 +16,7 @@ defmodule ControlKeelWeb.ProofBrowserLiveTest do
 
     assert html =~ "Proof browser"
     assert html =~ "Ship proof"
-    assert has_element?(view, "a[href=\"/proofs/#{proof.id}\"]", "View proof")
+    assert has_element?(view, "a[href=\"/proofs/#{proof.id}\"]", "View")
   end
 
   test "proof browser detail renders immutable proof content and related memory", %{conn: conn} do
@@ -28,5 +31,48 @@ defmodule ControlKeelWeb.ProofBrowserLiveTest do
     assert html =~ "Detailed proof"
     assert html =~ "Rollback instructions"
     assert html =~ "Related memory"
+  end
+
+  test "detail view enforces org workspace boundary", %{conn: conn} do
+    {:ok, org_a} =
+      %Org{}
+      |> Org.changeset(%{name: "Proof Org A", slug: "proof-org-a", status: "active"})
+      |> Repo.insert()
+
+    {:ok, org_b} =
+      %Org{}
+      |> Org.changeset(%{name: "Proof Org B", slug: "proof-org-b", status: "active"})
+      |> Repo.insert()
+
+    workspace_a = workspace_fixture(%{name: "Org A Workspace", org_id: org_a.id})
+    workspace_b = workspace_fixture(%{name: "Org B Workspace", org_id: org_b.id})
+
+    session_a = session_fixture(%{workspace: workspace_a, title: "Org A Session"})
+    session_b = session_fixture(%{workspace: workspace_b, title: "Org B Session"})
+
+    task_a = task_fixture(%{session: session_a, status: "done", title: "Org A Task"})
+    task_b = task_fixture(%{session: session_b, status: "done", title: "Org B Task"})
+
+    proof_a = proof_bundle_fixture(%{task: task_a})
+    proof_b = proof_bundle_fixture(%{task: task_b})
+
+    conn_a = Plug.Test.init_test_session(conn, %{"current_org_id" => org_a.id})
+
+    {:ok, _view, html} = live(conn_a, ~p"/proofs/#{proof_a.id}")
+    assert html =~ "Immutable proof snapshot"
+    assert html =~ "Org A Task"
+    refute html =~ "Org B Task"
+
+    {:ok, _view, html_unauth} = live(conn_a, ~p"/proofs/#{proof_b.id}")
+    assert html_unauth =~ "Proof not found"
+    assert html_unauth =~ "No proof bundle exists with this identifier."
+    refute html_unauth =~ "Immutable proof snapshot"
+    refute html_unauth =~ "Org B Task"
+  end
+
+  test "malformed proof id shows not-found inline", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/proofs/not-an-id")
+    assert html =~ "Proof not found"
+    assert html =~ "No proof bundle exists with this identifier."
   end
 end


### PR DESCRIPTION
This branch refactors the proof browser CSS classes to Tailwind utility classes. It adds org-based workspace access control on the detail view, replaces crash-on-bad-ID with an inline not-found page, removes the sticky "Mission Control" header from the app layout. The home page heading font stack is also cleaned up.

**Related Issue: #11**

### Changes

- **`assets/css/app.css`** — Removed serif `font-family` rule for `h1, h2, h3` (headings now use Inter sans-serif across the app).
- **`lib/controlkeel_web/components/layouts.ex`** — Removed sticky "Mission Control" header from the app layout.
- **`lib/controlkeel_web/live/proof_browser_live.ex`**:
  - Replaced all `ck-*` CSS classes with Tailwind utility classes (both index and show views).
  - **Show view:** replaced `push_navigate` + flash on missing proof with inline "Proof not found" UI.
  - Added `parse_int/1` guard — returns `nil` for non-numeric/zero/negative IDs instead of crashing.
  - Added org workspace boundary check: `org_workspace_ids/1` queries workspaces belonging to the user's `current_org_id` and blocks cross-org access.
  - Added new UI sections: verification assessment (score + status badges), task check counts with progress bar, context integrity, deploy readiness with risk-score bar, collapsible raw proof payload, finding resolution summary.
  - Status badge color helpers: `verification_score_color`, `verification_status_color`, `context_status_color`, `deploy_badge_class`, `risk_bar_width`.
  - **Index view:** added "Reset all" filter button, disabled-state pagination buttons at boundary pages, empty-state table row, "View" action label (was "View proof"), deploy_ready filter serialization fix.

- **`test/controlkeel_web/live/proof_browser_live_test.exs`**:
  - Updated link text assertion `"View proof"` → `"View"`.
  - Added test `"detail view enforces org workspace boundary"` — creates two orgs with separate workspaces/sessions/tasks/proofs, verifies cross-org access returns inline "Proof not found".
  - Added test `"malformed proof id shows not-found inline"` — verifies `/proofs/not-an-id` renders inline not-found without crashing.

### Test
- **Test run (all 4 pass):**
  ```
  mix test test/controlkeel_web/live/proof_browser_live_test.exs
  ```

### Notes
Some of the refactors are related to the mission and tasks. They will be handled while going through those modules.