### PR TITLE
fix(npm): de-obfuscate installer URLs (Socket urlStrings alert)

### DIFF
--- a/packages/npm/controlkeel/SECURITY.md
+++ b/packages/npm/controlkeel/SECURITY.md
@@ -88,17 +88,18 @@ The package uses a **lazy download model** - the native binary is downloaded on 
 
 ### Alert: URL Strings
 
-- **Status**: ✅ RESOLVED
-- **Original Issue**: Package contained `https://github.com/...` URL strings
-- **Resolution**: URLs constructed from base64-encoded parts at runtime
-- **Implementation**:
-
-  ```javascript
-  const GITHUB_BASE = Buffer.from("aHR0cHM6Ly9naXRodWIuY29t", "base64").toString("utf8"); // "https://github.com"
-  const RELEASES_PATH = Buffer.from("L3JlbGVhc2VzLw==", "base64").toString("utf8"); // "/releases/"
-  ```
-
-- **Verification**: `grep -r "github\.com" --include="*.js"` returns no matches
+- **Status**: ✅ ACCEPTED (benign, intentional)
+- **Issue**: Socket flags that the package references external URL strings.
+- **Assessment**: The package references exactly two external URLs, both required and intentional:
+  - `https://github.com/aryaminus/controlkeel/releases/...` — the public GitHub Releases host the prebuilt binary is downloaded from.
+  - `https://token.actions.githubusercontent.com` — the OIDC issuer used by cosign keyless verification to confirm the downloaded binary was signed by this repo's `release.yml` workflow.
+- **Resolution**: URLs are kept as plain, auditable strings. They were previously
+  assembled from base64 parts at runtime to evade the scanner; that obfuscation
+  was removed because (a) runtime-decoded/base64 URLs are a pattern scanners treat
+  as *more* suspicious than plaintext, (b) it made the installer harder to audit,
+  and (c) it was already defeated by the plaintext URLs in the cosign step. The
+  correct posture is transparency plus cryptographic signature verification.
+- **Triage**: Informational alert — acknowledge in the Socket dashboard with the assessment above.
 
 ---
 
@@ -118,14 +119,18 @@ security_controls:
     rationale: "Prevents configuration-based attacks"
   
   url_handling:
-    encoding: "base64"
+    encoding: "plaintext"
+    egress:
+      - "https://github.com/aryaminus/controlkeel/releases (binary download)"
+      - "https://token.actions.githubusercontent.com (cosign OIDC issuer for signature verification)"
     hardcoded_repository: "aryaminus/controlkeel"
     hardcoded_version: "package.json"
-    rationale: "Prevents URL detection and repository redirects"
+    rationale: "Plain, auditable URLs; runtime obfuscation removed as a scanner anti-pattern"
   
   download_verification:
-    method: "SHA-256"
-    source: "GitHub Releases SHASUMS256.txt"
+    method: "SHA-256 + cosign keyless signature (sigstore)"
+    source: "GitHub Releases SHASUMS256.txt + .sig/.pem"
+    cosign_identity: "release.yml workflow tag builds"
     https_only: true
   
   dependencies:

--- a/packages/npm/controlkeel/SECURITY.md
+++ b/packages/npm/controlkeel/SECURITY.md
@@ -44,7 +44,7 @@ The package uses a **lazy download model** - the native binary is downloaded on 
 |---------|---------------|------------------|
 | No Install Scripts | Removed all `postinstall` and lifecycle scripts | Code execution during install |
 | No Environment Variables | Removed all `process.env` usage; hardcoded configuration | Configuration-based attacks |
-| URL Encoding | Base64-encoded URL parts constructed at runtime | URL string detection by scanners |
+| Plain URLs | Plaintext, auditable URL strings (base64 removed) | Auditability; no hidden network destinations |
 | Hardcoded Repository | Fixed to `aryaminus/controlkeel` | Repository redirect attacks |
 | HTTPS Only | All downloads use HTTPS | Man-in-the-middle attacks |
 | SHA-256 Verification | Checksum verification against official releases | Tampered binary downloads |
@@ -120,17 +120,18 @@ security_controls:
   
   url_handling:
     encoding: "plaintext"
-    egress:
-      - "https://github.com/aryaminus/controlkeel/releases (binary download)"
-      - "https://token.actions.githubusercontent.com (cosign OIDC issuer for signature verification)"
+    url_strings_referenced:
+      - "https://github.com/aryaminus/controlkeel/releases — installer downloads binary, checksum, and optional cosign sig/cert from this base"
+      - "https://token.actions.githubusercontent.com — OIDC issuer string passed to cosign --certificate-oidc-issuer (not a direct HTTP endpoint; cosign contacts it)"
     hardcoded_repository: "aryaminus/controlkeel"
     hardcoded_version: "package.json"
     rationale: "Plain, auditable URLs; runtime obfuscation removed as a scanner anti-pattern"
   
   download_verification:
-    method: "SHA-256 + cosign keyless signature (sigstore)"
+    method: "SHA-256 (always); cosign keyless signature (when cosign is on PATH)"
     source: "GitHub Releases SHASUMS256.txt + .sig/.pem"
     cosign_identity: "release.yml workflow tag builds"
+    cosign_required: false
     https_only: true
   
   dependencies:

--- a/packages/npm/controlkeel/lib/install.js
+++ b/packages/npm/controlkeel/lib/install.js
@@ -12,19 +12,19 @@ const packageJson = require("../package.json");
 const REPOSITORY = "aryaminus/controlkeel";
 const VERSION = packageJson.version;
 
-// Base64 encoded URL parts to avoid supply chain scanners detecting URL strings
-const GITHUB_BASE = Buffer.from("aHR0cHM6Ly9naXRodWIuY29t", "base64").toString("utf8");
-const RELEASES_PATH = Buffer.from("L3JlbGVhc2VzLw==", "base64").toString("utf8");
-const LATEST_PART = Buffer.from("bGF0ZXN0L2Rvd25sb2Fk", "base64").toString("utf8");
-const DOWNLOAD_PART = Buffer.from("ZG93bmxvYWQv", "base64").toString("utf8");
-const VERSION_PREFIX = Buffer.from("dg==", "base64").toString("utf8");
+// Binary releases are downloaded from the project's public GitHub Releases and
+// their signatures verified with cosign (see verifyCosignSignature). These URLs
+// are intentional and the only network egress this installer performs. They are
+// kept as plain, auditable strings: obfuscating them (e.g. base64 at runtime)
+// is a pattern supply-chain scanners treat as MORE suspicious, not less.
+const RELEASES_URL = `https://github.com/${REPOSITORY}/releases`;
 
 function releaseBaseUrl() {
   if (VERSION === "latest") {
-    return GITHUB_BASE + `/${REPOSITORY}` + RELEASES_PATH + LATEST_PART;
+    return `${RELEASES_URL}/latest/download`;
   }
 
-  return GITHUB_BASE + `/${REPOSITORY}` + RELEASES_PATH + DOWNLOAD_PART + VERSION_PREFIX + VERSION;
+  return `${RELEASES_URL}/download/v${VERSION}`;
 }
 
 function assetName(platform = process.platform, arch = process.arch) {
@@ -184,7 +184,7 @@ async function verifySignature(filePath, asset, baseUrl) {
 
   if (!cosignPath) return;
 
-  const repo = `${Buffer.from("YXJ5YW1pbnVzL2NvbnRyb2xrZWVs", "base64")}`;
+  const repo = REPOSITORY;
   const sigUrl = `${baseUrl}/${asset}.sig`;
   const certUrl = `${baseUrl}/${asset}.pem`;
   const sigFile = path.join(os.tmpdir(), `${asset}.sig`);

--- a/packages/npm/controlkeel/lib/install.js
+++ b/packages/npm/controlkeel/lib/install.js
@@ -13,10 +13,11 @@ const REPOSITORY = "aryaminus/controlkeel";
 const VERSION = packageJson.version;
 
 // Binary releases are downloaded from the project's public GitHub Releases and
-// their signatures verified with cosign (see verifyCosignSignature). These URLs
-// are intentional and the only network egress this installer performs. They are
-// kept as plain, auditable strings: obfuscating them (e.g. base64 at runtime)
-// is a pattern supply-chain scanners treat as MORE suspicious, not less.
+// their signatures verified with cosign (see verifySignature). This is the base
+// URL for all network egress this installer performs — binary, checksum file,
+// and optional cosign sig/cert artifacts all resolve from here. Kept as plain,
+// auditable strings: obfuscating them (e.g. base64 at runtime) is a pattern
+// supply-chain scanners treat as MORE suspicious, not less.
 const RELEASES_URL = `https://github.com/${REPOSITORY}/releases`;
 
 function releaseBaseUrl() {


### PR DESCRIPTION
## Context

Socket flagged `@aryaminus/controlkeel@0.3.54` with a **URL strings** alert. Investigation: the alert is **benign** — the package references exactly two external URLs, both intentional:
- `https://github.com/aryaminus/controlkeel/releases/...` — the GitHub Releases host the binary is downloaded from.
- `https://token.actions.githubusercontent.com` — the cosign keyless OIDC issuer used to **verify the binary's signature** ([install.js](packages/npm/controlkeel/lib/install.js)). A security *feature*.

## The real problem

The installer assembled its release URLs from **base64 parts at runtime** to dodge the scanner, and `SECURITY.md` documented this as the "resolution." That's an anti-pattern:
1. Runtime-decoded / base64 URLs read as **more** suspicious to supply-chain scanners than plaintext.
2. It made the installer harder to audit.
3. It was already **defeated** — the later cosign step uses plaintext URLs, so 0.3.54 alerted anyway.

## Change

- Replace the base64 `GITHUB_BASE`/`RELEASES_PATH`/… constants with a plaintext `RELEASES_URL`. **Output is byte-identical** (verified both ways): `…/releases/latest/download` and `…/releases/download/v<version>`.
- Reuse the existing `REPOSITORY` constant instead of a second base64-encoded copy in the cosign block.
- `SECURITY.md`: replace the "resolved via base64" claim with an accurate account (intentional URLs + cosign verification; the urlStrings alert is benign and should be acknowledged in the Socket dashboard, not obfuscated).

## No regression
- Old vs new URL construction proven byte-identical via a side-by-side decode.
- `node --check packages/npm/controlkeel/lib/install.js` passes (also enforced in CI).
- Only network egress remains the signed binary download; cosign verification unchanged.

## Follow-up (dashboard, not code)
Acknowledge the `urlStrings` alert in Socket with the justification above — it cannot and should not be "fixed" by hiding legitimate URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)