### PR TITLE
chore(docker): bump base image to Debian trixie (supersedes #2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,31 @@ jobs:
       - run: chmod +x scripts/self_host_smoke.sh
       - name: Run self-host smoke
         run: scripts/self_host_smoke.sh
+
+  docker-base:
+    # Validates the Dockerfile base images without the expensive from-source OTP
+    # build: fully builds the agent-runner image and verifies the main
+    # Dockerfile's apt package sets resolve on its base image. Catches base-image
+    # bumps (e.g. bookworm -> trixie) that rename/drop packages.
+    if: >-
+      github.event_name != 'push' ||
+      !startsWith(github.event.head_commit.message || '', 'chore(release): bump version to ')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build agent-runner image
+        run: docker build -f Dockerfile.agent-runner -t controlkeel-agent-runner:ci .
+      - name: Verify main Dockerfile apt package sets resolve on its base image
+        run: |
+          set -euo pipefail
+          base="$(grep -m1 -oE '^FROM [^ ]+' Dockerfile | awk '{print $2}')"
+          echo "Base image: $base"
+          docker run --rm "$base" bash -c '
+            set -eux
+            apt-get update
+            apt-get install -y --no-install-recommends \
+              build-essential ca-certificates curl git wget unzip libssl-dev libncurses-dev
+            apt-get install -y --no-install-recommends \
+              libstdc++6 libssl3t64 ca-certificates libncurses6 git
+          '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,16 +154,22 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build agent-runner image
         run: docker build -f Dockerfile.agent-runner -t controlkeel-agent-runner:ci .
-      - name: Verify main Dockerfile apt package sets resolve on its base image
+      - name: Verify main Dockerfile apt package sets resolve on their base images
         run: |
           set -euo pipefail
-          base="$(grep -m1 -oE '^FROM [^ ]+' Dockerfile | awk '{print $2}')"
-          echo "Base image: $base"
-          docker run --rm "$base" bash -c '
+          build_base="$(awk '/^FROM/{print $2; exit}' Dockerfile)"
+          runtime_base="$(awk '/^FROM/ && seen++ {print $2; exit}' Dockerfile)"
+          echo "Build base: $build_base"
+          echo "Runtime base: $runtime_base"
+          docker run --rm "$build_base" bash -c '
             set -eux
             apt-get update
             apt-get install -y --no-install-recommends \
               build-essential ca-certificates curl git wget unzip libssl-dev libncurses-dev
+          '
+          docker run --rm "$runtime_base" bash -c '
+            set -eux
+            apt-get update
             apt-get install -y --no-install-recommends \
               libstdc++6 libssl3t64 ca-certificates libncurses6 git
           '

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@
 # (release-smoke.yml uses erlef/setup-beam with otp-version: "27.3.4.3"
 # and elixir-version: "1.19.5").  hexpm images no longer carry OTP 27 stable.
 #
-FROM debian:bookworm-slim AS build
+FROM debian:trixie-slim AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       build-essential ca-certificates curl git wget unzip \
-      libssl-dev libncurses5-dev \
+      libssl-dev libncurses-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Erlang/OTP 27.3.4.3 via kerl (matches CI).
@@ -62,10 +62,10 @@ COPY config/runtime.exs config/
 RUN mix release
 
 # ---- Runtime Stage ----
-FROM debian:bookworm-slim AS app
+FROM debian:trixie-slim AS app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      libstdc++6 libssl3 ca-certificates libncurses6 git \
+      libstdc++6 libssl3t64 ca-certificates libncurses6 git \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Dockerfile.agent-runner
+++ b/Dockerfile.agent-runner
@@ -9,7 +9,7 @@
 # Published by .github/workflows/agent-runner-image.yml to
 # ghcr.io/aryaminus/controlkeel-agent-runner:latest using the built-in
 # GITHUB_TOKEN (no external registry credentials required).
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

Supersedes #2 (Snyk's `bookworm-slim` → `13.4-slim`), which changed only the `FROM` lines and would **fail to build on trixie**: `libncurses5-dev` is dropped, and `libssl3` was renamed to `libssl3t64` in Debian's 64-bit `time_t` transition.

This does the bump correctly and coordinates **both** images:
- `Dockerfile` + `Dockerfile.agent-runner`: `debian:bookworm-slim` → `debian:trixie-slim`
- build stage: `libncurses5-dev` → `libncurses-dev`
- runtime stage: `libssl3` → `libssl3t64` (`libncurses6` / `libstdc++6` still present in trixie)

Package names verified against packages.debian.org for trixie.

## Verification

Adds a `docker-base` CI job (runs on PRs) that:
1. **Fully builds** `Dockerfile.agent-runner` on trixie.
2. Verifies the main `Dockerfile`'s build + runtime apt sets resolve on its base image.

The main `Dockerfile` was previously **never built in CI** (its from-source OTP/`kerl` build is too slow for per-PR runs) — which is exactly why #2's broken package set would not have been caught. This job closes that gap cheaply.

> Note: `debian:trixie-slim` still carries 2 upstream high CVEs per Snyk — current state of the latest stable Debian base; no cleaner stable base short of distroless.

Supersedes #2.

## Test plan
- [x] Package names verified on packages.debian.org (trixie)
- [x] `ci.yml` YAML validated (4 jobs, docker-base = 3 steps)
- [ ] `docker-base` CI job green (confirming post-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)