### PR TITLE
Refactor benchmark web view

### DIFF
--- a/lib/controlkeel_web/live/benchmarks_live.ex
+++ b/lib/controlkeel_web/live/benchmarks_live.ex
@@ -82,8 +82,18 @@ defmodule ControlKeelWeb.BenchmarksLive do
   end
 
   def handle_event("toggle_subject", %{"id" => id}, socket) do
-    current = List.wrap(socket.assigns.form.params["subjects"])
-    updated = if id in current, do: List.delete(current, id), else: current ++ [id]
+    current =
+      socket.assigns.form.params["subjects"]
+      |> List.wrap()
+      |> Enum.map(&to_string/1)
+      |> Enum.uniq()
+
+    updated =
+      if id in current do
+        Enum.reject(current, &(&1 == id))
+      else
+        current ++ [id]
+      end
     new_params = Map.put(socket.assigns.form.params, "subjects", updated)
 
     {:noreply,

--- a/lib/controlkeel_web/live/benchmarks_live.ex
+++ b/lib/controlkeel_web/live/benchmarks_live.ex
@@ -132,7 +132,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
           </a>
         </div>
 
-        <div class="border border-[var(--ck-stroke)]  rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+        <div class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
           <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold mb-4">
             Performance metrics
           </p>

--- a/lib/controlkeel_web/live/benchmarks_live.ex
+++ b/lib/controlkeel_web/live/benchmarks_live.ex
@@ -172,7 +172,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
           <div class="grid gap-4 grid-cols-2 max-[900px]:grid-cols-1">
             <div>
               <h3>Status</h3>
-              <p class="text-[var(--ck-muted)]">{@run.status}</p>
+              <p class="text-[var(--ck-muted)]">{run_status_label(@run.status)}</p>
             </div>
             <div>
               <h3>Baseline subject</h3>
@@ -427,36 +427,82 @@ defmodule ControlKeelWeb.BenchmarksLive do
         </div>
 
         <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 mt-6">
-          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-            Recent runs
-          </p>
-          <div class="overflow-x-auto">
-            <.table id="benchmark-runs" rows={@recent_runs}>
-              <:col :let={run} label="Run">
-                <.link
-                  navigate={~p"/benchmarks/runs/#{run.id}"}
-                  class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
-                >
-                  ##{run.id}
-                </.link>
-              </:col>
-              <:col :let={run} label="Suite">
-                {run.suite.slug}
-              </:col>
-              <:col :let={run} label="Status">
-                {run.status}
-              </:col>
-              <:col :let={run} label="Catch rate">
-                {run.catch_rate}%
-              </:col>
-              <:col :let={run} label="Baseline">
-                {run.baseline_subject}
-              </:col>
-              <:col :let={run} label="Domains">
-                {Enum.map_join(Benchmark.domain_packs_for_run(run), ", ", &format_domain_pack/1)}
-              </:col>
-            </.table>
+          <div class="flex items-center justify-between gap-4">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Recent runs
+            </p>
+            <span :if={@recent_runs != []} class="text-xs text-[var(--ck-muted)]">
+              {length(@recent_runs)} {if length(@recent_runs) == 1, do: "run", else: "runs"}
+            </span>
           </div>
+          <%= if @recent_runs == [] do %>
+            <div class="mt-4 rounded-[1rem] border border-dashed border-[var(--ck-stroke)] p-8 text-center">
+              <p class="text-[var(--ck-text)] text-sm font-medium">
+                No benchmark runs yet
+              </p>
+              <p class="text-[var(--ck-muted)] text-sm mt-1">
+                Pick a preset above and run your first suite to see results here.
+              </p>
+            </div>
+          <% else %>
+            <div class="overflow-x-auto mt-4">
+              <table id="benchmark-runs" class="min-w-full text-sm">
+                <thead>
+                  <tr class="text-left text-xs text-[var(--ck-muted)] uppercase tracking-wider">
+                    <th class="py-2 pr-4">Run</th>
+                    <th class="py-2 pr-4">Suite</th>
+                    <th class="py-2 pr-4">Status</th>
+                    <th class="py-2 pr-4">Catch rate</th>
+                    <th class="py-2 pr-4">Baseline</th>
+                    <th class="py-2 pr-4">Domains</th>
+                    <th class="py-2 pr-4 text-right">Overhead</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-[var(--ck-stroke)]">
+                  <%= for run <- @recent_runs do %>
+                    <tr id={"run-#{run.id}"} class="align-top">
+                      <td class="py-3 pr-4">
+                        <.link
+                          navigate={~p"/benchmarks/runs/#{run.id}"}
+                          class="font-semibold text-[var(--ck-lime)]"
+                        >
+                          ##{run.id}
+                        </.link>
+                      </td>
+                      <td class="py-3 pr-4 text-[var(--ck-muted)] truncate">
+                        {run.suite.name || run.suite.slug}
+                      </td>
+                      <td class="py-3 pr-4">
+                        <span class="inline-flex items-center rounded-full px-3 py-1 text-xs bg-white/5 border border-[var(--ck-stroke)]">
+                          {run_status_label(run.status)}
+                        </span>
+                      </td>
+                      <td class="py-3 pr-4"><strong>{format_percent(run.catch_rate)}</strong></td>
+                      <td class="py-3 pr-4 text-[var(--ck-muted)]">
+                        {subject_label(
+                          Enum.find(@available_subjects || [], fn s ->
+                            s["id"] == run.baseline_subject
+                          end) || %{"id" => run.baseline_subject}
+                        )}
+                      </td>
+                      <td class="py-3 pr-4">
+                        <div class="flex flex-wrap gap-2">
+                          <%= for pack <- Benchmark.domain_packs_for_run(run) do %>
+                            <span class="border border-[var(--ck-stroke)] bg-white/5 rounded-full px-2 py-0.5 text-[0.75rem]">
+                              {format_domain_pack(pack)}
+                            </span>
+                          <% end %>
+                        </div>
+                      </td>
+                      <td class="py-3 pr-4 text-right text-[var(--ck-muted)]">
+                        {format_percent(run.average_overhead_percent)}
+                      </td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+          <% end %>
         </div>
 
         <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 mt-6">
@@ -688,4 +734,13 @@ defmodule ControlKeelWeb.BenchmarksLive do
 
   defp format_domain_pack(nil), do: "Unknown"
   defp format_domain_pack(domain_pack), do: Intent.pack_label(domain_pack)
+
+  defp run_status_label(nil), do: "unknown"
+
+  defp run_status_label(status) when is_binary(status) do
+    status
+    |> String.replace("_", " ")
+    |> String.trim()
+    |> String.capitalize()
+  end
 end

--- a/lib/controlkeel_web/live/benchmarks_live.ex
+++ b/lib/controlkeel_web/live/benchmarks_live.ex
@@ -284,24 +284,13 @@ defmodule ControlKeelWeb.BenchmarksLive do
     ~H"""
     <Layouts.app flash={@flash}>
       <section class="w-[min(1180px,calc(100%-2rem))] mx-auto pt-8 pb-16 max-[900px]:w-[min(calc(100%-1.25rem),1180px)] max-[900px]:pt-6">
-        <div class="flex items-center justify-between gap-4 mt-6 mb-4 max-[900px]:flex-col max-[900px]:items-start">
-          <div>
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Benchmark engine
-            </p>
-            <h1 class="text-[clamp(2rem,4vw,3.4rem)] leading-[1.02]">
-              Run persisted benchmark matrices
-            </h1>
-            <p class="text-[var(--ck-muted)] max-w-[48rem] text-[1.05rem] leading-[1.7]">
-              Compare governed subjects and external agents on the same scenario suites, then keep the results as product evidence.
-            </p>
-          </div>
-          <.link
-            navigate={~p"/"}
-            class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
-          >
-            Back home
-          </.link>
+        <div>
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Benchmark engine
+          </p>
+          <p class="text-[var(--ck-muted)] max-w-[48rem] text-[1.05rem] leading-[1.7]">
+            Compare governed subjects and external agents on the same scenario suites, then keep the results as product evidence.
+          </p>
         </div>
 
         <div class="grid gap-4 grid-cols-[repeat(auto-fit,minmax(180px,1fr))] mt-5">
@@ -331,18 +320,99 @@ defmodule ControlKeelWeb.BenchmarksLive do
           </div>
         </div>
 
-        <div class="grid grid-cols-[minmax(0,1.35fr)_minmax(280px,0.75fr)] gap-6 max-[900px]:grid-cols-1 mt-6">
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+        <div class="grid gap-4 grid-cols-[2fr_1fr] mt-6">
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 grid gap-4">
+            <div class="flex flex-col gap-3 mb-6">
+              <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+                Quick presets
+              </p>
+              <p class="text-[var(--ck-muted)] text-sm mb-2 max-w-[42rem] leading-relaxed">
+                One-click subject and suite configurations. Pick one to populate the form below.
+              </p>
+
+              <div class="flex flex-wrap gap-2">
+                <button
+                  :for={{preset_id, preset_value, preset_label} <- preset_chips()}
+                  type="button"
+                  id={preset_id}
+                  phx-click="preset_benchmark"
+                  phx-value-preset={preset_value}
+                  aria-pressed={to_string(preset_value == @active_preset)}
+                  class={[
+                    "group inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm transition-all duration-150 active:scale-[0.98]",
+                    if(preset_value == @active_preset,
+                      do: "border-[var(--ck-lime)] bg-[rgba(196,240,66,0.16)] text-[var(--ck-lime)]",
+                      else:
+                        "border-[var(--ck-stroke)] bg-white/5 text-[var(--ck-text)] hover:-translate-y-px hover:border-[var(--ck-lime)] hover:bg-[rgba(196,240,66,0.08)] hover:text-[var(--ck-lime)]"
+                    )
+                  ]}
+                >
+                  {preset_label}
+                </button>
+              </div>
+            </div>
+            <.form
+              for={@form}
+              id="benchmark-runner"
+              phx-submit="run"
+              phx-change="benchmark_form_change"
+            >
+              <div class="flex flex-col gap-4">
+                <.input
+                  field={@form[:suite]}
+                  type="select"
+                  label="Suite"
+                  options={Enum.map(@all_suites, &{"#{&1.name} (#{&1.slug})", &1.slug})}
+                />
+                <.subject_multi_select
+                  field={@form[:subjects]}
+                  label="Subjects"
+                  options={subject_options(@available_subjects)}
+                  selected={@form[:subjects].value}
+                  open={@subjects_dropdown_open}
+                  id="benchmark-subjects-input"
+                />
+                <.input
+                  field={@form[:baseline_subject]}
+                  type="select"
+                  label="Baseline subject"
+                  options={subject_options(@available_subjects)}
+                  id="benchmark-baseline-input"
+                />
+                <.input
+                  field={@form[:domain_pack]}
+                  type="select"
+                  label="Run only this domain"
+                  prompt="All suite scenarios"
+                  options={@domain_pack_options}
+                />
+              </div>
+              <div class="flex items-center justify-between gap-4 mt-4 max-[900px]:flex-col max-[900px]:items-start">
+                <button
+                  type="submit"
+                  class="inline-flex items-center justify-center gap-[0.4rem] px-4 py-2 rounded-full bg-[var(--ck-lime)] text-[#11170d] font-bold transition-transform transition-shadow duration-150 hover:-translate-y-px hover:shadow-[0_12px_24px_rgba(196,240,66,0.24)]"
+                >
+                  Run benchmark
+                </button>
+              </div>
+            </.form>
+            <p class="text-[var(--ck-muted)] text-sm mt-4">
+              For a reproducible external comparison, start with `controlkeel_validate,opencode_manual`
+              and import the OpenCode output after the awaiting-import run finishes.
+            </p>
+          </div>
+
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 h-fit">
             <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
               Blessed external path
             </p>
-            <h3 class="mb-2">OpenCode vs ControlKeel</h3>
-            <p class="text-[var(--ck-muted)]">
+            <h3 class="my-2">OpenCode vs ControlKeel</h3>
+            <p class="text-[var(--ck-muted)] text-sm">
               The recommended first external comparison path is OpenCode. Start with a manual import
               subject for the quickest reproducible run, then swap to a shell-based wrapper if you
               want fully scripted replay.
             </p>
-            <ul class="grid gap-4 m-0 mt-3 p-0 list-none">
+            <ul class="grid gap-2 mt-4 list-none text-sm">
               <li>
                 Create or review `controlkeel/benchmark_subjects.json` with the OpenCode subject you want to import.
               </li>
@@ -354,165 +424,76 @@ defmodule ControlKeelWeb.BenchmarksLive do
               </li>
             </ul>
           </div>
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Available subjects
-            </p>
-            <div class="flex flex-wrap gap-2">
-              <%= for subject <- @available_subjects do %>
-                <span class="border border-[var(--ck-stroke)] bg-white/5 rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem]">
-                  {subject_label(subject)}
-                </span>
-              <% end %>
-            </div>
-            <p class="text-[var(--ck-muted)] mt-3">
-              Built-ins are always present. External subjects appear when the current project has a
-              `controlkeel/benchmark_subjects.json` file.
-            </p>
-          </div>
         </div>
 
-        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 grid gap-4">
-          <div class="flex flex-col gap-3 mb-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Quick presets
-            </p>
-            <p class="text-[var(--ck-muted)] text-sm mb-2 max-w-[42rem] leading-relaxed">
-              One-click subject and suite configurations. Pick one to populate the form below.
-            </p>
-
-            <div class="flex flex-wrap gap-2">
-              <button
-                :for={{preset_id, preset_value, preset_label} <- preset_chips()}
-                type="button"
-                id={preset_id}
-                phx-click="preset_benchmark"
-                phx-value-preset={preset_value}
-                aria-pressed={to_string(preset_value == @active_preset)}
-                class={[
-                  "group inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm transition-all duration-150 active:scale-[0.98]",
-                  if(preset_value == @active_preset,
-                    do: "border-[var(--ck-lime)] bg-[rgba(196,240,66,0.16)] text-[var(--ck-lime)]",
-                    else:
-                      "border-[var(--ck-stroke)] bg-white/5 text-[var(--ck-text)] hover:-translate-y-px hover:border-[var(--ck-lime)] hover:bg-[rgba(196,240,66,0.08)] hover:text-[var(--ck-lime)]"
-                  )
-                ]}
-              >
-                {preset_label}
-              </button>
-            </div>
-          </div>
-          <.form for={@form} id="benchmark-runner" phx-submit="run" phx-change="benchmark_form_change">
-            <div class="flex flex-col gap-4">
-              <.input
-                field={@form[:suite]}
-                type="select"
-                label="Suite"
-                options={Enum.map(@all_suites, &{"#{&1.name} (#{&1.slug})", &1.slug})}
-              />
-              <.subject_multi_select
-                field={@form[:subjects]}
-                label="Subjects"
-                options={subject_options(@available_subjects)}
-                selected={@form[:subjects].value}
-                open={@subjects_dropdown_open}
-                id="benchmark-subjects-input"
-              />
-              <.input
-                field={@form[:baseline_subject]}
-                type="select"
-                label="Baseline subject"
-                options={subject_options(@available_subjects)}
-                id="benchmark-baseline-input"
-              />
-              <.input
-                field={@form[:domain_pack]}
-                type="select"
-                label="Run only this domain"
-                prompt="All suite scenarios"
-                options={@domain_pack_options}
-              />
-            </div>
-            <div class="flex items-center justify-between gap-4 mt-4 max-[900px]:flex-col max-[900px]:items-start">
-              <button
-                type="submit"
-                class="inline-flex items-center justify-center gap-[0.4rem] px-4 py-2 rounded-full bg-[var(--ck-lime)] text-[#11170d] font-bold transition-transform transition-shadow duration-150 hover:-translate-y-px hover:shadow-[0_12px_24px_rgba(196,240,66,0.24)]"
-              >
-                Run benchmark
-              </button>
-            </div>
-          </.form>
-          <p class="text-[var(--ck-muted)] text-sm mt-4">
-            For a reproducible external comparison, start with `controlkeel_validate,opencode_manual`
-            and import the OpenCode output after the awaiting-import run finishes.
+        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 mt-6">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Recent runs
           </p>
+          <div class="overflow-x-auto">
+            <.table id="benchmark-runs" rows={@recent_runs}>
+              <:col :let={run} label="Run">
+                <.link
+                  navigate={~p"/benchmarks/runs/#{run.id}"}
+                  class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
+                >
+                  ##{run.id}
+                </.link>
+              </:col>
+              <:col :let={run} label="Suite">
+                {run.suite.slug}
+              </:col>
+              <:col :let={run} label="Status">
+                {run.status}
+              </:col>
+              <:col :let={run} label="Catch rate">
+                {run.catch_rate}%
+              </:col>
+              <:col :let={run} label="Baseline">
+                {run.baseline_subject}
+              </:col>
+              <:col :let={run} label="Domains">
+                {Enum.map_join(Benchmark.domain_packs_for_run(run), ", ", &format_domain_pack/1)}
+              </:col>
+            </.table>
+          </div>
         </div>
 
-        <div class="grid grid-cols-[minmax(0,1.35fr)_minmax(280px,0.75fr)] gap-6 max-[900px]:grid-cols-1 mt-6">
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Built-in suites
-            </p>
-            <div class="grid gap-4 m-0 p-0 list-none">
-              <%= for suite <- @suites do %>
-                <article
-                  class="border border-white/[0.07] rounded-[1.1rem] p-4 bg-white/[0.03] grid gap-[0.55rem]"
-                  id={"suite-#{suite.slug}"}
-                >
-                  <div class="flex items-center justify-between gap-4 max-[900px]:flex-col max-[900px]:items-start">
-                    <h3>{suite.name}</h3>
-                    <span class="border border-[var(--ck-stroke)] rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]">
-                      v{suite.version}
-                    </span>
-                  </div>
-                  <p class="text-[var(--ck-muted)]">{suite.description}</p>
-                  <div class="flex items-center justify-between gap-4">
-                    <span>{length(suite.scenarios)} scenarios</span>
-                    <span>{suite.status}</span>
-                  </div>
-                  <div class="flex flex-wrap gap-2 mt-2">
-                    <%= for pack <- Benchmark.domain_packs_for_suite(suite) do %>
-                      <span class="border border-[var(--ck-stroke)] bg-white/5 rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem]">
-                        {format_domain_pack(pack)}
-                      </span>
-                    <% end %>
-                  </div>
-                </article>
-              <% end %>
-            </div>
-          </div>
+        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 mt-6">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Built-in suites
+          </p>
+          <p class="text-[var(--ck-muted)] text-xs mt-1">
+            Built-ins are always present. External subjects appear when the current project has a
+            `controlkeel/benchmark_subjects.json` file.
+          </p>
 
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Recent runs
-            </p>
-            <div class="overflow-x-auto">
-              <.table id="benchmark-runs" rows={@recent_runs}>
-                <:col :let={run} label="Run">
-                  <.link
-                    navigate={~p"/benchmarks/runs/#{run.id}"}
-                    class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
-                  >
-                    ##{run.id}
-                  </.link>
-                </:col>
-                <:col :let={run} label="Suite">
-                  {run.suite.slug}
-                </:col>
-                <:col :let={run} label="Status">
-                  {run.status}
-                </:col>
-                <:col :let={run} label="Catch rate">
-                  {run.catch_rate}%
-                </:col>
-                <:col :let={run} label="Baseline">
-                  {run.baseline_subject}
-                </:col>
-                <:col :let={run} label="Domains">
-                  {Enum.map_join(Benchmark.domain_packs_for_run(run), ", ", &format_domain_pack/1)}
-                </:col>
-              </.table>
-            </div>
+          <div class="grid gap-4 m-0 p-0 list-none mt-4 max-h-[28rem] overflow-y-auto pr-1">
+            <%= for suite <- @suites do %>
+              <article
+                class="border border-white/[0.07] rounded-[1.1rem] p-4 bg-white/[0.03] grid gap-[0.55rem]"
+                id={"suite-#{suite.slug}"}
+              >
+                <div class="flex items-center justify-between gap-4 max-[900px]:flex-col max-[900px]:items-start">
+                  <h3>{suite.name}</h3>
+                  <span class="border border-[var(--ck-stroke)] rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]">
+                    v{suite.version}
+                  </span>
+                </div>
+                <p class="text-[var(--ck-muted)]">{suite.description}</p>
+                <div class="flex items-center justify-between gap-4">
+                  <span>{length(suite.scenarios)} scenarios</span>
+                  <span>{suite.status}</span>
+                </div>
+                <div class="flex flex-wrap gap-2 mt-2">
+                  <%= for pack <- Benchmark.domain_packs_for_suite(suite) do %>
+                    <span class="border border-[var(--ck-stroke)] bg-white/5 rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem]">
+                      {format_domain_pack(pack)}
+                    </span>
+                  <% end %>
+                </div>
+              </article>
+            <% end %>
           </div>
         </div>
       </section>

--- a/lib/controlkeel_web/live/benchmarks_live.ex
+++ b/lib/controlkeel_web/live/benchmarks_live.ex
@@ -673,7 +673,6 @@ defmodule ControlKeelWeb.BenchmarksLive do
               {decision_label(@result.decision)}
             </span>
             <span
-              :if={status_label(@result.status)}
               class={[
                 "rounded-full px-2 py-0.5 text-[0.7rem] border",
                 status_badge_class(@result.status)

--- a/lib/controlkeel_web/live/benchmarks_live.ex
+++ b/lib/controlkeel_web/live/benchmarks_live.ex
@@ -12,8 +12,9 @@ defmodule ControlKeelWeb.BenchmarksLive do
      |> assign(:run, nil)
      |> assign(:matrix, %{subjects: [], scenarios: []})
      |> assign(:detail_metrics, %{})
+     |> assign(:subjects_dropdown_open, false)
+     |> assign(:active_preset, "opencode_compare")
      |> assign(:form, to_form(default_form_params(), as: :benchmark))
-     |> assign(:filter_form, to_form(%{"domain_pack" => ""}, as: :filters))
      |> assign(:domain_pack_options, domain_pack_options())
      |> refresh_dashboard_assigns()}
   end
@@ -37,17 +38,6 @@ defmodule ControlKeelWeb.BenchmarksLive do
     end
   end
 
-  def handle_params(%{"domain_pack" => domain_pack} = _params, _uri, socket) do
-    {:noreply,
-     socket
-     |> assign(:run, nil)
-     |> assign(:matrix, %{subjects: [], scenarios: []})
-     |> assign(:detail_metrics, %{})
-     |> assign(:page_title, "Benchmarks")
-     |> assign(:filter_form, to_form(%{"domain_pack" => domain_pack}, as: :filters))
-     |> refresh_dashboard_assigns(domain_pack)}
-  end
-
   def handle_params(_params, _uri, socket) do
     {:noreply,
      socket
@@ -55,7 +45,6 @@ defmodule ControlKeelWeb.BenchmarksLive do
      |> assign(:matrix, %{subjects: [], scenarios: []})
      |> assign(:detail_metrics, %{})
      |> assign(:page_title, "Benchmarks")
-     |> assign(:filter_form, to_form(%{"domain_pack" => ""}, as: :filters))
      |> refresh_dashboard_assigns()}
   end
 
@@ -73,10 +62,6 @@ defmodule ControlKeelWeb.BenchmarksLive do
     end
   end
 
-  def handle_event("filter_domain", %{"filters" => filters}, socket) do
-    {:noreply, push_patch(socket, to: ~p"/benchmarks?#{domain_filter_params(filters)}")}
-  end
-
   def handle_event("preset_benchmark", %{"preset" => preset}, socket) do
     case benchmark_presets()[preset] do
       nil ->
@@ -87,8 +72,37 @@ defmodule ControlKeelWeb.BenchmarksLive do
           socket.assigns.form.params
           |> Map.merge(patch)
 
-        {:noreply, assign(socket, :form, to_form(merged, as: :benchmark))}
+        {:noreply,
+         socket
+         |> assign(:form, to_form(merged, as: :benchmark))
+         |> assign(:active_preset, preset)}
     end
+  end
+
+  def handle_event("toggle_subject", %{"id" => id}, socket) do
+    current = List.wrap(socket.assigns.form.params["subjects"])
+    updated = if id in current, do: List.delete(current, id), else: current ++ [id]
+    new_params = Map.put(socket.assigns.form.params, "subjects", updated)
+
+    {:noreply,
+     socket
+     |> assign(:form, to_form(new_params, as: :benchmark))
+     |> assign(:active_preset, nil)}
+  end
+
+  def handle_event("toggle_subjects_dropdown", _params, socket) do
+    {:noreply, assign(socket, :subjects_dropdown_open, !socket.assigns.subjects_dropdown_open)}
+  end
+
+  def handle_event("close_subjects_dropdown", _params, socket) do
+    {:noreply, assign(socket, :subjects_dropdown_open, false)}
+  end
+
+  def handle_event("benchmark_form_change", %{"benchmark" => params}, socket) do
+    {:noreply,
+     socket
+     |> assign(:form, to_form(params, as: :benchmark))
+     |> assign(:active_preset, nil)}
   end
 
   @impl true
@@ -358,85 +372,50 @@ defmodule ControlKeelWeb.BenchmarksLive do
           </div>
         </div>
 
-        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 grid gap-4 mt-6">
-          <.form for={@filter_form} id="benchmark-filters" phx-change="filter_domain">
-            <div class="grid grid-cols-5 gap-4 max-[900px]:grid-cols-1">
-              <.input
-                field={@filter_form[:domain_pack]}
-                type="select"
-                label="Domain pack"
-                prompt="All domains"
-                options={@domain_pack_options}
-              />
-            </div>
-          </.form>
-        </div>
-
         <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 grid gap-4">
-          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold mb-2">
-            Quick presets
-          </p>
-          <div class="flex items-center justify-between gap-2 mb-4 flex-wrap max-[900px]:flex-col max-[900px]:items-start">
-            <button
-              type="button"
-              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
-              id="benchmark-preset-opencode"
-              phx-click="preset_benchmark"
-              phx-value-preset="opencode_compare"
-            >
-              OpenCode comparison
-            </button>
-            <button
-              type="button"
-              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
-              id="benchmark-preset-ck-only"
-              phx-click="preset_benchmark"
-              phx-value-preset="ck_only"
-            >
-              ControlKeel validate only
-            </button>
-            <button
-              type="button"
-              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
-              id="benchmark-preset-proxy"
-              phx-click="preset_benchmark"
-              phx-value-preset="ck_proxy"
-            >
-              Validate + governed proxy
-            </button>
-            <button
-              type="button"
-              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
-              id="benchmark-preset-copilot-vs-opencode"
-              phx-click="preset_benchmark"
-              phx-value-preset="copilot_vs_opencode"
-            >
-              Copilot vs OpenCode
-            </button>
-            <button
-              type="button"
-              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
-              id="benchmark-preset-full-compare"
-              phx-click="preset_benchmark"
-              phx-value-preset="full_compare"
-            >
-              Full host comparison
-            </button>
+          <div class="flex flex-col gap-3 mb-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Quick presets
+            </p>
+            <p class="text-[var(--ck-muted)] text-sm mb-2 max-w-[42rem] leading-relaxed">
+              One-click subject and suite configurations. Pick one to populate the form below.
+            </p>
+
+            <div class="flex flex-wrap gap-2">
+              <button
+                :for={{preset_id, preset_value, preset_label} <- preset_chips()}
+                type="button"
+                id={preset_id}
+                phx-click="preset_benchmark"
+                phx-value-preset={preset_value}
+                aria-pressed={to_string(preset_value == @active_preset)}
+                class={[
+                  "group inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm transition-all duration-150 active:scale-[0.98]",
+                  if(preset_value == @active_preset,
+                    do: "border-[var(--ck-lime)] bg-[rgba(196,240,66,0.16)] text-[var(--ck-lime)]",
+                    else:
+                      "border-[var(--ck-stroke)] bg-white/5 text-[var(--ck-text)] hover:-translate-y-px hover:border-[var(--ck-lime)] hover:bg-[rgba(196,240,66,0.08)] hover:text-[var(--ck-lime)]"
+                  )
+                ]}
+              >
+                {preset_label}
+              </button>
+            </div>
           </div>
-          <.form for={@form} id="benchmark-runner" phx-submit="run">
-            <div class="grid grid-cols-5 gap-4 max-[900px]:grid-cols-1">
+          <.form for={@form} id="benchmark-runner" phx-submit="run" phx-change="benchmark_form_change">
+            <div class="flex flex-col gap-4">
               <.input
                 field={@form[:suite]}
                 type="select"
                 label="Suite"
-                options={Enum.map(@suites, &{"#{&1.name} (#{&1.slug})", &1.slug})}
+                options={Enum.map(@all_suites, &{"#{&1.name} (#{&1.slug})", &1.slug})}
               />
-              <.input
+              <.subject_multi_select
                 field={@form[:subjects]}
-                type="select"
-                multiple={true}
                 label="Subjects"
                 options={subject_options(@available_subjects)}
+                selected={@form[:subjects].value}
+                open={@subjects_dropdown_open}
                 id="benchmark-subjects-input"
               />
               <.input
@@ -457,13 +436,13 @@ defmodule ControlKeelWeb.BenchmarksLive do
             <div class="flex items-center justify-between gap-4 mt-4 max-[900px]:flex-col max-[900px]:items-start">
               <button
                 type="submit"
-                class="inline-flex items-center justify-center gap-[0.4rem] px-5 py-[0.95rem] rounded-full bg-[var(--ck-lime)] text-[#11170d] font-bold transition-transform transition-shadow duration-150 hover:-translate-y-px hover:shadow-[0_12px_24px_rgba(196,240,66,0.24)]"
+                class="inline-flex items-center justify-center gap-[0.4rem] px-4 py-2 rounded-full bg-[var(--ck-lime)] text-[#11170d] font-bold transition-transform transition-shadow duration-150 hover:-translate-y-px hover:shadow-[0_12px_24px_rgba(196,240,66,0.24)]"
               >
                 Run benchmark
               </button>
             </div>
           </.form>
-          <p class="text-[var(--ck-muted)] mt-4">
+          <p class="text-[var(--ck-muted)] text-sm mt-4">
             For a reproducible external comparison, start with `controlkeel_validate,opencode_manual`
             and import the OpenCode output after the awaiting-import run finishes.
           </p>
@@ -550,6 +529,16 @@ defmodule ControlKeelWeb.BenchmarksLive do
     }
   end
 
+  defp preset_chips do
+    [
+      {"benchmark-preset-opencode", "opencode_compare", "OpenCode comparison"},
+      {"benchmark-preset-ck-only", "ck_only", "ControlKeel validate only"},
+      {"benchmark-preset-proxy", "ck_proxy", "Validate + governed proxy"},
+      {"benchmark-preset-copilot-vs-opencode", "copilot_vs_opencode", "Copilot vs OpenCode"},
+      {"benchmark-preset-full-compare", "full_compare", "Full host comparison"}
+    ]
+  end
+
   defp benchmark_presets do
     %{
       "opencode_compare" => %{
@@ -584,13 +573,12 @@ defmodule ControlKeelWeb.BenchmarksLive do
     }
   end
 
-  defp refresh_dashboard_assigns(socket, domain_pack \\ nil) do
-    filter_opts = benchmark_filter_opts(domain_pack)
-
+  defp refresh_dashboard_assigns(socket) do
     socket
-    |> assign(:summary, Benchmark.benchmark_summary(filter_opts))
-    |> assign(:suites, Benchmark.list_suites(filter_opts))
-    |> assign(:recent_runs, Benchmark.list_recent_runs(filter_opts))
+    |> assign(:summary, Benchmark.benchmark_summary([]))
+    |> assign(:suites, Benchmark.list_suites([]))
+    |> assign(:all_suites, Benchmark.list_suites([]))
+    |> assign(:recent_runs, Benchmark.list_recent_runs([]))
     |> assign(:available_subjects, Benchmark.available_subjects())
   end
 
@@ -602,6 +590,99 @@ defmodule ControlKeelWeb.BenchmarksLive do
     Enum.map(subjects, fn subject ->
       {subject_label(subject), subject["id"]}
     end)
+  end
+
+  defp subject_multi_select(assigns) do
+    assigns =
+      assigns
+      |> assign(:selected, List.wrap(assigns[:selected]))
+      |> assign(
+        :labels_by_value,
+        Map.new(assigns[:options] || [], fn {label, value} -> {value, label} end)
+      )
+      |> assign_new(:open, fn -> false end)
+
+    ~H"""
+    <div
+      class="fieldset mb-2 relative"
+      id={@id}
+      phx-click-away={@open && "close_subjects_dropdown"}
+    >
+      <span :if={@label} class="label mb-1 block">{@label}</span>
+      <div :if={@selected != []} class="flex flex-wrap gap-2 mb-2">
+        <span
+          :for={selected_value <- @selected}
+          class="inline-flex items-center gap-1 rounded-full border border-[var(--ck-stroke)] text-[var(--ck-muted)] pl-3 pr-1.5 py-1 text-xs"
+        >
+          {Map.get(@labels_by_value, selected_value, selected_value)}
+          <button
+            type="button"
+            phx-click="toggle_subject"
+            phx-value-id={selected_value}
+            aria-label={"Remove #{Map.get(@labels_by_value, selected_value, selected_value)}"}
+            class="inline-flex items-center justify-center rounded-full p-0.5 hover:text-[var(--ck-lime)] transition-colors"
+          >
+            <.icon name="hero-x-mark" class="w-3 h-3" />
+          </button>
+        </span>
+      </div>
+      <button
+        type="button"
+        phx-click="toggle_subjects_dropdown"
+        aria-haspopup="listbox"
+        aria-expanded={to_string(@open)}
+        class={[
+          "select w-full flex items-center justify-between gap-2 px-3 py-2 text-left",
+          "focus:outline-none focus:border-[var(--ck-lime)]"
+        ]}
+      >
+        <span class="text-[var(--ck-muted)]">Select subjects</span>
+        <.icon
+          name="hero-chevron-down"
+          class={["w-4 h-4 shrink-0 transition-transform", @open && "rotate-180"]}
+        />
+      </button>
+      <div
+        :if={@open}
+        class="absolute z-30 mt-1 w-full max-h-72 overflow-y-auto rounded-[1rem] border border-[var(--ck-stroke)] bg-[#0d1216] shadow-[0_24px_80px_rgba(0,0,0,0.45)] p-1"
+        role="listbox"
+        aria-label={@label}
+        aria-multiselectable="true"
+      >
+        <button
+          :for={{option_label, option_value} <- @options}
+          type="button"
+          role="option"
+          aria-selected={if(option_value in @selected, do: "true", else: "false")}
+          data-subject-id={option_value}
+          phx-click="toggle_subject"
+          phx-value-id={option_value}
+          class={[
+            "w-full flex items-center gap-2 px-3 py-2 rounded-[0.6rem] text-left text-sm transition-colors cursor-pointer",
+            if(option_value in @selected,
+              do: "bg-[rgba(196,240,66,0.14)] text-[#d2ffe7]",
+              else: "text-[var(--ck-text)] hover:bg-white/5"
+            )
+          ]}
+        >
+          <.icon
+            name="hero-check"
+            class={[
+              "w-4 h-4 shrink-0",
+              if(option_value in @selected, do: "text-[var(--ck-lime)]", else: "opacity-0")
+            ]}
+          />
+          <span class="truncate">{option_label}</span>
+        </button>
+      </div>
+      <input
+        :for={selected_value <- @selected}
+        type="hidden"
+        name={"#{@field.name}[]"}
+        value={selected_value}
+      />
+    </div>
+    """
   end
 
   defp subject_label(subject) do
@@ -619,16 +700,6 @@ defmodule ControlKeelWeb.BenchmarksLive do
 
   defp format_latency(nil), do: "n/a"
   defp format_latency(value), do: "#{value}ms"
-
-  defp benchmark_filter_opts(nil), do: []
-  defp benchmark_filter_opts(""), do: []
-  defp benchmark_filter_opts(domain_pack), do: [domain_pack: domain_pack]
-
-  defp domain_filter_params(filters) do
-    filters
-    |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
-    |> Enum.into(%{})
-  end
 
   defp domain_pack_options do
     Enum.map(Intent.supported_packs(), &{Intent.pack_label(&1), &1})

--- a/lib/controlkeel_web/live/benchmarks_live.ex
+++ b/lib/controlkeel_web/live/benchmarks_live.ex
@@ -373,11 +373,6 @@ defmodule ControlKeelWeb.BenchmarksLive do
         </div>
 
         <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 grid gap-4">
-          <datalist id="benchmark-subject-suggestions">
-            <%= for subject <- @available_subjects do %>
-              <option value={subject["id"]}>{subject["label"] || subject["id"]}</option>
-            <% end %>
-          </datalist>
           <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold mb-2">
             Quick presets
           </p>
@@ -438,18 +433,17 @@ defmodule ControlKeelWeb.BenchmarksLive do
               />
               <.input
                 field={@form[:subjects]}
-                type="text"
-                label="Subjects (comma-separated)"
-                placeholder="controlkeel_validate,opencode_manual"
-                list="benchmark-subject-suggestions"
+                type="select"
+                multiple={true}
+                label="Subjects"
+                options={subject_options(@available_subjects)}
                 id="benchmark-subjects-input"
               />
               <.input
                 field={@form[:baseline_subject]}
-                type="text"
+                type="select"
                 label="Baseline subject"
-                placeholder="controlkeel_validate"
-                list="benchmark-subject-suggestions"
+                options={subject_options(@available_subjects)}
                 id="benchmark-baseline-input"
               />
               <.input
@@ -470,13 +464,6 @@ defmodule ControlKeelWeb.BenchmarksLive do
             </div>
           </.form>
           <p class="text-[var(--ck-muted)] mt-4">
-            Subjects currently visible to this server process: {Enum.map_join(
-              @available_subjects,
-              ", ",
-              & &1["id"]
-            )}
-          </p>
-          <p class="text-[var(--ck-muted)] mt-2">
             For a reproducible external comparison, start with `controlkeel_validate,opencode_manual`
             and import the OpenCode output after the awaiting-import run finishes.
           </p>
@@ -557,7 +544,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
   defp default_form_params do
     %{
       "suite" => "vibe_failures_v1",
-      "subjects" => "controlkeel_validate,opencode_manual",
+      "subjects" => ["controlkeel_validate", "opencode_manual"],
       "baseline_subject" => "controlkeel_validate",
       "domain_pack" => ""
     }
@@ -566,26 +553,32 @@ defmodule ControlKeelWeb.BenchmarksLive do
   defp benchmark_presets do
     %{
       "opencode_compare" => %{
-        "subjects" => "controlkeel_validate,opencode_manual",
+        "subjects" => ["controlkeel_validate", "opencode_manual"],
         "baseline_subject" => "controlkeel_validate"
       },
       "ck_only" => %{
-        "subjects" => "controlkeel_validate",
+        "subjects" => ["controlkeel_validate"],
         "baseline_subject" => "controlkeel_validate"
       },
       "ck_proxy" => %{
-        "subjects" => "controlkeel_validate,controlkeel_proxy",
+        "subjects" => ["controlkeel_validate", "controlkeel_proxy"],
         "baseline_subject" => "controlkeel_validate"
       },
       "copilot_vs_opencode" => %{
         "suite" => "host_comparison_v1",
-        "subjects" => "controlkeel_validate,opencode_manual,copilot_manual",
+        "subjects" => ["controlkeel_validate", "opencode_manual", "copilot_manual"],
         "baseline_subject" => "controlkeel_validate"
       },
       "full_compare" => %{
         "suite" => "host_comparison_v1",
-        "subjects" =>
-          "controlkeel_validate,opencode_manual,copilot_manual,gemini_manual,codex_manual,claude_manual",
+        "subjects" => [
+          "controlkeel_validate",
+          "opencode_manual",
+          "copilot_manual",
+          "gemini_manual",
+          "codex_manual",
+          "claude_manual"
+        ],
         "baseline_subject" => "controlkeel_validate"
       }
     }
@@ -604,6 +597,12 @@ defmodule ControlKeelWeb.BenchmarksLive do
   defp format_percent(nil), do: "Not recorded"
   defp format_percent(value) when is_integer(value), do: "#{value}%"
   defp format_percent(value), do: "#{Float.round(value, 1)}%"
+
+  defp subject_options(subjects) do
+    Enum.map(subjects, fn subject ->
+      {subject_label(subject), subject["id"]}
+    end)
+  end
 
   defp subject_label(subject) do
     label = subject["label"] || subject["id"] || "Unknown subject"

--- a/lib/controlkeel_web/live/benchmarks_live.ex
+++ b/lib/controlkeel_web/live/benchmarks_live.ex
@@ -284,44 +284,17 @@ defmodule ControlKeelWeb.BenchmarksLive do
     ~H"""
     <Layouts.app flash={@flash}>
       <section class="w-[min(1180px,calc(100%-2rem))] mx-auto pt-8 pb-16 max-[900px]:w-[min(calc(100%-1.25rem),1180px)] max-[900px]:pt-6">
-        <div>
-          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+        <div class="space-y-1">
+          <h2 class="text-2xl font-semibold text-[var(--ck-lime)] leading-6 tracking-wide uppercase">
             Benchmark engine
-          </p>
-          <p class="text-[var(--ck-muted)] max-w-[48rem] text-[1.05rem] leading-[1.7]">
+          </h2>
+          <p class="text-[var(--ck-muted)]">
             Compare governed subjects and external agents on the same scenario suites, then keep the results as product evidence.
           </p>
         </div>
 
-        <div class="grid gap-4 grid-cols-[repeat(auto-fit,minmax(180px,1fr))] mt-5">
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Suites
-            </p>
-            <strong>{@summary.total_suites}</strong>
-          </div>
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Runs
-            </p>
-            <strong>{@summary.total_runs}</strong>
-          </div>
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Average catch rate
-            </p>
-            <strong>{format_percent(@summary.average_catch_rate)}</strong>
-          </div>
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Average overhead
-            </p>
-            <strong>{format_percent(@summary.average_overhead_percent)}</strong>
-          </div>
-        </div>
-
         <div class="grid gap-4 grid-cols-[2fr_1fr] mt-6">
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 grid gap-4">
+          <div class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 grid gap-4">
             <div class="flex flex-col gap-3 mb-6">
               <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
                 Quick presets
@@ -403,7 +376,31 @@ defmodule ControlKeelWeb.BenchmarksLive do
           </div>
 
           <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 h-fit">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            <div class="space-y-2 border-b border-[var(--ck-stroke)] pb-4 mb-4">
+              <p>
+                Suites: <span class="text-[var(--ck-lime)]">{@summary.total_suites}</span>
+              </p>
+
+              <p>
+                Runs: <span class="text-[var(--ck-lime)]">{@summary.total_runs}</span>
+              </p>
+
+              <p>
+                Average catch rate:
+                <span class="text-[var(--ck-lime)]">
+                  {format_percent(@summary.average_catch_rate)}
+                </span>
+              </p>
+
+              <p>
+                Average overhead:
+                <span class="text-[var(--ck-lime)]">
+                  {format_percent(@summary.average_overhead_percent)}
+                </span>
+              </p>
+            </div>
+
+            <p class="uppercase tracking-[0.14em] text-[var(--ck-lime)] font-semibold mt-4">
               Blessed external path
             </p>
             <h3 class="my-2">OpenCode vs ControlKeel</h3>
@@ -426,7 +423,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
           </div>
         </div>
 
-        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 mt-6">
+        <div class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 mt-6">
           <div class="flex items-center justify-between gap-4">
             <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
               Recent runs
@@ -505,7 +502,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
           <% end %>
         </div>
 
-        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 mt-6">
+        <div class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 mt-6">
           <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
             Built-in suites
           </p>

--- a/lib/controlkeel_web/live/benchmarks_live.ex
+++ b/lib/controlkeel_web/live/benchmarks_live.ex
@@ -95,80 +95,104 @@ defmodule ControlKeelWeb.BenchmarksLive do
   def render(%{live_action: :show} = assigns) do
     ~H"""
     <Layouts.app flash={@flash}>
-      <section class="ck-shell ck-shell-tight">
-        <div class="ck-section-header">
+      <section class="w-[min(1180px,calc(100%-2rem))] mx-auto pt-8 pb-16 max-[900px]:w-[min(calc(100%-1.25rem),1180px)] max-[900px]:pt-6">
+        <div class="flex items-center justify-between gap-4 mt-6 mb-4 max-[900px]:flex-col max-[900px]:items-start">
           <div>
-            <p class="ck-kicker">Benchmark run</p>
-            <h1 class="ck-section-title">Run ##{@run.id} — {@run.suite.name}</h1>
-            <p class="ck-lead ck-lead-tight">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Benchmark run
+            </p>
+            <h1 class="text-[clamp(2rem,4vw,3.4rem)] leading-[1.02]">
+              Run ##{@run.id} — {@run.suite.name}
+            </h1>
+            <p class="text-[var(--ck-muted)] max-w-[48rem] text-[1.05rem] leading-[1.7]">
               Compare governed and external subjects across the same failure scenarios without polluting mission data.
             </p>
           </div>
-          <div class="ck-action-row">
-            <.link navigate={~p"/benchmarks"} class="ck-link">Back to benchmarks</.link>
-            <a href={~p"/api/v1/benchmarks/runs/#{@run.id}/export?format=csv"} class="ck-link">
+          <div class="flex items-center justify-between gap-4 max-[900px]:flex-col max-[900px]:items-start">
+            <.link
+              navigate={~p"/benchmarks"}
+              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
+            >
+              Back to benchmarks
+            </.link>
+            <a
+              href={~p"/api/v1/benchmarks/runs/#{@run.id}/export?format=csv"}
+              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
+            >
               Export CSV
             </a>
           </div>
         </div>
 
-        <div class="ck-stat-grid">
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Catch rate</p>
+        <div class="grid gap-4 grid-cols-[repeat(auto-fit,minmax(180px,1fr))] mt-5">
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Catch rate
+            </p>
             <strong>{@run.catch_rate}%</strong>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Block rate</p>
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Block rate
+            </p>
             <strong>{@detail_metrics.block_rate}%</strong>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Expected rule hit rate</p>
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Expected rule hit rate
+            </p>
             <strong>{@detail_metrics.expected_rule_hit_rate}%</strong>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Average overhead</p>
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Average overhead
+            </p>
             <strong>{format_percent(@run.average_overhead_percent)}</strong>
           </div>
         </div>
 
-        <div class="ck-card">
-          <p class="ck-mini-label">Run metadata</p>
-          <div class="ck-brief-grid">
+        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Run metadata
+          </p>
+          <div class="grid gap-4 grid-cols-2 max-[900px]:grid-cols-1">
             <div>
               <h3>Status</h3>
-              <p class="ck-note">{@run.status}</p>
+              <p class="text-[var(--ck-muted)]">{@run.status}</p>
             </div>
             <div>
               <h3>Baseline subject</h3>
-              <p class="ck-note">{@run.baseline_subject}</p>
+              <p class="text-[var(--ck-muted)]">{@run.baseline_subject}</p>
             </div>
             <div>
               <h3>Subjects</h3>
-              <p class="ck-note">{Enum.join(@run.subjects, ", ")}</p>
+              <p class="text-[var(--ck-muted)]">{Enum.join(@run.subjects, ", ")}</p>
             </div>
             <div>
               <h3>Median latency</h3>
-              <p class="ck-note">{format_latency(@run.median_latency_ms)}</p>
+              <p class="text-[var(--ck-muted)]">{format_latency(@run.median_latency_ms)}</p>
             </div>
             <div>
               <h3>Domain packs</h3>
-              <p class="ck-note">
+              <p class="text-[var(--ck-muted)]">
                 {Enum.map_join(Benchmark.domain_packs_for_run(@run), ", ", &format_domain_pack/1)}
               </p>
             </div>
           </div>
         </div>
 
-        <div class="ck-card">
-          <p class="ck-mini-label">Promotion integrity</p>
+        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Promotion integrity
+          </p>
           <% integrity = get_in(Benchmark.run_eval_profile(@run), ["promotion_integrity"]) || %{} %>
-          <div class="ck-finding-head">
+          <div class="flex items-center justify-between gap-4 max-[900px]:flex-col max-[900px]:items-start">
             <h3>{integrity["status"] || "unknown"}</h3>
-            <span class="ck-pill ck-pill-neutral">
+            <span class="border border-[var(--ck-stroke)] rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]">
               {Enum.join(integrity["evidence_channels"] || [], ", ")}
             </span>
           </div>
-          <p class="ck-note">
+          <p class="text-[var(--ck-muted)]">
             <%= case integrity["warnings"] || [] do %>
               <% [] -> %>
                 Held-out, diversity, and classification evidence are present for this run.
@@ -178,10 +202,12 @@ defmodule ControlKeelWeb.BenchmarksLive do
           </p>
         </div>
 
-        <div class="ck-card">
-          <p class="ck-mini-label">Scenario matrix</p>
-          <div class="ck-table-wrap">
-            <table class="min-w-full text-sm" id="benchmark-matrix">
+        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Scenario matrix
+          </p>
+          <div class="overflow-x-auto">
+            <table class="min-w-full w-full text-sm" id="benchmark-matrix">
               <thead>
                 <tr>
                   <th class="text-left py-2 pr-4">Scenario</th>
@@ -195,8 +221,8 @@ defmodule ControlKeelWeb.BenchmarksLive do
                   <tr id={"scenario-#{row.scenario.slug}"}>
                     <td class="align-top py-3 pr-4">
                       <strong>{row.scenario.name}</strong>
-                      <p class="ck-note">{row.scenario.incident_label}</p>
-                      <p class="ck-note">
+                      <p class="text-[var(--ck-muted)]">{row.scenario.incident_label}</p>
+                      <p class="text-[var(--ck-muted)]">
                         {format_domain_pack(get_in(row.scenario.metadata || %{}, ["domain_pack"]))} • {get_in(
                           row.scenario.metadata || %{},
                           ["risk_tier"]
@@ -206,17 +232,26 @@ defmodule ControlKeelWeb.BenchmarksLive do
                     <%= for result <- row.results do %>
                       <td class="align-top py-3 pr-4">
                         <%= if result do %>
-                          <div class="ck-badge-stack">
-                            <span class="ck-pill ck-pill-neutral">{result.status}</span>
-                            <span :if={result.decision} class="ck-pill ck-pill-neutral">
+                          <div class="flex flex-wrap gap-2">
+                            <span class="border border-[var(--ck-stroke)] rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]">
+                              {result.status}
+                            </span>
+                            <span
+                              :if={result.decision}
+                              class="border border-[var(--ck-stroke)] rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]"
+                            >
                               {result.decision}
                             </span>
                           </div>
-                          <p class="ck-note">{result.findings_count} findings</p>
-                          <p class="ck-note">latency {format_latency(result.latency_ms)}</p>
-                          <p class="ck-note">overhead {format_percent(result.overhead_percent)}</p>
+                          <p class="text-[var(--ck-muted)]">{result.findings_count} findings</p>
+                          <p class="text-[var(--ck-muted)]">
+                            latency {format_latency(result.latency_ms)}
+                          </p>
+                          <p class="text-[var(--ck-muted)]">
+                            overhead {format_percent(result.overhead_percent)}
+                          </p>
                         <% else %>
-                          <p class="ck-note">No result</p>
+                          <p class="text-[var(--ck-muted)]">No result</p>
                         <% end %>
                       </td>
                     <% end %>
@@ -234,47 +269,66 @@ defmodule ControlKeelWeb.BenchmarksLive do
   def render(assigns) do
     ~H"""
     <Layouts.app flash={@flash}>
-      <section class="ck-shell ck-shell-tight">
-        <div class="ck-section-header">
+      <section class="w-[min(1180px,calc(100%-2rem))] mx-auto pt-8 pb-16 max-[900px]:w-[min(calc(100%-1.25rem),1180px)] max-[900px]:pt-6">
+        <div class="flex items-center justify-between gap-4 mt-6 mb-4 max-[900px]:flex-col max-[900px]:items-start">
           <div>
-            <p class="ck-kicker">Benchmark engine</p>
-            <h1 class="ck-section-title">Run persisted benchmark matrices</h1>
-            <p class="ck-lead ck-lead-tight">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Benchmark engine
+            </p>
+            <h1 class="text-[clamp(2rem,4vw,3.4rem)] leading-[1.02]">
+              Run persisted benchmark matrices
+            </h1>
+            <p class="text-[var(--ck-muted)] max-w-[48rem] text-[1.05rem] leading-[1.7]">
               Compare governed subjects and external agents on the same scenario suites, then keep the results as product evidence.
             </p>
           </div>
-          <.link navigate={~p"/"} class="ck-link">Back home</.link>
+          <.link
+            navigate={~p"/"}
+            class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
+          >
+            Back home
+          </.link>
         </div>
 
-        <div class="ck-stat-grid">
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Suites</p>
+        <div class="grid gap-4 grid-cols-[repeat(auto-fit,minmax(180px,1fr))] mt-5">
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Suites
+            </p>
             <strong>{@summary.total_suites}</strong>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Runs</p>
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Runs
+            </p>
             <strong>{@summary.total_runs}</strong>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Average catch rate</p>
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Average catch rate
+            </p>
             <strong>{format_percent(@summary.average_catch_rate)}</strong>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Average overhead</p>
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Average overhead
+            </p>
             <strong>{format_percent(@summary.average_overhead_percent)}</strong>
           </div>
         </div>
 
-        <div class="ck-grid ck-grid-dashboard" style="margin-top: 1.5rem;">
-          <div class="ck-card">
-            <p class="ck-mini-label">Blessed external path</p>
-            <h3 style="margin: 0 0 0.5rem;">OpenCode vs ControlKeel</h3>
-            <p class="ck-note">
+        <div class="grid grid-cols-[minmax(0,1.35fr)_minmax(280px,0.75fr)] gap-6 max-[900px]:grid-cols-1 mt-6">
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Blessed external path
+            </p>
+            <h3 class="mb-2">OpenCode vs ControlKeel</h3>
+            <p class="text-[var(--ck-muted)]">
               The recommended first external comparison path is OpenCode. Start with a manual import
               subject for the quickest reproducible run, then swap to a shell-based wrapper if you
               want fully scripted replay.
             </p>
-            <ul class="ck-mini-list" style="margin-top: 0.75rem;">
+            <ul class="grid gap-4 m-0 mt-3 p-0 list-none">
               <li>
                 Create or review `controlkeel/benchmark_subjects.json` with the OpenCode subject you want to import.
               </li>
@@ -286,23 +340,27 @@ defmodule ControlKeelWeb.BenchmarksLive do
               </li>
             </ul>
           </div>
-          <div class="ck-card">
-            <p class="ck-mini-label">Available subjects</p>
-            <div class="ck-tag-list">
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Available subjects
+            </p>
+            <div class="flex flex-wrap gap-2">
               <%= for subject <- @available_subjects do %>
-                <span class="ck-tag">{subject_label(subject)}</span>
+                <span class="border border-[var(--ck-stroke)] bg-white/5 rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem]">
+                  {subject_label(subject)}
+                </span>
               <% end %>
             </div>
-            <p class="ck-note" style="margin-top: 0.75rem;">
+            <p class="text-[var(--ck-muted)] mt-3">
               Built-ins are always present. External subjects appear when the current project has a
               `controlkeel/benchmark_subjects.json` file.
             </p>
           </div>
         </div>
 
-        <div class="ck-card ck-browser-filters" style="margin-top: 1.5rem;">
+        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 grid gap-4 mt-6">
           <.form for={@filter_form} id="benchmark-filters" phx-change="filter_domain">
-            <div class="ck-filter-grid">
+            <div class="grid grid-cols-5 gap-4 max-[900px]:grid-cols-1">
               <.input
                 field={@filter_form[:domain_pack]}
                 type="select"
@@ -314,17 +372,19 @@ defmodule ControlKeelWeb.BenchmarksLive do
           </.form>
         </div>
 
-        <div class="ck-card ck-browser-filters">
+        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 grid gap-4">
           <datalist id="benchmark-subject-suggestions">
             <%= for subject <- @available_subjects do %>
               <option value={subject["id"]}>{subject["label"] || subject["id"]}</option>
             <% end %>
           </datalist>
-          <p class="ck-mini-label" style="margin-bottom: 0.5rem;">Quick presets</p>
-          <div class="ck-action-row" style="margin-bottom: 1rem; flex-wrap: wrap; gap: 0.5rem;">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold mb-2">
+            Quick presets
+          </p>
+          <div class="flex items-center justify-between gap-2 mb-4 flex-wrap max-[900px]:flex-col max-[900px]:items-start">
             <button
               type="button"
-              class="ck-link"
+              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
               id="benchmark-preset-opencode"
               phx-click="preset_benchmark"
               phx-value-preset="opencode_compare"
@@ -333,7 +393,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
             </button>
             <button
               type="button"
-              class="ck-link"
+              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
               id="benchmark-preset-ck-only"
               phx-click="preset_benchmark"
               phx-value-preset="ck_only"
@@ -342,7 +402,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
             </button>
             <button
               type="button"
-              class="ck-link"
+              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
               id="benchmark-preset-proxy"
               phx-click="preset_benchmark"
               phx-value-preset="ck_proxy"
@@ -351,7 +411,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
             </button>
             <button
               type="button"
-              class="ck-link"
+              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
               id="benchmark-preset-copilot-vs-opencode"
               phx-click="preset_benchmark"
               phx-value-preset="copilot_vs_opencode"
@@ -360,7 +420,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
             </button>
             <button
               type="button"
-              class="ck-link"
+              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
               id="benchmark-preset-full-compare"
               phx-click="preset_benchmark"
               phx-value-preset="full_compare"
@@ -369,7 +429,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
             </button>
           </div>
           <.form for={@form} id="benchmark-runner" phx-submit="run">
-            <div class="ck-filter-grid">
+            <div class="grid grid-cols-5 gap-4 max-[900px]:grid-cols-1">
               <.input
                 field={@form[:suite]}
                 type="select"
@@ -400,41 +460,55 @@ defmodule ControlKeelWeb.BenchmarksLive do
                 options={@domain_pack_options}
               />
             </div>
-            <div class="ck-action-row" style="margin-top: 1rem;">
-              <button type="submit" class="ck-button-primary">Run benchmark</button>
+            <div class="flex items-center justify-between gap-4 mt-4 max-[900px]:flex-col max-[900px]:items-start">
+              <button
+                type="submit"
+                class="inline-flex items-center justify-center gap-[0.4rem] px-5 py-[0.95rem] rounded-full bg-[var(--ck-lime)] text-[#11170d] font-bold transition-transform transition-shadow duration-150 hover:-translate-y-px hover:shadow-[0_12px_24px_rgba(196,240,66,0.24)]"
+              >
+                Run benchmark
+              </button>
             </div>
           </.form>
-          <p class="ck-note" style="margin-top: 1rem;">
+          <p class="text-[var(--ck-muted)] mt-4">
             Subjects currently visible to this server process: {Enum.map_join(
               @available_subjects,
               ", ",
               & &1["id"]
             )}
           </p>
-          <p class="ck-note" style="margin-top: 0.5rem;">
+          <p class="text-[var(--ck-muted)] mt-2">
             For a reproducible external comparison, start with `controlkeel_validate,opencode_manual`
             and import the OpenCode output after the awaiting-import run finishes.
           </p>
         </div>
 
-        <div class="ck-grid ck-grid-dashboard">
-          <div class="ck-card">
-            <p class="ck-mini-label">Built-in suites</p>
-            <div class="ck-finding-list">
+        <div class="grid grid-cols-[minmax(0,1.35fr)_minmax(280px,0.75fr)] gap-6 max-[900px]:grid-cols-1 mt-6">
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Built-in suites
+            </p>
+            <div class="grid gap-4 m-0 p-0 list-none">
               <%= for suite <- @suites do %>
-                <article class="ck-finding-item" id={"suite-#{suite.slug}"}>
-                  <div class="ck-finding-head">
+                <article
+                  class="border border-white/[0.07] rounded-[1.1rem] p-4 bg-white/[0.03] grid gap-[0.55rem]"
+                  id={"suite-#{suite.slug}"}
+                >
+                  <div class="flex items-center justify-between gap-4 max-[900px]:flex-col max-[900px]:items-start">
                     <h3>{suite.name}</h3>
-                    <span class="ck-pill ck-pill-neutral">v{suite.version}</span>
+                    <span class="border border-[var(--ck-stroke)] rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]">
+                      v{suite.version}
+                    </span>
                   </div>
-                  <p class="ck-note">{suite.description}</p>
-                  <div class="ck-metric-row">
+                  <p class="text-[var(--ck-muted)]">{suite.description}</p>
+                  <div class="flex items-center justify-between gap-4">
                     <span>{length(suite.scenarios)} scenarios</span>
                     <span>{suite.status}</span>
                   </div>
-                  <div class="ck-tag-list" style="margin-top: 0.5rem;">
+                  <div class="flex flex-wrap gap-2 mt-2">
                     <%= for pack <- Benchmark.domain_packs_for_suite(suite) do %>
-                      <span class="ck-tag">{format_domain_pack(pack)}</span>
+                      <span class="border border-[var(--ck-stroke)] bg-white/5 rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem]">
+                        {format_domain_pack(pack)}
+                      </span>
                     <% end %>
                   </div>
                 </article>
@@ -442,12 +516,17 @@ defmodule ControlKeelWeb.BenchmarksLive do
             </div>
           </div>
 
-          <div class="ck-card">
-            <p class="ck-mini-label">Recent runs</p>
-            <div class="ck-table-wrap">
+          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Recent runs
+            </p>
+            <div class="overflow-x-auto">
               <.table id="benchmark-runs" rows={@recent_runs}>
                 <:col :let={run} label="Run">
-                  <.link navigate={~p"/benchmarks/runs/#{run.id}"} class="ck-link">
+                  <.link
+                    navigate={~p"/benchmarks/runs/#{run.id}"}
+                    class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
+                  >
                     ##{run.id}
                   </.link>
                 </:col>

--- a/lib/controlkeel_web/live/benchmarks_live.ex
+++ b/lib/controlkeel_web/live/benchmarks_live.ex
@@ -34,6 +34,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
          |> assign(:run, run)
          |> assign(:matrix, Benchmark.run_matrix(run))
          |> assign(:detail_metrics, Benchmark.run_detail_metrics(run))
+         |> assign(:eval_profile, Benchmark.run_eval_profile(run))
          |> assign(:page_title, "Benchmark Run #{run.id}")}
     end
   end
@@ -44,6 +45,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
      |> assign(:run, nil)
      |> assign(:matrix, %{subjects: [], scenarios: []})
      |> assign(:detail_metrics, %{})
+     |> assign(:eval_profile, %{})
      |> assign(:page_title, "Benchmarks")
      |> refresh_dashboard_assigns()}
   end
@@ -196,7 +198,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
           <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
             Promotion integrity
           </p>
-          <% integrity = get_in(Benchmark.run_eval_profile(@run), ["promotion_integrity"]) || %{} %>
+          <% integrity = get_in(@eval_profile, ["promotion_integrity"]) || %{} %>
           <div class="flex items-center justify-between gap-4 max-[900px]:flex-col max-[900px]:items-start">
             <h3>{integrity["status"] || "unknown"}</h3>
             <span class="border border-[var(--ck-stroke)] rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]">
@@ -325,7 +327,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
                   field={@form[:suite]}
                   type="select"
                   label="Suite"
-                  options={Enum.map(@all_suites, &{"#{&1.name} (#{&1.slug})", &1.slug})}
+                  options={Enum.map(@suites, &{"#{&1.name} (#{&1.slug})", &1.slug})}
                 />
                 <.subject_multi_select
                   field={@form[:subjects]}
@@ -589,7 +591,6 @@ defmodule ControlKeelWeb.BenchmarksLive do
     socket
     |> assign(:summary, Benchmark.benchmark_summary([]))
     |> assign(:suites, Benchmark.list_suites([]))
-    |> assign(:all_suites, Benchmark.list_suites([]))
     |> assign(:recent_runs, Benchmark.list_recent_runs([]))
     |> assign(:available_subjects, subjects)
     |> assign(:subjects_by_id, Map.new(subjects, fn s -> {s["id"], s} end))

--- a/lib/controlkeel_web/live/benchmarks_live.ex
+++ b/lib/controlkeel_web/live/benchmarks_live.ex
@@ -109,64 +109,57 @@ defmodule ControlKeelWeb.BenchmarksLive do
   def render(%{live_action: :show} = assigns) do
     ~H"""
     <Layouts.app flash={@flash}>
-      <section class="w-[min(1180px,calc(100%-2rem))] mx-auto pt-8 pb-16 max-[900px]:w-[min(calc(100%-1.25rem),1180px)] max-[900px]:pt-6">
+      <section class="w-[min(1180px,calc(100%-2rem))] mx-auto pt-4 pb-16 max-[900px]:w-[min(calc(100%-1.25rem),1180px)] max-[900px]:pt-6">
+        <.link
+          navigate={~p"/benchmarks"}
+          class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400 hover:text-neutral-200"
+        >
+          <.icon name="hero-arrow-left" class="w-3 h-3" /> Back to benchmarks
+        </.link>
+
         <div class="flex items-center justify-between gap-4 mt-6 mb-4 max-[900px]:flex-col max-[900px]:items-start">
-          <div>
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Benchmark run
-            </p>
-            <h1 class="text-[clamp(2rem,4vw,3.4rem)] leading-[1.02]">
+          <div class="space-y-1">
+            <h2 class="text-2xl font-semibold text-[var(--ck-lime)] leading-6 tracking-wide uppercase">
               Run ##{@run.id} — {@run.suite.name}
-            </h1>
-            <p class="text-[var(--ck-muted)] max-w-[48rem] text-[1.05rem] leading-[1.7]">
-              Compare governed and external subjects across the same failure scenarios without polluting mission data.
-            </p>
+            </h2>
           </div>
-          <div class="flex items-center justify-between gap-4 max-[900px]:flex-col max-[900px]:items-start">
-            <.link
-              navigate={~p"/benchmarks"}
-              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
-            >
-              Back to benchmarks
-            </.link>
-            <a
-              href={~p"/api/v1/benchmarks/runs/#{@run.id}/export?format=csv"}
-              class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold"
-            >
-              Export CSV
-            </a>
-          </div>
+
+          <a
+            href={~p"/api/v1/benchmarks/runs/#{@run.id}/export?format=csv"}
+            class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] border border-neutral-400 rounded-xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] px-3 py-2 text-neutral-400 hover:text-neutral-200 hover:border-neutral-400"
+          >
+            <.icon name="hero-document-text" class="w-3 h-3" /> Export CSV
+          </a>
         </div>
 
-        <div class="grid gap-4 grid-cols-[repeat(auto-fit,minmax(180px,1fr))] mt-5">
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Catch rate
-            </p>
-            <strong>{@run.catch_rate}%</strong>
-          </div>
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Block rate
-            </p>
-            <strong>{@detail_metrics.block_rate}%</strong>
-          </div>
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Expected rule hit rate
-            </p>
-            <strong>{@detail_metrics.expected_rule_hit_rate}%</strong>
-          </div>
-          <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-              Average overhead
-            </p>
-            <strong>{format_percent(@run.average_overhead_percent)}</strong>
-          </div>
-        </div>
+        <div class="border border-[var(--ck-stroke)]  rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold mb-4">
+            Performance metrics
+          </p>
 
-        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+          <div class="grid gap-4 grid-cols-2 max-[900px]:grid-cols-1">
+            <div>
+              <h3>Catch rate</h3>
+              <p class="text-[var(--ck-muted)]">{@run.catch_rate}%</p>
+            </div>
+
+            <div>
+              <h3>Block rate</h3>
+              <p class="text-[var(--ck-muted)]">{@detail_metrics.block_rate}%</p>
+            </div>
+
+            <div>
+              <h3>Expected rule hit rate</h3>
+              <p class="text-[var(--ck-muted)]">{@detail_metrics.expected_rule_hit_rate}%</p>
+            </div>
+
+            <div>
+              <h3>Average overhead</h3>
+              <p class="text-[var(--ck-muted)]">{format_percent(@run.average_overhead_percent)}</p>
+            </div>
+          </div>
+
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold mt-8 mb-4">
             Run metadata
           </p>
           <div class="grid gap-4 grid-cols-2 max-[900px]:grid-cols-1">
@@ -176,11 +169,15 @@ defmodule ControlKeelWeb.BenchmarksLive do
             </div>
             <div>
               <h3>Baseline subject</h3>
-              <p class="text-[var(--ck-muted)]">{@run.baseline_subject}</p>
+              <p class="text-[var(--ck-muted)]">
+                {subject_label_by_id(@subjects_by_id, @run.baseline_subject)}
+              </p>
             </div>
             <div>
               <h3>Subjects</h3>
-              <p class="text-[var(--ck-muted)]">{Enum.join(@run.subjects, ", ")}</p>
+              <p class="text-[var(--ck-muted)]">
+                {Enum.map_join(@run.subjects, ", ", &subject_label_by_id(@subjects_by_id, &1))}
+              </p>
             </div>
             <div>
               <h3>Median latency</h3>
@@ -195,7 +192,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
           </div>
         </div>
 
-        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+        <div class="border border-[var(--ck-stroke)] my-6 rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
           <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
             Promotion integrity
           </p>
@@ -216,64 +213,57 @@ defmodule ControlKeelWeb.BenchmarksLive do
           </p>
         </div>
 
-        <div class="border border-[var(--ck-stroke)] bg-[var(--ck-panel)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
-            Scenario matrix
-          </p>
-          <div class="overflow-x-auto">
-            <table class="min-w-full w-full text-sm" id="benchmark-matrix">
-              <thead>
-                <tr>
-                  <th class="text-left py-2 pr-4">Scenario</th>
-                  <%= for subject <- @matrix.subjects do %>
-                    <th class="text-left py-2 pr-4">{subject}</th>
-                  <% end %>
-                </tr>
-              </thead>
-              <tbody>
-                <%= for row <- @matrix.scenarios do %>
-                  <tr id={"scenario-#{row.scenario.slug}"}>
-                    <td class="align-top py-3 pr-4">
-                      <strong>{row.scenario.name}</strong>
-                      <p class="text-[var(--ck-muted)]">{row.scenario.incident_label}</p>
-                      <p class="text-[var(--ck-muted)]">
-                        {format_domain_pack(get_in(row.scenario.metadata || %{}, ["domain_pack"]))} • {get_in(
-                          row.scenario.metadata || %{},
-                          ["risk_tier"]
-                        ) || "n/a"}
-                      </p>
-                    </td>
-                    <%= for result <- row.results do %>
-                      <td class="align-top py-3 pr-4">
-                        <%= if result do %>
-                          <div class="flex flex-wrap gap-2">
-                            <span class="border border-[var(--ck-stroke)] rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]">
-                              {result.status}
-                            </span>
-                            <span
-                              :if={result.decision}
-                              class="border border-[var(--ck-stroke)] rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]"
-                            >
-                              {result.decision}
-                            </span>
-                          </div>
-                          <p class="text-[var(--ck-muted)]">{result.findings_count} findings</p>
-                          <p class="text-[var(--ck-muted)]">
-                            latency {format_latency(result.latency_ms)}
-                          </p>
-                          <p class="text-[var(--ck-muted)]">
-                            overhead {format_percent(result.overhead_percent)}
-                          </p>
-                        <% else %>
-                          <p class="text-[var(--ck-muted)]">No result</p>
-                        <% end %>
-                      </td>
-                    <% end %>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
+        <div class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 mt-6">
+          <div class="flex items-center justify-between gap-4">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Scenario matrix
+            </p>
+            <span class="text-xs text-[var(--ck-muted)]">
+              {length(@matrix.scenarios)} {if length(@matrix.scenarios) == 1,
+                do: "scenario",
+                else: "scenarios"}
+            </span>
           </div>
+
+          <%= if @matrix.scenarios == [] do %>
+            <div class="mt-4 rounded-[1rem] border border-dashed border-[var(--ck-stroke)] p-8 text-center">
+              <p class="text-[var(--ck-text)] text-sm font-medium">No scenarios recorded</p>
+              <p class="text-[var(--ck-muted)] text-sm mt-1">This run has no scenario results yet.</p>
+            </div>
+          <% else %>
+            <div class="grid gap-4 mt-4 grid-cols-2 max-[900px]:grid-cols-1">
+              <%= for row <- @matrix.scenarios do %>
+                <article
+                  id={"scenario-#{row.scenario.slug}"}
+                  class="border border-white/[0.07] rounded-[1.1rem] bg-white/[0.03] p-4 grid gap-3"
+                >
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="min-w-0 space-y-1">
+                      <strong class="block leading-snug">{row.scenario.name}</strong>
+                      <p class="text-[var(--ck-muted)] text-sm">{row.scenario.incident_label}</p>
+                    </div>
+                    <div class="flex flex-col items-end gap-1 shrink-0">
+                      <span class="border border-[var(--ck-stroke)] bg-white/5 rounded-full px-2 py-0.5 text-[0.7rem]">
+                        {format_domain_pack(get_in(row.scenario.metadata || %{}, ["domain_pack"]))}
+                      </span>
+                      <span class="text-[0.7rem] text-[var(--ck-muted)] uppercase tracking-wider">
+                        {get_in(row.scenario.metadata || %{}, ["risk_tier"]) || "n/a"}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div class="grid gap-2">
+                    <%= for {result, subject_id} <- Enum.zip(row.results, @matrix.subjects) do %>
+                      <.scenario_result
+                        result={result}
+                        subject_label={subject_label_by_id(@subjects_by_id, subject_id)}
+                      />
+                    <% end %>
+                  </div>
+                </article>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </section>
     </Layouts.app>
@@ -476,11 +466,7 @@ defmodule ControlKeelWeb.BenchmarksLive do
                       </td>
                       <td class="py-3 pr-4"><strong>{format_percent(run.catch_rate)}</strong></td>
                       <td class="py-3 pr-4 text-[var(--ck-muted)]">
-                        {subject_label(
-                          Enum.find(@available_subjects || [], fn s ->
-                            s["id"] == run.baseline_subject
-                          end) || %{"id" => run.baseline_subject}
-                        )}
+                        {subject_label_by_id(@subjects_by_id, run.baseline_subject)}
                       </td>
                       <td class="py-3 pr-4">
                         <div class="flex flex-wrap gap-2">
@@ -598,22 +584,109 @@ defmodule ControlKeelWeb.BenchmarksLive do
   end
 
   defp refresh_dashboard_assigns(socket) do
+    subjects = Benchmark.available_subjects()
+
     socket
     |> assign(:summary, Benchmark.benchmark_summary([]))
     |> assign(:suites, Benchmark.list_suites([]))
     |> assign(:all_suites, Benchmark.list_suites([]))
     |> assign(:recent_runs, Benchmark.list_recent_runs([]))
-    |> assign(:available_subjects, Benchmark.available_subjects())
+    |> assign(:available_subjects, subjects)
+    |> assign(:subjects_by_id, Map.new(subjects, fn s -> {s["id"], s} end))
   end
 
   defp format_percent(nil), do: "Not recorded"
   defp format_percent(value) when is_integer(value), do: "#{value}%"
   defp format_percent(value), do: "#{Float.round(value, 1)}%"
 
+  defp decision_badge_class(nil),
+    do: "border-[var(--ck-stroke)] bg-white/5 text-[var(--ck-muted)]"
+
+  defp decision_badge_class("block"),
+    do: "border-[rgba(255,143,107,0.35)] bg-[rgba(255,143,107,0.12)] text-[#ffd6cb]"
+
+  defp decision_badge_class("warn"),
+    do: "border-[rgba(255,207,107,0.35)] bg-[rgba(255,207,107,0.12)] text-[#fff0bf]"
+
+  defp decision_badge_class("allow"),
+    do: "border-[rgba(125,226,174,0.35)] bg-[rgba(125,226,174,0.12)] text-[#d2ffe7]"
+
+  defp decision_badge_class(_), do: "border-[var(--ck-stroke)] bg-white/5 text-[var(--ck-muted)]"
+
+  defp decision_label(nil), do: "no ruling"
+  defp decision_label("block"), do: "blocked"
+  defp decision_label("warn"), do: "warned"
+  defp decision_label("allow"), do: "allowed"
+  defp decision_label(other), do: other
+
+  defp status_label(nil), do: "unknown"
+  defp status_label("completed"), do: "completed"
+  defp status_label("failed"), do: "failed"
+  defp status_label("timed_out"), do: "timed out"
+  defp status_label("awaiting_import"), do: "awaiting import"
+  defp status_label("pending"), do: "pending"
+  defp status_label(other), do: String.replace(other, "_", " ")
+
+  defp status_badge_class(status) when status in ["failed", "timed_out"] do
+    "border-[rgba(255,143,107,0.35)] bg-[rgba(255,143,107,0.12)] text-[#ffd6cb]"
+  end
+
+  defp status_badge_class(status) when status in ["awaiting_import", "pending"] do
+    "border-[rgba(255,207,107,0.35)] bg-[rgba(255,207,107,0.12)] text-[#fff0bf]"
+  end
+
+  defp status_badge_class(_), do: "border-[var(--ck-stroke)] bg-white/5 text-[var(--ck-muted)]"
+
   defp subject_options(subjects) do
     Enum.map(subjects, fn subject ->
       {subject_label(subject), subject["id"]}
     end)
+  end
+
+  defp scenario_result(assigns) do
+    ~H"""
+    <div class="rounded-[0.8rem] bg-white/[0.02] px-3 py-2.5 grid gap-2">
+      <%= if @result do %>
+        <div class="flex items-center justify-between gap-2">
+          <div class="flex items-center gap-1.5 min-w-0">
+            <span class="text-sm font-semibold truncate">{@subject_label}</span>
+            <%= if @result.matched_expected do %>
+              <.icon name="hero-check-badge" class="w-4 h-4 text-[var(--ck-lime)] shrink-0" />
+            <% end %>
+          </div>
+          <div class="flex flex-wrap gap-1.5 justify-end shrink-0">
+            <span class={[
+              "rounded-full px-2 py-0.5 text-[0.7rem] font-medium border",
+              decision_badge_class(@result.decision)
+            ]}>
+              {decision_label(@result.decision)}
+            </span>
+            <span
+              :if={status_label(@result.status)}
+              class={[
+                "rounded-full px-2 py-0.5 text-[0.7rem] border",
+                status_badge_class(@result.status)
+              ]}
+            >
+              {status_label(@result.status)}
+            </span>
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--ck-muted)]">
+          <span>{@result.findings_count} findings</span>
+          <span>latency {format_latency(@result.latency_ms)}</span>
+          <span>overhead {format_percent(@result.overhead_percent)}</span>
+        </div>
+      <% else %>
+        <div class="flex items-center justify-between gap-2">
+          <span class="text-sm text-[var(--ck-muted)] truncate">{@subject_label}</span>
+          <span class="text-[0.7rem] text-[var(--ck-muted)] uppercase tracking-wider">
+            no result
+          </span>
+        </div>
+      <% end %>
+    </div>
+    """
   end
 
   defp subject_multi_select(assigns) do
@@ -707,6 +780,10 @@ defmodule ControlKeelWeb.BenchmarksLive do
       />
     </div>
     """
+  end
+
+  defp subject_label_by_id(subjects_by_id, id) do
+    subject_label(Map.get(subjects_by_id, id) || %{"id" => id})
   end
 
   defp subject_label(subject) do

--- a/test/controlkeel_web/live/benchmarks_live_test.exs
+++ b/test/controlkeel_web/live/benchmarks_live_test.exs
@@ -24,7 +24,7 @@ defmodule ControlKeelWeb.BenchmarksLiveTest do
       form(view, "#benchmark-runner",
         benchmark: %{
           "suite" => "vibe_failures_v1",
-          "subjects" => "controlkeel_validate",
+          "subjects" => ["controlkeel_validate"],
           "baseline_subject" => "controlkeel_validate"
         }
       )
@@ -38,10 +38,12 @@ defmodule ControlKeelWeb.BenchmarksLiveTest do
     {:ok, view, _html} = live(conn, ~p"/benchmarks")
 
     view |> element("#benchmark-preset-proxy") |> render_click()
-    assert render(view) =~ "controlkeel_validate,controlkeel_proxy"
+    html = render(view)
+    assert html =~ ~r/selected(?:="")?\s+value="controlkeel_validate"/
+    assert html =~ ~r/selected(?:="")?\s+value="controlkeel_proxy"/
 
     view |> element("#benchmark-preset-opencode") |> render_click()
-    assert render(view) =~ "controlkeel_validate,opencode_manual"
+    assert render(view) =~ ~r/selected(?:="")?\s+value="opencode_manual"/
 
     view |> element("#benchmark-preset-ck-only") |> render_click()
     assert render(view) =~ "benchmark-subjects-input"

--- a/test/controlkeel_web/live/benchmarks_live_test.exs
+++ b/test/controlkeel_web/live/benchmarks_live_test.exs
@@ -11,7 +11,6 @@ defmodule ControlKeelWeb.BenchmarksLiveTest do
 
     assert html =~ "Benchmark engine"
     assert html =~ "OpenCode vs ControlKeel"
-    assert has_element?(view, "#benchmark-filters")
     assert has_element?(view, "#benchmark-runner")
     assert has_element?(view, "#benchmark-preset-opencode")
     assert has_element?(view, "#benchmark-subjects-input")
@@ -38,12 +37,23 @@ defmodule ControlKeelWeb.BenchmarksLiveTest do
     {:ok, view, _html} = live(conn, ~p"/benchmarks")
 
     view |> element("#benchmark-preset-proxy") |> render_click()
-    html = render(view)
-    assert html =~ ~r/selected(?:="")?\s+value="controlkeel_validate"/
-    assert html =~ ~r/selected(?:="")?\s+value="controlkeel_proxy"/
+
+    assert has_element?(
+             view,
+             "#benchmark-runner input[name='benchmark[subjects][]'][value='controlkeel_validate']"
+           )
+
+    assert has_element?(
+             view,
+             "#benchmark-runner input[name='benchmark[subjects][]'][value='controlkeel_proxy']"
+           )
 
     view |> element("#benchmark-preset-opencode") |> render_click()
-    assert render(view) =~ ~r/selected(?:="")?\s+value="opencode_manual"/
+
+    assert has_element?(
+             view,
+             "#benchmark-runner input[name='benchmark[subjects][]'][value='opencode_manual']"
+           )
 
     view |> element("#benchmark-preset-ck-only") |> render_click()
     assert render(view) =~ "benchmark-subjects-input"
@@ -77,14 +87,6 @@ defmodule ControlKeelWeb.BenchmarksLiveTest do
     {:ok, _view, html} = live(conn, ~p"/benchmarks")
 
     assert html =~ "OpenCode Manual Import (external)"
-  end
-
-  test "index filters suites by domain pack", %{conn: conn} do
-    {:ok, view, _html} = live(conn, ~p"/benchmarks?domain_pack=hr")
-
-    assert has_element?(view, "#benchmark-filters")
-    assert has_element?(view, "#suite-domain_expansion_v1")
-    refute has_element?(view, "#suite-vibe_failures_v1")
   end
 
   test "show renders the persisted scenario matrix", %{conn: conn} do

--- a/test/controlkeel_web/live/benchmarks_live_test.exs
+++ b/test/controlkeel_web/live/benchmarks_live_test.exs
@@ -137,4 +137,72 @@ defmodule ControlKeelWeb.BenchmarksLiveTest do
     assert html =~ "codex_manual"
     assert html =~ "claude_manual"
   end
+
+  test "multi-select subject dropdown toggles subjects on and off", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/benchmarks")
+
+    refute has_element?(view, "#benchmark-subjects-input [role='listbox']")
+
+    view
+    |> element("#benchmark-subjects-input button[phx-click='toggle_subjects_dropdown']")
+    |> render_click()
+
+    assert has_element?(view, "#benchmark-subjects-input [role='listbox']")
+
+    view
+    |> element(
+      "#benchmark-subjects-input button[role='option'][data-subject-id='controlkeel_proxy']"
+    )
+    |> render_click()
+
+    assert has_element?(
+             view,
+             "#benchmark-subjects-input input[name='benchmark[subjects][]'][value='controlkeel_proxy']"
+           )
+
+    view
+    |> element(
+      "#benchmark-subjects-input button[role='option'][data-subject-id='controlkeel_proxy']"
+    )
+    |> render_click()
+
+    refute has_element?(
+             view,
+             "#benchmark-subjects-input input[name='benchmark[subjects][]'][value='controlkeel_proxy']"
+           )
+  end
+
+  test "manually toggling a subject clears the active preset", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/benchmarks")
+
+    assert has_element?(view, "#benchmark-preset-opencode[aria-pressed='true']")
+
+    view |> element("#benchmark-preset-ck-only") |> render_click()
+    assert has_element?(view, "#benchmark-preset-ck-only[aria-pressed='true']")
+
+    view
+    |> element("#benchmark-subjects-input button[phx-click='toggle_subjects_dropdown']")
+    |> render_click()
+
+    view
+    |> element(
+      "#benchmark-subjects-input button[role='option'][data-subject-id='controlkeel_proxy']"
+    )
+    |> render_click()
+
+    refute has_element?(view, "#benchmark-preset-ck-only[aria-pressed='true']")
+  end
+
+  test "index renders an empty state when there are no runs", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/benchmarks")
+
+    assert html =~ "No benchmark runs yet"
+  end
+
+  test "show redirects to index when the run is not found", %{conn: conn} do
+    assert {:error, {:live_redirect, %{to: "/benchmarks", flash: flash}}} =
+             live(conn, ~p"/benchmarks/runs/999999")
+
+    assert flash["error"] == "Benchmark run not found."
+  end
 end

--- a/test/controlkeel_web/live/benchmarks_live_test.exs
+++ b/test/controlkeel_web/live/benchmarks_live_test.exs
@@ -103,9 +103,23 @@ defmodule ControlKeelWeb.BenchmarksLiveTest do
     assert html =~ "Scenario matrix"
     assert html =~ "Catch rate"
     assert html =~ "Promotion integrity"
-    assert has_element?(view, "#benchmark-matrix")
     assert has_element?(view, "#scenario-hr_discriminatory_candidate_filter")
     assert has_element?(view, "a[href=\"/api/v1/benchmarks/runs/#{run.id}/export?format=csv\"]")
+
+    # Loop access: each subject label renders (zip alignment + subject lookup).
+    assert html =~ "ControlKeel Validate"
+    assert html =~ "ControlKeel Proxy"
+
+    # Loop access: result fields resolve inside scenario_result/1.
+    assert html =~ "findings"
+    assert html =~ "latency"
+    assert html =~ "overhead"
+
+    # Status badge renders (was previously suppressed for "completed").
+    assert html =~ "completed"
+
+    # Loop access: the second scenario row renders too.
+    assert has_element?(view, "#scenario-legal_privileged_memo_logging")
   end
 
   test "index preset buttons fill multi-host subject fields", %{conn: conn} do


### PR DESCRIPTION
This branch redesigns the Benchmarks LiveView (inline Tailwind replacing `ck-*` classes, a custom multi-select subject picker, preset highlighting, and a card-grid scenario matrix). This PR polishes the branch and expands test coverage for the new interactive behavior.

**Issue: #18**

## Changes

### `lib/controlkeel_web/live/benchmarks_live.ex`
- Replaced `ck-*` utility classes with inline Tailwind.
- Added a custom multi-select subject picker (`subject_multi_select/1`) with `toggle_subject`, `toggle_subjects_dropdown`, and `close_subjects_dropdown` events.
- Preset chips now track/highlight an `active_preset`; manual changes clear it.
- Removed the dashboard domain-pack filter.
- Converted the show-view scenario matrix from a table to a card grid with a new `scenario_result/1` component.
- Added empty-state placeholders for runs and scenarios; fixed a double space in a class string.

### `test/controlkeel_web/live/benchmarks_live_test.exs`
- Added 4 tests for the new picker, preset clearing, empty state, and not-found redirect.

## Validation and test
- `mix test test/controlkeel_web/live/benchmarks_live_test.exs`

**Note:** The changes might not be exactly as per planned in the issue. The design and requirement might have changed while refactoring the file.