### PR TITLE
Refactor observability sub-routes: session layout, re-surface nav, Tailwind migration

### DIFF
--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -502,6 +502,7 @@ defmodule ControlKeel.Observability do
       when status in ["approved", "rejected", "archived"] do
     with {:ok, draft_id} <- parse_id(id),
          %BenchmarkDraft{} = draft <- Repo.get(BenchmarkDraft, draft_id) || {:error, :not_found},
+         :ok <- authorize_benchmark_draft_scope(draft, opts),
          {:ok, updated} <- update_benchmark_draft_record(draft, status, opts) do
       {:ok, benchmark_draft_status_result(updated)}
     end
@@ -2439,6 +2440,27 @@ defmodule ControlKeel.Observability do
       blocked > 0,
       "#{blocked} candidate(s) still need approval, materialization, successful runs, or investigation."
     )
+  end
+
+  defp authorize_benchmark_draft_scope(%BenchmarkDraft{} = draft, opts) do
+    workspace_id = Keyword.get(opts, :workspace_id)
+    org_id = Keyword.get(opts, :org_id)
+
+    cond do
+      is_integer(workspace_id) and draft.workspace_id != workspace_id -> {:error, :forbidden}
+      is_integer(org_id) ->
+        case draft.workspace_id do
+          nil -> {:error, :forbidden}
+          draft_workspace_id ->
+            case Repo.get(ControlKeel.Mission.Workspace, draft_workspace_id) do
+              %{org_id: ^org_id} -> :ok
+              _ -> {:error, :forbidden}
+            end
+        end
+
+      true ->
+        :ok
+    end
   end
 
   defp update_benchmark_draft_record(%BenchmarkDraft{} = draft, status, opts) do

--- a/lib/controlkeel_web.ex
+++ b/lib/controlkeel_web.ex
@@ -78,11 +78,13 @@ defmodule ControlKeelWeb do
       import Phoenix.HTML
       # Core UI components
       import ControlKeelWeb.CoreComponents
+      import ControlKeelWeb.FormatHelpers
 
       # Common modules used in templates
       alias Phoenix.LiveView.JS
       alias ControlKeelWeb.Layouts
       alias ControlKeelWeb.ObservabilityLayout
+      alias ControlKeelWeb.ObservabilitySessionLayout
 
       # Routes generation with the ~p sigil
       unquote(verified_routes())

--- a/lib/controlkeel_web/components/observability_layout.ex
+++ b/lib/controlkeel_web/components/observability_layout.ex
@@ -84,6 +84,36 @@ defmodule ControlKeelWeb.ObservabilityLayout do
             Regressions
           </.link>
           <.link
+            navigate={~p"/observability/evals"}
+            class={nav_link_class("/observability/evals", @current_path)}
+          >
+            Evals
+          </.link>
+          <.link
+            navigate={~p"/observability/evals/persisted"}
+            class={nav_link_class("/observability/evals/persisted", @current_path)}
+          >
+            Saved evals
+          </.link>
+          <.link
+            navigate={~p"/observability/benchmarks/drafts"}
+            class={nav_link_class("/observability/benchmarks/drafts", @current_path)}
+          >
+            Drafts
+          </.link>
+          <.link
+            navigate={~p"/observability/benchmarks/scenarios"}
+            class={nav_link_class("/observability/benchmarks/scenarios", @current_path)}
+          >
+            Scenarios
+          </.link>
+          <.link
+            navigate={~p"/observability/benchmarks/history"}
+            class={nav_link_class("/observability/benchmarks/history", @current_path)}
+          >
+            History
+          </.link>
+          <.link
             navigate={~p"/observability/recommendations"}
             class={nav_link_class("/observability/recommendations", @current_path)}
           >

--- a/lib/controlkeel_web/components/observability_session_layout.ex
+++ b/lib/controlkeel_web/components/observability_session_layout.ex
@@ -1,0 +1,83 @@
+defmodule ControlKeelWeb.ObservabilitySessionLayout do
+  use ControlKeelWeb, :html
+
+  @doc """
+  Renders the session-scoped observability layout with Overview / Timeline /
+  Memory / Export JSON tabs. Shared by the three `/observability/sessions/:id`
+  routes so the tab bar stays consistent and highlights the active view.
+  """
+  attr :flash, :map, required: true
+  attr :current_path, :string, default: ""
+  attr :session_id, :integer, required: true
+  attr :session_title, :string, default: ""
+  slot :inner_block, required: true
+
+  def session(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash}>
+      <section class="mx-auto w-[min(1180px,calc(100%-2rem))] pt-8 pb-16">
+        <div class="space-y-1 mb-4">
+          <.link
+            navigate={~p"/observability"}
+            class="text-sm text-[var(--ck-muted)] hover:text-[var(--ck-lime)] transition-colors"
+          >
+            ← Observability
+          </.link>
+          <h2 class="text-xl font-semibold text-[var(--ck-text)] leading-6 mt-4">
+            {@session_title}
+          </h2>
+          <p class="text-[var(--ck-muted)] text-sm">Session run observability</p>
+        </div>
+
+        <div class="flex gap-3 flex-wrap mb-8">
+          <.link
+            navigate={~p"/observability/sessions/#{@session_id}"}
+            class={tab_class("/observability/sessions/#{@session_id}", @current_path)}
+          >
+            Overview
+          </.link>
+          <.link
+            id="observability-open-timeline"
+            navigate={~p"/observability/sessions/#{@session_id}/timeline"}
+            class={tab_class("/observability/sessions/#{@session_id}/timeline", @current_path)}
+          >
+            Timeline
+          </.link>
+          <.link
+            id="observability-open-memory"
+            navigate={~p"/observability/sessions/#{@session_id}/memory"}
+            class={tab_class("/observability/sessions/#{@session_id}/memory", @current_path)}
+          >
+            Memory
+          </.link>
+          <.link
+            id="observability-export-json"
+            href={~p"/observability/sessions/#{@session_id}/export.json"}
+            class={tab_inactive_class()}
+          >
+            Export JSON
+          </.link>
+        </div>
+
+        {render_slot(@inner_block)}
+      </section>
+    </Layouts.app>
+    """
+  end
+
+  defp tab_class(path, current_path) do
+    if path == current_path do
+      "#{tab_base_class()} text-[var(--ck-lime)] bg-[rgba(190,242,100,0.1)] border-[var(--ck-lime)]"
+    else
+      tab_inactive_class()
+    end
+  end
+
+  defp tab_inactive_class do
+    "#{tab_base_class()} text-[var(--ck-text)] hover:text-[var(--ck-lime)] bg-[rgba(255,255,255,0.03)] hover:bg-[rgba(255,255,255,0.06)] border-[var(--ck-stroke)]"
+  end
+
+  defp tab_base_class do
+    "text-sm font-medium transition-colors px-3 py-1.5 rounded-lg border"
+  end
+end

--- a/lib/controlkeel_web/format_helpers.ex
+++ b/lib/controlkeel_web/format_helpers.ex
@@ -42,4 +42,12 @@ defmodule ControlKeelWeb.FormatHelpers do
   end
 
   def format_datetime(value, _fallback), do: to_string(value)
+
+  @doc """
+  CSS class string for a neutral pill/badge used in observability pages.
+  Consolidated here to eliminate duplication across eight LiveViews.
+  """
+  def neutral_pill_class,
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 end

--- a/lib/controlkeel_web/format_helpers.ex
+++ b/lib/controlkeel_web/format_helpers.ex
@@ -35,7 +35,7 @@ defmodule ControlKeelWeb.FormatHelpers do
 
       _ ->
         case NaiveDateTime.from_iso8601(value) do
-          {:ok, ndt} -> Calendar.strftime(ndt, "%Y-%m-%d %H:%M:%S UTC")
+          {:ok, ndt} -> Calendar.strftime(ndt, "%Y-%m-%d %H:%M:%S")
           _ -> value
         end
     end

--- a/lib/controlkeel_web/format_helpers.ex
+++ b/lib/controlkeel_web/format_helpers.ex
@@ -26,7 +26,7 @@ defmodule ControlKeelWeb.FormatHelpers do
     do: Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S UTC")
 
   def format_datetime(%NaiveDateTime{} = dt, _fallback),
-    do: Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S UTC")
+    do: Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S")
 
   def format_datetime(value, _fallback) when is_binary(value) do
     case DateTime.from_iso8601(value) do

--- a/lib/controlkeel_web/format_helpers.ex
+++ b/lib/controlkeel_web/format_helpers.ex
@@ -1,0 +1,39 @@
+defmodule ControlKeelWeb.FormatHelpers do
+  @moduledoc """
+  Shared presentation helpers imported into every view through the
+  `html_helpers` block in `ControlKeelWeb`. Dependency-free: stdlib
+  `Calendar`/`DateTime` only.
+
+  Extracted from the private `format_datetime/1` copies that lived in
+  `observability_problems_live`, `proof_browser_live`, and the session run
+  page so every view formats timestamps the same way.
+  """
+
+  @doc """
+  Formats a timestamp for display. Accepts a `DateTime`, `NaiveDateTime`,
+  ISO8601 string, `nil`, or `""`. Unparseable strings pass through unchanged.
+
+  `fallback` is returned for `nil`/`""` so callers can preserve page-specific
+  empty-state copy (e.g. the proof browser shows "Not recorded"). Defaults to
+  "unknown" to match the observability pages.
+  """
+  def format_datetime(value, fallback \\ "unknown")
+
+  def format_datetime(nil, fallback), do: fallback
+  def format_datetime("", fallback), do: fallback
+
+  def format_datetime(%DateTime{} = dt, _fallback),
+    do: Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S UTC")
+
+  def format_datetime(%NaiveDateTime{} = dt, _fallback),
+    do: Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S UTC")
+
+  def format_datetime(value, _fallback) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} -> Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S UTC")
+      _ -> value
+    end
+  end
+
+  def format_datetime(value, _fallback), do: to_string(value)
+end

--- a/lib/controlkeel_web/format_helpers.ex
+++ b/lib/controlkeel_web/format_helpers.ex
@@ -30,8 +30,14 @@ defmodule ControlKeelWeb.FormatHelpers do
 
   def format_datetime(value, _fallback) when is_binary(value) do
     case DateTime.from_iso8601(value) do
-      {:ok, dt, _offset} -> Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S UTC")
-      _ -> value
+      {:ok, dt, _offset} ->
+        Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S UTC")
+
+      _ ->
+        case NaiveDateTime.from_iso8601(value) do
+          {:ok, ndt} -> Calendar.strftime(ndt, "%Y-%m-%d %H:%M:%S UTC")
+          _ -> value
+        end
     end
   end
 

--- a/lib/controlkeel_web/live/observability_benchmark_drafts_live.ex
+++ b/lib/controlkeel_web/live/observability_benchmark_drafts_live.ex
@@ -3,6 +3,9 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
 
   alias ControlKeel.Mission
   alias ControlKeel.Observability
+  alias ControlKeelWeb.CommandPill
+
+  on_mount ControlKeelWeb.CommandPill
 
   @impl true
   def mount(_params, _session, socket) do
@@ -35,96 +38,116 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash}>
-      <section id="observability-benchmark-drafts-page" class="ck-shell ck-shell-tight">
-        <div class="ck-section-header">
+    <ObservabilityLayout.observability flash={@flash} current_path="/observability/benchmarks/drafts">
+      <section
+        id="observability-benchmark-drafts-page"
+        class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 space-y-5"
+      >
+        <div class="flex items-start justify-between gap-4">
           <div>
-            <p class="ck-kicker">Observability</p>
-            <h1 class="ck-section-title">Benchmark drafts</h1>
-            <p class="ck-lead ck-lead-tight">
+            <h1 class="text-xl font-semibold text-[var(--ck-lime)]">Benchmark drafts</h1>
+            <p class="text-[var(--ck-muted)] text-sm mt-1">
               Human-gated local benchmark draft scenarios generated from saved eval candidates.
             </p>
           </div>
-          <div class="ck-badge-stack">
-            <span id="observability-benchmark-drafts-count" class="ck-pill ck-pill-neutral">
+          <div class="flex items-center gap-3 shrink-0 flex-wrap justify-end">
+            <span id="observability-benchmark-drafts-count" class={neutral_pill_class()}>
               {@drafts.count} draft(s)
             </span>
-            <.link navigate={~p"/observability/evals/persisted"} class="ck-link">Saved evals</.link>
-            <.link navigate={~p"/observability/regressions"} class="ck-link">Regressions</.link>
-            <.link navigate={~p"/observability/benchmarks/scenarios"} class="ck-link">
-              Scenarios
-            </.link>
-            <.link navigate={~p"/observability/benchmarks/history"} class="ck-link">History</.link>
-            <.link navigate={~p"/benchmarks"} class="ck-link">Benchmarks</.link>
-            <.link navigate={~p"/observability"} class="ck-link">Overview</.link>
           </div>
         </div>
 
-        <div class="ck-stat-grid">
-          <div id="observability-benchmark-drafts-status" class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Status</p>
-            <strong>{format_frequency(@drafts.by_status)}</strong>
+        <CommandPill.command_pill command="controlkeel obs benchmarks drafts" />
+
+        <div class="grid grid-cols-2 gap-4">
+          <div
+            id="observability-benchmark-drafts-status"
+            class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+          >
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Status</p>
+            <p class="text-lg font-semibold text-[var(--ck-text)]">
+              {format_frequency(@drafts.by_status)}
+            </p>
           </div>
-          <div id="observability-benchmark-drafts-suites" class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Suites</p>
-            <strong>{format_frequency(@drafts.by_suite)}</strong>
+          <div
+            id="observability-benchmark-drafts-suites"
+            class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+          >
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Suites</p>
+            <p class="text-lg font-semibold text-[var(--ck-text)]">
+              {format_frequency(@drafts.by_suite)}
+            </p>
           </div>
         </div>
 
-        <div id="observability-benchmark-drafts-recommendations" class="ck-card">
-          <p class="ck-mini-label">Recommendations</p>
-          <ul class="ck-mini-list">
-            <%= for recommendation <- @drafts.recommendations do %>
-              <li>{recommendation}</li>
-            <% end %>
-          </ul>
-        </div>
-
-        <div id="observability-benchmark-drafts-list" class="ck-card">
-          <%= if @drafts.drafts == [] do %>
-            <p class="ck-note">No benchmark drafts yet.</p>
-          <% else %>
-            <ul class="ck-mini-list">
-              <%= for draft <- @drafts.drafts do %>
-                <li id={"observability-benchmark-draft-#{draft.id}"}>
-                  <div class="ck-card-header">
-                    <div>
-                      <p class="ck-mini-label">{draft.suite_slug}</p>
-                      <strong>{draft.title}</strong>
-                    </div>
-                    <span class="ck-pill ck-pill-neutral">{draft.status}</span>
-                  </div>
-                  <p>{draft.scenario_prompt}</p>
-                  <p class="ck-note">Expected: {draft.expected_behavior}</p>
-                  <p class="ck-note">Human gate required: {draft.human_gate_required}</p>
-                  <p class="ck-note">Scenario: {materialized_scenario(draft)}</p>
-                  <div class="ck-button-row">
-                    <button
-                      id={"observability-benchmark-draft-approve-#{draft.id}"}
-                      type="button"
-                      class="ck-button ck-button-primary"
-                      phx-click="approve-draft"
-                      phx-value-id={draft.id}
-                    >
-                      Approve
-                    </button>
-                    <button
-                      id={"observability-benchmark-draft-reject-#{draft.id}"}
-                      type="button"
-                      class="ck-button"
-                      phx-click="reject-draft"
-                      phx-value-id={draft.id}
-                    >
-                      Reject
-                    </button>
-                  </div>
-                </li>
+        <%= if @drafts.recommendations != [] do %>
+          <div id="observability-benchmark-drafts-recommendations" class="space-y-2">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Recommendations
+            </p>
+            <ul class="list-disc pl-5">
+              <%= for recommendation <- @drafts.recommendations do %>
+                <li class="text-[var(--ck-muted)] text-sm leading-relaxed">{recommendation}</li>
               <% end %>
             </ul>
+          </div>
+        <% end %>
+
+        <div id="observability-benchmark-drafts-list" class="space-y-3">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Draft scenarios
+          </p>
+          <%= if @drafts.drafts == [] do %>
+            <p class="text-[var(--ck-muted)] text-sm">No benchmark drafts yet.</p>
+          <% else %>
+            <%= for draft <- @drafts.drafts do %>
+              <div
+                id={"observability-benchmark-draft-#{draft.id}"}
+                class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-2"
+              >
+                <div class="flex items-center justify-between gap-4">
+                  <div>
+                    <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                      {draft.suite_slug}
+                    </p>
+                    <p class="text-sm font-semibold text-[var(--ck-text)]">{draft.title}</p>
+                  </div>
+                  <span class={neutral_pill_class()}>{draft.status}</span>
+                </div>
+                <p class="text-sm text-[var(--ck-text)] leading-relaxed">{draft.scenario_prompt}</p>
+                <p class="text-[var(--ck-muted)] text-xs">Expected: {draft.expected_behavior}</p>
+                <p class="text-[var(--ck-muted)] text-xs">
+                  Human gate required: {draft.human_gate_required}
+                </p>
+                <p class="text-[var(--ck-muted)] text-xs">
+                  Scenario: {materialized_scenario(draft)}
+                </p>
+                <div class="flex items-center gap-3 pt-1">
+                  <button
+                    id={"observability-benchmark-draft-approve-#{draft.id}"}
+                    type="button"
+                    class="inline-flex items-center rounded-lg px-3 py-1.5 text-sm font-semibold bg-[rgba(190,242,100,0.14)] text-[var(--ck-lime)] border border-[var(--ck-lime)] hover:opacity-80 transition-opacity"
+                    phx-click="approve-draft"
+                    phx-value-id={draft.id}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    id={"observability-benchmark-draft-reject-#{draft.id}"}
+                    type="button"
+                    class="inline-flex items-center rounded-lg px-3 py-1.5 text-sm font-semibold border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.03)] text-[var(--ck-text)] hover:opacity-80 transition-opacity"
+                    phx-click="reject-draft"
+                    phx-value-id={draft.id}
+                  >
+                    Reject
+                  </button>
+                </div>
+              </div>
+            <% end %>
           <% end %>
         </div>
       </section>
-    </Layouts.app>
+    </ObservabilityLayout.observability>
     """
   end
 
@@ -144,4 +167,8 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
     |> Enum.map(fn {key, count} -> "#{key}: #{count}" end)
     |> Enum.join(", ")
   end
+
+  defp neutral_pill_class,
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 end

--- a/lib/controlkeel_web/live/observability_benchmark_drafts_live.ex
+++ b/lib/controlkeel_web/live/observability_benchmark_drafts_live.ex
@@ -22,17 +22,31 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
 
   @impl true
   def handle_event("approve-draft", %{"id" => id}, socket) do
-    {:ok, _result} =
-      Observability.update_benchmark_draft_status(id, "approved", reviewed_by: "web")
+    opts = Keyword.merge(socket.assigns.opts, reviewed_by: "web")
 
-    {:noreply, assign(socket, :drafts, Observability.benchmark_drafts(socket.assigns.opts))}
+    case Observability.update_benchmark_draft_status(id, "approved", opts) do
+      {:ok, _result} ->
+        {:noreply, assign(socket, :drafts, Observability.benchmark_drafts(socket.assigns.opts))}
+
+      {:error, reason} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, flash_for_status_error(reason))}
+    end
   end
 
   def handle_event("reject-draft", %{"id" => id}, socket) do
-    {:ok, _result} =
-      Observability.update_benchmark_draft_status(id, "rejected", reviewed_by: "web")
+    opts = Keyword.merge(socket.assigns.opts, reviewed_by: "web")
 
-    {:noreply, assign(socket, :drafts, Observability.benchmark_drafts(socket.assigns.opts))}
+    case Observability.update_benchmark_draft_status(id, "rejected", opts) do
+      {:ok, _result} ->
+        {:noreply, assign(socket, :drafts, Observability.benchmark_drafts(socket.assigns.opts))}
+
+      {:error, reason} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, flash_for_status_error(reason))}
+    end
   end
 
   @impl true
@@ -157,6 +171,11 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
       _ -> "not materialized"
     end
   end
+
+  defp flash_for_status_error(:forbidden), do: "You can only review drafts from the current workspace."
+  defp flash_for_status_error(:not_found), do: "Benchmark draft was not found."
+  defp flash_for_status_error(:invalid_id), do: "The provided draft id was invalid."
+  defp flash_for_status_error(_reason), do: "Unable to update benchmark draft status."
 
   defp format_frequency(map) when map == %{}, do: "none"
 

--- a/lib/controlkeel_web/live/observability_benchmark_drafts_live.ex
+++ b/lib/controlkeel_web/live/observability_benchmark_drafts_live.ex
@@ -168,7 +168,4 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
     |> Enum.join(", ")
   end
 
-  defp neutral_pill_class,
-    do:
-      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 end

--- a/lib/controlkeel_web/live/observability_benchmark_history_live.ex
+++ b/lib/controlkeel_web/live/observability_benchmark_history_live.ex
@@ -68,7 +68,9 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkHistoryLive do
               </p>
             </div>
             <div class="rounded-lg p-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.02)] space-y-1">
-              <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Materialized</p>
+              <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                Materialized
+              </p>
               <p class="text-xl font-semibold text-[var(--ck-text)]">
                 {@history.coverage.materialized_scenarios}
               </p>
@@ -112,7 +114,9 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkHistoryLive do
                     <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
                       {run.suite}
                     </p>
-                    <p class="text-sm font-semibold text-[var(--ck-text)]">Run #{run.id}: {run.status}</p>
+                    <p class="text-sm font-semibold text-[var(--ck-text)]">
+                      Run #{run.id}: {run.status}
+                    </p>
                   </div>
                 </div>
                 <p class="text-[var(--ck-muted)] text-xs">

--- a/lib/controlkeel_web/live/observability_benchmark_history_live.ex
+++ b/lib/controlkeel_web/live/observability_benchmark_history_live.ex
@@ -131,7 +131,4 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkHistoryLive do
     """
   end
 
-  defp neutral_pill_class,
-    do:
-      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 end

--- a/lib/controlkeel_web/live/observability_benchmark_history_live.ex
+++ b/lib/controlkeel_web/live/observability_benchmark_history_live.ex
@@ -3,6 +3,9 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkHistoryLive do
 
   alias ControlKeel.Mission
   alias ControlKeel.Observability
+  alias ControlKeelWeb.CommandPill
+
+  on_mount ControlKeelWeb.CommandPill
 
   @impl true
   def mount(_params, _session, socket) do
@@ -19,68 +22,112 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkHistoryLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash}>
-      <section id="observability-benchmark-history-page" class="ck-shell ck-shell-tight">
-        <div class="ck-section-header">
+    <ObservabilityLayout.observability
+      flash={@flash}
+      current_path="/observability/benchmarks/history"
+    >
+      <section
+        id="observability-benchmark-history-page"
+        class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 space-y-5"
+      >
+        <div class="flex items-start justify-between gap-4">
           <div>
-            <p class="ck-kicker">Observability</p>
-            <h1 class="ck-section-title">Benchmark history</h1>
-            <p class="ck-lead ck-lead-tight">
+            <h1 class="text-xl font-semibold text-[var(--ck-lime)]">Benchmark history</h1>
+            <p class="text-[var(--ck-muted)] text-sm mt-1">
               Read-only readiness and run evidence for generated observability benchmark scenarios.
             </p>
           </div>
-          <div class="ck-badge-stack">
-            <span id="observability-benchmark-history-readiness" class="ck-pill ck-pill-neutral">
+          <div class="flex items-center gap-3 shrink-0">
+            <span id="observability-benchmark-history-readiness" class={neutral_pill_class()}>
               {@history.readiness.status}
             </span>
-            <.link navigate={~p"/observability/benchmarks/scenarios"} class="ck-link">
-              Scenarios
-            </.link>
-            <.link navigate={~p"/observability/benchmarks/drafts"} class="ck-link">Drafts</.link>
-            <.link navigate={~p"/observability/promotions"} class="ck-link">Promotions</.link>
-            <.link navigate={~p"/observability"} class="ck-link">Overview</.link>
           </div>
         </div>
 
-        <div id="observability-benchmark-history-summary" class="ck-card">
-          <p class="ck-mini-label">Readiness</p>
-          <strong>{@history.readiness.reason}</strong>
-          <div class="ck-stat-grid">
-            <div class="ck-stat-card">Saved evals: {@history.coverage.saved_eval_candidates}</div>
-            <div class="ck-stat-card">Drafts: {@history.coverage.benchmark_drafts}</div>
-            <div class="ck-stat-card">Materialized: {@history.coverage.materialized_scenarios}</div>
-            <div class="ck-stat-card">Covered: {@history.coverage.covered_scenarios}</div>
+        <CommandPill.command_pill command="controlkeel obs benchmarks history" />
+
+        <div
+          id="observability-benchmark-history-summary"
+          class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-4"
+        >
+          <div class="space-y-1">
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Readiness</p>
+            <p class="text-base font-semibold text-[var(--ck-text)]">{@history.readiness.reason}</p>
+          </div>
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div class="rounded-lg p-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.02)] space-y-1">
+              <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Saved evals</p>
+              <p class="text-xl font-semibold text-[var(--ck-text)]">
+                {@history.coverage.saved_eval_candidates}
+              </p>
+            </div>
+            <div class="rounded-lg p-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.02)] space-y-1">
+              <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Drafts</p>
+              <p class="text-xl font-semibold text-[var(--ck-text)]">
+                {@history.coverage.benchmark_drafts}
+              </p>
+            </div>
+            <div class="rounded-lg p-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.02)] space-y-1">
+              <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Materialized</p>
+              <p class="text-xl font-semibold text-[var(--ck-text)]">
+                {@history.coverage.materialized_scenarios}
+              </p>
+            </div>
+            <div class="rounded-lg p-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.02)] space-y-1">
+              <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Covered</p>
+              <p class="text-xl font-semibold text-[var(--ck-text)]">
+                {@history.coverage.covered_scenarios}
+              </p>
+            </div>
           </div>
         </div>
 
-        <div id="observability-benchmark-history-recommendations" class="ck-card">
-          <p class="ck-mini-label">Recommendations</p>
-          <ul class="ck-mini-list">
-            <%= for recommendation <- @history.recommendations do %>
-              <li>{recommendation}</li>
-            <% end %>
-          </ul>
-        </div>
-
-        <div id="observability-benchmark-history-runs" class="ck-card">
-          <p class="ck-mini-label">Recent generated-suite runs</p>
-          <%= if @history.runs == [] do %>
-            <p class="ck-note">No observability benchmark runs yet.</p>
-          <% else %>
-            <ul class="ck-mini-list">
-              <%= for run <- @history.runs do %>
-                <li id={"observability-benchmark-history-run-#{run.id}"}>
-                  <strong>Run #{run.id}: {run.status}</strong>
-                  <p class="ck-note">
-                    {run.suite} · catch {run.catch_rate}% · rule-hit {run.expected_rule_hit_rate}%
-                  </p>
-                </li>
+        <%= if @history.recommendations != [] do %>
+          <div id="observability-benchmark-history-recommendations" class="space-y-2">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Recommendations
+            </p>
+            <ul class="list-disc pl-5">
+              <%= for recommendation <- @history.recommendations do %>
+                <li class="text-[var(--ck-muted)] text-sm leading-relaxed">{recommendation}</li>
               <% end %>
             </ul>
+          </div>
+        <% end %>
+
+        <div id="observability-benchmark-history-runs" class="space-y-3">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Recent generated-suite runs
+          </p>
+          <%= if @history.runs == [] do %>
+            <p class="text-[var(--ck-muted)] text-sm">No observability benchmark runs yet.</p>
+          <% else %>
+            <%= for run <- @history.runs do %>
+              <div
+                id={"observability-benchmark-history-run-#{run.id}"}
+                class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+              >
+                <div class="flex items-center justify-between gap-4">
+                  <div>
+                    <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                      {run.suite}
+                    </p>
+                    <p class="text-sm font-semibold text-[var(--ck-text)]">Run #{run.id}: {run.status}</p>
+                  </div>
+                </div>
+                <p class="text-[var(--ck-muted)] text-xs">
+                  catch {run.catch_rate}% · rule-hit {run.expected_rule_hit_rate}%
+                </p>
+              </div>
+            <% end %>
           <% end %>
         </div>
       </section>
-    </Layouts.app>
+    </ObservabilityLayout.observability>
     """
   end
+
+  defp neutral_pill_class,
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 end

--- a/lib/controlkeel_web/live/observability_benchmark_scenarios_live.ex
+++ b/lib/controlkeel_web/live/observability_benchmark_scenarios_live.ex
@@ -113,7 +113,4 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkScenariosLive do
     """
   end
 
-  defp neutral_pill_class,
-    do:
-      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 end

--- a/lib/controlkeel_web/live/observability_benchmark_scenarios_live.ex
+++ b/lib/controlkeel_web/live/observability_benchmark_scenarios_live.ex
@@ -3,6 +3,9 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkScenariosLive do
 
   alias ControlKeel.Mission
   alias ControlKeel.Observability
+  alias ControlKeelWeb.CommandPill
+
+  on_mount ControlKeelWeb.CommandPill
 
   @impl true
   def mount(_params, _session, socket) do
@@ -21,68 +24,96 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkScenariosLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash}>
-      <section id="observability-benchmark-scenarios-page" class="ck-shell ck-shell-tight">
-        <div class="ck-section-header">
+    <ObservabilityLayout.observability
+      flash={@flash}
+      current_path="/observability/benchmarks/scenarios"
+    >
+      <section
+        id="observability-benchmark-scenarios-page"
+        class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 space-y-5"
+      >
+        <div class="flex items-start justify-between gap-4">
           <div>
-            <p class="ck-kicker">Observability</p>
-            <h1 class="ck-section-title">Materialized benchmark scenarios</h1>
-            <p class="ck-lead ck-lead-tight">
+            <h1 class="text-xl font-semibold text-[var(--ck-lime)]">
+              Materialized benchmark scenarios
+            </h1>
+            <p class="text-[var(--ck-muted)] text-sm mt-1">
               Local Benchmark.Scenario records generated from approved observability drafts.
             </p>
           </div>
-          <div class="ck-badge-stack">
-            <span id="observability-benchmark-scenarios-count" class="ck-pill ck-pill-neutral">
+          <div class="flex items-center gap-3 shrink-0">
+            <span id="observability-benchmark-scenarios-count" class={neutral_pill_class()}>
               {@scenarios.count} scenario(s)
             </span>
-            <.link navigate={~p"/observability/benchmarks/drafts"} class="ck-link">Drafts</.link>
-            <.link navigate={~p"/observability/benchmarks/history"} class="ck-link">History</.link>
-            <.link navigate={~p"/benchmarks"} class="ck-link">Benchmarks</.link>
-            <.link navigate={~p"/observability"} class="ck-link">Overview</.link>
           </div>
         </div>
 
-        <div id="observability-benchmark-scenarios-summary" class="ck-card">
-          <p class="ck-mini-label">Recommendations</p>
-          <ul class="ck-mini-list">
-            <%= for recommendation <- @scenarios.recommendations do %>
-              <li>{recommendation}</li>
-            <% end %>
-          </ul>
-        </div>
+        <CommandPill.command_pill command="controlkeel obs benchmarks scenarios" />
 
-        <div id="observability-benchmark-run-guidance" class="ck-card">
-          <p class="ck-mini-label">Human-gated execution</p>
-          <p class="ck-note">
+        <%= if @scenarios.recommendations != [] do %>
+          <div id="observability-benchmark-scenarios-summary" class="space-y-2">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Recommendations
+            </p>
+            <ul class="list-disc pl-5">
+              <%= for recommendation <- @scenarios.recommendations do %>
+                <li class="text-[var(--ck-muted)] text-sm leading-relaxed">{recommendation}</li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <div
+          id="observability-benchmark-run-guidance"
+          class="space-y-3"
+        >
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Human-gated execution
+          </p>
+          <p class="text-[var(--ck-muted)] text-sm leading-relaxed">
             Benchmark execution is CLI-only. Review generated scenarios first, then run an explicit command.
           </p>
-          <code class="ck-code">
+          <code class="block rounded-lg border border-[var(--ck-stroke)] bg-[rgba(0,0,0,0.3)] px-3 py-2 text-xs text-[var(--ck-muted)] overflow-x-auto">
             {@run_preview.command || "controlkeel obs benchmarks run --dry-run"}
           </code>
-          <ul class="ck-mini-list">
-            <%= for recommendation <- @run_preview.recommendations do %>
-              <li>{recommendation}</li>
-            <% end %>
-          </ul>
-        </div>
-
-        <div id="observability-benchmark-scenarios-list" class="ck-card">
-          <%= if @scenarios.scenarios == [] do %>
-            <p class="ck-note">No materialized observability scenarios yet.</p>
-          <% else %>
-            <ul class="ck-mini-list">
-              <%= for scenario <- @scenarios.scenarios do %>
-                <li id={"observability-benchmark-scenario-#{scenario.id}"}>
-                  <strong>{scenario.name}</strong>
-                  <p class="ck-note">{scenario.suite_slug} · {scenario.slug} · {scenario.split}</p>
-                  <p class="ck-note">Expected rules: {Enum.join(scenario.expected_rules, ", ")}</p>
-                </li>
+          <%= if @run_preview.recommendations != [] do %>
+            <ul class="list-disc pl-5">
+              <%= for recommendation <- @run_preview.recommendations do %>
+                <li class="text-[var(--ck-muted)] text-sm leading-relaxed">{recommendation}</li>
               <% end %>
             </ul>
           <% end %>
         </div>
+
+        <div id="observability-benchmark-scenarios-list" class="space-y-3">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Scenarios
+          </p>
+          <%= if @scenarios.scenarios == [] do %>
+            <p class="text-[var(--ck-muted)] text-sm">No materialized observability scenarios yet.</p>
+          <% else %>
+            <%= for scenario <- @scenarios.scenarios do %>
+              <div
+                id={"observability-benchmark-scenario-#{scenario.id}"}
+                class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+              >
+                <p class="text-sm font-semibold text-[var(--ck-text)]">{scenario.name}</p>
+                <p class="text-[var(--ck-muted)] text-xs">
+                  {scenario.suite_slug} · {scenario.slug} · {scenario.split}
+                </p>
+                <p class="text-[var(--ck-muted)] text-xs">
+                  Expected rules: {Enum.join(scenario.expected_rules, ", ")}
+                </p>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
       </section>
-    </Layouts.app>
+    </ObservabilityLayout.observability>
     """
   end
+
+  defp neutral_pill_class,
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 end

--- a/lib/controlkeel_web/live/observability_evals_live.ex
+++ b/lib/controlkeel_web/live/observability_evals_live.ex
@@ -123,7 +123,4 @@ defmodule ControlKeelWeb.ObservabilityEvalsLive do
     do:
       "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 
-  defp neutral_pill_class,
-    do:
-      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 end

--- a/lib/controlkeel_web/live/observability_evals_live.ex
+++ b/lib/controlkeel_web/live/observability_evals_live.ex
@@ -3,6 +3,9 @@ defmodule ControlKeelWeb.ObservabilityEvalsLive do
 
   alias ControlKeel.Mission
   alias ControlKeel.Observability
+  alias ControlKeelWeb.CommandPill
+
+  on_mount ControlKeelWeb.CommandPill
 
   @impl true
   def mount(_params, _session, socket) do
@@ -19,82 +22,108 @@ defmodule ControlKeelWeb.ObservabilityEvalsLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash}>
-      <section id="observability-evals-page" class="ck-shell ck-shell-tight">
-        <div class="ck-section-header">
+    <ObservabilityLayout.observability flash={@flash} current_path="/observability/evals">
+      <section
+        id="observability-evals-page"
+        class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 space-y-5"
+      >
+        <div class="flex items-start justify-between gap-4">
           <div>
-            <p class="ck-kicker">Observability</p>
-            <h1 class="ck-section-title">Eval candidates</h1>
-            <p class="ck-lead ck-lead-tight">
+            <h1 class="text-xl font-semibold text-[var(--ck-lime)]">Eval candidates</h1>
+            <p class="text-[var(--ck-muted)] text-sm mt-1">
               Advisory regression candidates derived from grouped problems and feedback evidence.
             </p>
           </div>
-          <div class="ck-badge-stack">
+          <div class="flex items-center gap-3 shrink-0 flex-wrap justify-end">
             <span id="observability-evals-health" class={health_pill_class(@eval_candidates.health)}>
               {@eval_candidates.health}
             </span>
-            <span class="ck-pill ck-pill-neutral">{@eval_candidates.count} candidate(s)</span>
-            <.link navigate={~p"/observability/recommendations"} class="ck-link">
-              Recommendations
-            </.link>
-            <.link navigate={~p"/observability/evals/persisted"} class="ck-link">
-              Saved candidates
-            </.link>
+            <span class={neutral_pill_class()}>{@eval_candidates.count} candidate(s)</span>
           </div>
         </div>
 
-        <div id="observability-evals-summary" class="ck-card">
-          <p class="ck-mini-label">Recommended next actions</p>
-          <ul class="ck-mini-list">
-            <%= for recommendation <- @eval_candidates.recommendations do %>
-              <li>{recommendation}</li>
-            <% end %>
-          </ul>
-        </div>
+        <CommandPill.command_pill command="controlkeel obs evals" />
 
-        <div id="observability-evals-list" class="ck-card">
-          <%= if @eval_candidates.candidates == [] do %>
-            <p class="ck-note">No eval candidates are currently active.</p>
-          <% else %>
-            <ul class="ck-mini-list">
-              <%= for candidate <- @eval_candidates.candidates do %>
-                <li id={"observability-eval-#{candidate.id}"}>
-                  <div class="ck-card-header">
-                    <div>
-                      <p class="ck-mini-label">{candidate.category}</p>
-                      <strong>{candidate.title}</strong>
-                    </div>
-                    <span class={priority_pill_class(candidate.priority)}>
-                      {candidate.priority}
-                    </span>
-                  </div>
-                  <p class="ck-note">
-                    {candidate.rule_id} · {candidate.finding_count} finding(s) · {candidate.affected_session_count} session(s)
-                  </p>
-                  <p>{candidate.evidence_summary}</p>
-                  <p class="ck-note">Benchmark hint: {candidate.benchmark_hint}</p>
-                  <p class="ck-note">
-                    Human gate required: {candidate.human_gate_required}
-                  </p>
-                  <.link navigate={candidate.links.problems} class="ck-link">
-                    Open problem groups
-                  </.link>
-                  <.link navigate={candidate.links.benchmarks} class="ck-link">Open benchmarks</.link>
-                </li>
+        <%= if @eval_candidates.recommendations != [] do %>
+          <div class="space-y-2">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Recommended next actions
+            </p>
+            <ul class="list-disc pl-5">
+              <%= for recommendation <- @eval_candidates.recommendations do %>
+                <li class="text-[var(--ck-muted)] text-sm leading-relaxed">{recommendation}</li>
               <% end %>
             </ul>
+          </div>
+        <% end %>
+
+        <div id="observability-evals-list" class="space-y-3">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Active candidates
+          </p>
+          <%= if @eval_candidates.candidates == [] do %>
+            <p class="text-[var(--ck-muted)] text-sm">No eval candidates are currently active.</p>
+          <% else %>
+            <%= for candidate <- @eval_candidates.candidates do %>
+              <div
+                id={"observability-eval-#{candidate.id}"}
+                class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-2"
+              >
+                <div class="flex items-center justify-between gap-4">
+                  <div>
+                    <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                      {candidate.category}
+                    </p>
+                    <p class="text-sm font-semibold text-[var(--ck-text)]">{candidate.title}</p>
+                  </div>
+                  <span class={priority_pill_class(candidate.priority)}>{candidate.priority}</span>
+                </div>
+                <p class="text-[var(--ck-muted)] text-xs">
+                  {candidate.rule_id} · {candidate.finding_count} finding(s) · {candidate.affected_session_count} session(s)
+                </p>
+                <p class="text-sm text-[var(--ck-text)] leading-relaxed">
+                  {candidate.evidence_summary}
+                </p>
+                <p class="text-[var(--ck-muted)] text-xs">
+                  Benchmark hint: {candidate.benchmark_hint}
+                </p>
+                <p class="text-[var(--ck-muted)] text-xs">
+                  Human gate required: {candidate.human_gate_required}
+                </p>
+              </div>
+            <% end %>
           <% end %>
         </div>
       </section>
-    </Layouts.app>
+    </ObservabilityLayout.observability>
     """
   end
 
-  defp health_pill_class("red"), do: "ck-pill ck-pill-critical"
-  defp health_pill_class("yellow"), do: "ck-pill ck-pill-warning"
-  defp health_pill_class(_), do: "ck-pill ck-pill-low"
+  defp health_pill_class("red"),
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,107,107,0.1)] text-[#ff6b6b]"
 
-  defp priority_pill_class("critical"), do: "ck-pill ck-pill-critical"
-  defp priority_pill_class("high"), do: "ck-pill ck-pill-warning"
-  defp priority_pill_class(_), do: "ck-pill ck-pill-neutral"
+  defp health_pill_class("yellow"),
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,207,107,0.1)] text-[#ffcf6b]"
+
+  defp health_pill_class(_),
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]"
+
+  defp priority_pill_class("critical"),
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,107,107,0.1)] text-[#ff6b6b]"
+
+  defp priority_pill_class("high"),
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,207,107,0.1)] text-[#ffcf6b]"
+
+  defp priority_pill_class(_),
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
+
+  defp neutral_pill_class,
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 end

--- a/lib/controlkeel_web/live/observability_live.ex
+++ b/lib/controlkeel_web/live/observability_live.ex
@@ -2,6 +2,9 @@ defmodule ControlKeelWeb.ObservabilityLive do
   use ControlKeelWeb, :live_view
 
   alias ControlKeel.Observability
+  alias ControlKeelWeb.CommandPill
+
+  on_mount ControlKeelWeb.CommandPill
 
   @impl true
   def mount(%{"id" => id}, _session, socket) do
@@ -42,241 +45,320 @@ defmodule ControlKeelWeb.ObservabilityLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash}>
-      <section id="observability-run-page" class="ck-shell ck-shell-tight">
-        <div class="ck-section-header">
+    <ObservabilitySessionLayout.session
+      flash={@flash}
+      current_path={"/observability/sessions/#{@run.session.id}"}
+      session_id={@run.session.id}
+      session_title={@run.session.title}
+    >
+      <section
+        id="observability-run-page"
+        class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 space-y-5"
+      >
+        <div class="flex items-start justify-between gap-4 flex-wrap">
           <div>
-            <p class="ck-kicker">Session run observability</p>
-            <h1 class="ck-section-title">{@run.session.title}</h1>
-            <p class="ck-lead ck-lead-tight">{@run.session.objective}</p>
+            <h1 class="text-xl font-semibold text-[var(--ck-lime)]">{@run.session.objective}</h1>
+            <p class="text-[var(--ck-muted)] text-sm mt-1">
+              Run health and governed activity for this session.
+            </p>
           </div>
-          <div class="ck-badge-stack">
+          <div class="flex items-center gap-3 shrink-0">
             <span class={obs_health_pill_class(@run.health.status)}>{@run.health.status}</span>
-            <span class="ck-pill ck-pill-neutral">session ##{@run.session.id}</span>
-            <.link navigate={~p"/missions/#{@run.session.id}"} class="ck-link">Open mission</.link>
-            <.link
-              id="observability-export-json"
-              href={~p"/observability/sessions/#{@run.session.id}/export.json"}
-              class="ck-link"
-            >
-              Export JSON
-            </.link>
-            <.link
-              id="observability-open-problems"
-              navigate={~p"/observability/problems"}
-              class="ck-link"
-            >
-              Open problems
-            </.link>
-            <.link
-              id="observability-open-timeline"
-              navigate={~p"/observability/sessions/#{@run.session.id}/timeline"}
-              class="ck-link"
-            >
-              Timeline
-            </.link>
-            <.link
-              id="observability-open-memory"
-              navigate={~p"/observability/sessions/#{@run.session.id}/memory"}
-              class="ck-link"
-            >
-              Memory
-            </.link>
+            <span class={neutral_pill_class()}>session ##{@run.session.id}</span>
           </div>
         </div>
 
-        <div class="ck-stat-grid">
-          <div id="observability-health-card" class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Health</p>
-            <strong>{@run.health.label}</strong>
-            <ul class="ck-mini-list" style="margin-top: 0.75rem;">
+        <CommandPill.command_pill command={"controlkeel obs run #{@run.session.id}"} />
+
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div
+            id="observability-health-card"
+            class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-2"
+          >
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Health</p>
+            <p class="text-2xl font-semibold text-[var(--ck-text)]">{@run.health.label}</p>
+            <ul class="list-disc pl-5">
               <%= for reason <- @run.health.reasons do %>
-                <li>{reason}</li>
+                <li class="text-[var(--ck-muted)] text-xs leading-relaxed">{reason}</li>
               <% end %>
             </ul>
           </div>
 
-          <div id="observability-costs" class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Budget</p>
-            <strong>{@run.budget["decision"] || "unknown"}</strong>
-            <p class="ck-note">
+          <div
+            id="observability-costs"
+            class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+          >
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Budget</p>
+            <p class="text-2xl font-semibold text-[var(--ck-text)]">
+              {@run.budget["decision"] || "unknown"}
+            </p>
+            <p class="text-[var(--ck-muted)] text-xs">
               {format_currency(@run.budget["spent_cents"] || 0)} / {format_currency(
                 @run.budget["session_budget_cents"] || 0
               )} used
             </p>
-            <p class="ck-note">
+            <p class="text-[var(--ck-muted)] text-xs">
               Rolling 24h: {format_currency(@run.budget["rolling_24h_spend_cents"] || 0)} / {format_currency(
                 @run.budget["daily_budget_cents"] || 0
               )}
             </p>
           </div>
 
-          <div id="observability-findings" class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Findings</p>
-            <strong>{@run.findings.active} active / {@run.findings.total} total</strong>
-            <p class="ck-note">
+          <div
+            id="observability-findings"
+            class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+          >
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Findings</p>
+            <p class="text-2xl font-semibold text-[var(--ck-text)]">
+              {@run.findings.active} active / {@run.findings.total} total
+            </p>
+            <p class="text-[var(--ck-muted)] text-xs">
               {@run.findings.critical} critical · {@run.findings.high} high · {@run.findings.blocked} blocked
             </p>
-            <.link navigate={~p"/findings"} class="ck-link">Open findings</.link>
-          </div>
-
-          <div id="observability-gates" class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Gates</p>
-            <strong>{@run.gates.pending_reviews} pending</strong>
-            <p class="ck-note">{@run.gates.total_reviews} total review gates</p>
-          </div>
-        </div>
-
-        <div class="ck-grid ck-grid-dashboard">
-          <div id="observability-timeline" class="ck-card">
-            <p class="ck-mini-label">Timeline</p>
-            <%= if @run.timeline.recent == [] do %>
-              <p class="ck-note">No timeline events recorded yet.</p>
-            <% else %>
-              <ul class="ck-mini-list">
-                <%= for event <- @run.timeline.recent do %>
-                  <li>
-                    <strong>{event.event_type || "event"}</strong>
-                    <p class="ck-note">
-                      {event.summary || "No summary"} · {event.actor || "unknown"} · {event.inserted_at ||
-                        "unknown time"}
-                    </p>
-                  </li>
-                <% end %>
-              </ul>
-            <% end %>
-            <.link navigate={~p"/observability/sessions/#{@run.session.id}/timeline"} class="ck-link">
-              Open full timeline
+            <.link
+              navigate={~p"/findings"}
+              class="text-sm text-[var(--ck-lime)] font-semibold hover:opacity-80 transition-opacity"
+            >
+              Open findings →
             </.link>
           </div>
 
-          <div class="ck-side-stack">
-            <div id="observability-tools" class="ck-card">
-              <p class="ck-mini-label">Hosts, models, and tools</p>
-              <div class="ck-brief-grid">
-                <div>
-                  <h3>Invocations</h3>
-                  <p class="ck-note">{@run.hosts_models_tools.invocations}</p>
+          <div
+            id="observability-gates"
+            class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+          >
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Gates</p>
+            <p class="text-2xl font-semibold text-[var(--ck-text)]">
+              {@run.gates.pending_reviews} pending
+            </p>
+            <p class="text-[var(--ck-muted)] text-xs">
+              {@run.gates.total_reviews} total review gates
+            </p>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div
+            id="observability-timeline"
+            class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-3"
+          >
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Timeline</p>
+            <%= if @run.timeline.recent == [] do %>
+              <p class="text-[var(--ck-muted)] text-sm">No timeline events recorded yet.</p>
+            <% else %>
+              <div class="space-y-2 max-h-80 overflow-y-auto pr-1">
+                <%= for event <- @run.timeline.recent do %>
+                  <div class="rounded-lg px-3 py-2 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.02)]">
+                    <div class="flex items-start justify-between gap-3">
+                      <p class="text-sm font-medium text-[var(--ck-text)]">
+                        {event.event_type || "event"}
+                      </p>
+                      <time class="text-[10px] font-mono text-[var(--ck-muted)] whitespace-nowrap shrink-0">
+                        {format_datetime(event.inserted_at)}
+                      </time>
+                    </div>
+                    <p class="text-[var(--ck-muted)] text-xs mt-1">
+                      {event.summary || "No summary"} · {event.actor || "unknown"}
+                    </p>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+            <.link
+              navigate={~p"/observability/sessions/#{@run.session.id}/timeline"}
+              class="text-sm text-[var(--ck-lime)] font-semibold hover:opacity-80 transition-opacity"
+            >
+              Open full timeline →
+            </.link>
+          </div>
+
+          <div class="space-y-4">
+            <div
+              id="observability-tools"
+              class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-3"
+            >
+              <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                Hosts, models, and tools
+              </p>
+              <div class="grid grid-cols-2 gap-3">
+                <div class="space-y-1">
+                  <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                    Invocations
+                  </p>
+                  <p class="text-base font-semibold text-[var(--ck-text)]">
+                    {@run.hosts_models_tools.invocations}
+                  </p>
                 </div>
-                <div>
-                  <h3>Estimated cost</h3>
-                  <p class="ck-note">
+                <div class="space-y-1">
+                  <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                    Estimated cost
+                  </p>
+                  <p class="text-base font-semibold text-[var(--ck-text)]">
                     {format_currency(@run.hosts_models_tools.estimated_cost_cents)}
                   </p>
                 </div>
-                <div>
-                  <h3>Sources</h3>
-                  <p class="ck-note">{format_frequency(@run.hosts_models_tools.by_source)}</p>
+                <div class="space-y-1">
+                  <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Sources</p>
+                  <p class="text-[var(--ck-text)] text-xs">
+                    {format_frequency(@run.hosts_models_tools.by_source)}
+                  </p>
                 </div>
-                <div>
-                  <h3>Models</h3>
-                  <p class="ck-note">{format_frequency(@run.hosts_models_tools.by_model)}</p>
+                <div class="space-y-1">
+                  <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Models</p>
+                  <p class="text-[var(--ck-text)] text-xs">
+                    {format_frequency(@run.hosts_models_tools.by_model)}
+                  </p>
                 </div>
-                <div>
-                  <h3>Tools</h3>
-                  <p class="ck-note">{format_frequency(@run.hosts_models_tools.by_tool)}</p>
+                <div class="space-y-1">
+                  <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Tools</p>
+                  <p class="text-[var(--ck-text)] text-xs">
+                    {format_frequency(@run.hosts_models_tools.by_tool)}
+                  </p>
                 </div>
               </div>
             </div>
 
-            <div id="observability-memory-proof" class="ck-card">
-              <p class="ck-mini-label">Context, memory, and proof</p>
-              <div class="ck-brief-grid">
-                <div>
-                  <h3>Memory records</h3>
-                  <p class="ck-note">{@run.memory.records}</p>
+            <div
+              id="observability-memory-proof"
+              class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-3"
+            >
+              <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                Context, memory, and proof
+              </p>
+              <div class="grid grid-cols-3 gap-3">
+                <div class="space-y-1">
+                  <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Memory</p>
+                  <p class="text-base font-semibold text-[var(--ck-text)]">{@run.memory.records}</p>
                   <.link
                     navigate={~p"/observability/sessions/#{@run.session.id}/memory"}
-                    class="ck-link"
+                    class="text-xs text-[var(--ck-lime)] font-semibold hover:opacity-80 transition-opacity"
                   >
-                    Open memory
+                    Open →
                   </.link>
                 </div>
-                <div>
-                  <h3>Proof bundles</h3>
-                  <p class="ck-note">{@run.proofs.count}</p>
-                  <.link navigate={~p"/proofs"} class="ck-link">Open proofs</.link>
+                <div class="space-y-1">
+                  <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Proofs</p>
+                  <p class="text-base font-semibold text-[var(--ck-text)]">{@run.proofs.count}</p>
+                  <.link
+                    navigate={~p"/proofs"}
+                    class="text-xs text-[var(--ck-lime)] font-semibold hover:opacity-80 transition-opacity"
+                  >
+                    Open →
+                  </.link>
                 </div>
-                <div>
-                  <h3>Active tasks</h3>
-                  <p class="ck-note">{@run.tasks.active} / {@run.tasks.total}</p>
+                <div class="space-y-1">
+                  <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Tasks</p>
+                  <p class="text-base font-semibold text-[var(--ck-text)]">
+                    {@run.tasks.active}/{@run.tasks.total}
+                  </p>
                 </div>
               </div>
             </div>
           </div>
         </div>
 
-        <div id="observability-recommendations" class="ck-card">
-          <p class="ck-mini-label">Recommendations</p>
-          <ul class="ck-mini-list">
-            <%= for recommendation <- @run.recommendations do %>
-              <li>{recommendation}</li>
-            <% end %>
-          </ul>
-        </div>
+        <%= if @run.recommendations != [] do %>
+          <div id="observability-recommendations" class="space-y-2">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Recommendations
+            </p>
+            <ul class="list-disc pl-5">
+              <%= for recommendation <- @run.recommendations do %>
+                <li class="text-[var(--ck-muted)] text-sm leading-relaxed">{recommendation}</li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
 
-        <div id="observability-telemetry-export" class="ck-card">
-          <p class="ck-mini-label">Trace/proof export</p>
-          <p class="ck-note">
-            Download the local observability envelope for this run, then preview it locally with <code>controlkeel obs import &lt;file&gt; --dry-run</code>.
+        <div
+          id="observability-telemetry-export"
+          class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-2"
+        >
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Trace/proof export
+          </p>
+          <p class="text-[var(--ck-muted)] text-sm leading-relaxed">
+            Download the local observability envelope for this run, then preview it locally with <code class="text-[var(--ck-lime)] font-semibold ml-2 text-xs">
+              controlkeel obs import &lt;file&gt; --dry-run
+            </code>.
           </p>
           <.link
             href={~p"/observability/sessions/#{@run.session.id}/export.json"}
-            class="ck-link"
+            class="text-sm text-[var(--ck-lime)] font-semibold hover:opacity-80 transition-opacity"
           >
-            Download JSON envelope
+            Download JSON envelope →
           </.link>
         </div>
 
-        <div class="ck-grid ck-grid-dashboard">
-          <div class="ck-card">
-            <p class="ck-mini-label">Recent findings</p>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-2">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Recent findings
+            </p>
             <%= if @run.findings.recent == [] do %>
-              <p class="ck-note">No findings recorded yet.</p>
+              <p class="text-[var(--ck-muted)] text-sm">No findings recorded yet.</p>
             <% else %>
-              <ul class="ck-mini-list">
+              <div class="space-y-2">
                 <%= for finding <- @run.findings.recent do %>
-                  <li>
-                    <strong>{finding.title}</strong>
-                    <p class="ck-note">
+                  <div class="rounded-lg px-3 py-2 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.02)]">
+                    <p class="text-sm font-medium text-[var(--ck-text)]">{finding.title}</p>
+                    <p class="text-[var(--ck-muted)] text-xs">
                       {finding.severity} / {finding.status} · {finding.rule_id}
                     </p>
-                  </li>
+                  </div>
                 <% end %>
-              </ul>
+              </div>
             <% end %>
           </div>
 
-          <div class="ck-card">
-            <p class="ck-mini-label">Recent review gates</p>
+          <div class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-2">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Recent review gates
+            </p>
             <%= if @run.gates.latest == [] do %>
-              <p class="ck-note">No review gates recorded yet.</p>
+              <p class="text-[var(--ck-muted)] text-sm">No review gates recorded yet.</p>
             <% else %>
-              <ul class="ck-mini-list">
+              <div class="space-y-2">
                 <%= for review <- @run.gates.latest do %>
-                  <li>
-                    <.link navigate={~p"/reviews/#{review.id}"} class="ck-link">
+                  <div class="rounded-lg px-3 py-2 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.02)]">
+                    <.link
+                      navigate={~p"/reviews/#{review.id}"}
+                      class="text-sm font-medium text-[var(--ck-lime)] hover:opacity-80 transition-opacity"
+                    >
                       {review.title}
                     </.link>
-                    <p class="ck-note">{review.review_type} / {review.status}</p>
-                  </li>
+                    <p class="text-[var(--ck-muted)] text-xs">
+                      {review.review_type} / {review.status}
+                    </p>
+                  </div>
                 <% end %>
-              </ul>
+              </div>
             <% end %>
           </div>
         </div>
       </section>
-    </Layouts.app>
+    </ObservabilitySessionLayout.session>
     """
   end
 
-  defp obs_health_pill_class("red"), do: "ck-pill ck-pill-critical"
-  defp obs_health_pill_class("yellow"), do: "ck-pill ck-pill-warning"
-  defp obs_health_pill_class(_status), do: "ck-pill ck-pill-low"
+  defp obs_health_pill_class("red"),
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,107,107,0.1)] text-[#ff6b6b]"
+
+  defp obs_health_pill_class("yellow"),
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,207,107,0.1)] text-[#ffcf6b]"
+
+  defp obs_health_pill_class(_status),
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]"
+
+  defp neutral_pill_class,
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 
   defp format_currency(cents) when is_integer(cents), do: cents |> Kernel./(100) |> Float.round(2)
   defp format_currency(_cents), do: 0.0
-
   defp format_frequency(map) when map == %{}, do: "none"
 
   defp format_frequency(map) when is_map(map) do

--- a/lib/controlkeel_web/live/observability_live.ex
+++ b/lib/controlkeel_web/live/observability_live.ex
@@ -353,11 +353,7 @@ defmodule ControlKeelWeb.ObservabilityLive do
     do:
       "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]"
 
-  defp neutral_pill_class,
-    do:
-      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
-
-  defp format_currency(cents) when is_integer(cents), do: cents |> Kernel./(100) |> Float.round(2)
+  defp format_currency(cents) when is_integer(cents), do: (cents / 100) |> Float.round(2)
   defp format_currency(_cents), do: 0.0
   defp format_frequency(map) when map == %{}, do: "none"
 

--- a/lib/controlkeel_web/live/observability_memory_live.ex
+++ b/lib/controlkeel_web/live/observability_memory_live.ex
@@ -152,10 +152,6 @@ defmodule ControlKeelWeb.ObservabilityMemoryLive do
     """
   end
 
-  defp neutral_pill_class,
-    do:
-      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
-
   defp format_frequency(map) when map == %{}, do: "none"
 
   defp format_frequency(map) when is_map(map) do

--- a/lib/controlkeel_web/live/observability_memory_live.ex
+++ b/lib/controlkeel_web/live/observability_memory_live.ex
@@ -2,6 +2,9 @@ defmodule ControlKeelWeb.ObservabilityMemoryLive do
   use ControlKeelWeb, :live_view
 
   alias ControlKeel.Observability
+  alias ControlKeelWeb.CommandPill
+
+  on_mount ControlKeelWeb.CommandPill
 
   @impl true
   def mount(%{"id" => id}, _session, socket) do
@@ -23,96 +26,131 @@ defmodule ControlKeelWeb.ObservabilityMemoryLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash}>
-      <section id="observability-memory-page" class="ck-shell ck-shell-tight">
-        <div class="ck-section-header">
+    <ObservabilitySessionLayout.session
+      flash={@flash}
+      current_path={"/observability/sessions/#{@memory_context.session.id}/memory"}
+      session_id={@memory_context.session.id}
+      session_title={@memory_context.session.title}
+    >
+      <section
+        id="observability-memory-page"
+        class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 space-y-5"
+      >
+        <div class="flex items-start justify-between gap-4">
           <div>
-            <p class="ck-kicker">Observability</p>
-            <h1 class="ck-section-title">Context and memory</h1>
-            <p class="ck-lead ck-lead-tight">
+            <h1 class="text-xl font-semibold text-[var(--ck-lime)]">Context and memory</h1>
+            <p class="text-[var(--ck-muted)] text-sm mt-1">
               Summary-only memory and context posture for {@memory_context.session.title}.
             </p>
           </div>
-          <div class="ck-badge-stack">
-            <span id="observability-memory-total" class="ck-pill ck-pill-neutral">
+          <div class="flex items-center gap-3 shrink-0">
+            <span id="observability-memory-total" class={neutral_pill_class()}>
               {@memory_context.memory.active} active memory
             </span>
-            <.link
-              navigate={~p"/observability/sessions/#{@memory_context.session.id}"}
-              class="ck-link"
-            >
-              Run
-            </.link>
-            <.link navigate={~p"/observability/memory-quality"} class="ck-link">Memory quality</.link>
-            <.link navigate={~p"/observability"} class="ck-link">Overview</.link>
           </div>
         </div>
 
-        <div id="observability-memory-summary" class="ck-stat-grid">
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Memory</p>
-            <strong>{@memory_context.memory.active} active</strong>
-            <p class="ck-note">
+        <CommandPill.command_pill command={"controlkeel obs memory #{@memory_context.session.id}"} />
+
+        <div id="observability-memory-summary" class="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1">
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Memory</p>
+            <p class="text-2xl font-semibold text-[var(--ck-text)]">
+              {@memory_context.memory.active} active
+            </p>
+            <p class="text-[var(--ck-muted)] text-xs">
               {@memory_context.memory.archived} archived / {@memory_context.memory.count} recent
             </p>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Context</p>
-            <strong>{@memory_context.context.tasks} task(s)</strong>
-            <p class="ck-note">
+          <div class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1">
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Context</p>
+            <p class="text-2xl font-semibold text-[var(--ck-text)]">
+              {@memory_context.context.tasks} task(s)
+            </p>
+            <p class="text-[var(--ck-muted)] text-xs">
               {@memory_context.context.findings} finding(s), {@memory_context.context.reviews} review(s)
             </p>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Types</p>
-            <strong>{map_size(@memory_context.memory.by_type)}</strong>
-            <p class="ck-note">{format_frequency(@memory_context.memory.by_type)}</p>
+          <div class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1">
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Types</p>
+            <p class="text-2xl font-semibold text-[var(--ck-text)]">
+              {map_size(@memory_context.memory.by_type)}
+            </p>
+            <p class="text-[var(--ck-muted)] text-xs">
+              {format_frequency(@memory_context.memory.by_type)}
+            </p>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Sources</p>
-            <strong>{map_size(@memory_context.memory.by_source)}</strong>
-            <p class="ck-note">{format_frequency(@memory_context.memory.by_source)}</p>
+          <div class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1">
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Sources</p>
+            <p class="text-2xl font-semibold text-[var(--ck-text)]">
+              {map_size(@memory_context.memory.by_source)}
+            </p>
+            <p class="text-[var(--ck-muted)] text-xs">
+              {format_frequency(@memory_context.memory.by_source)}
+            </p>
           </div>
         </div>
 
-        <div id="observability-memory-recommendations" class="ck-card">
-          <p class="ck-mini-label">Recommended next actions</p>
-          <ul class="ck-mini-list">
-            <%= for recommendation <- @memory_context.recommendations do %>
-              <li>{recommendation}</li>
-            <% end %>
-          </ul>
-        </div>
-
-        <div id="observability-memory-records" class="ck-card">
-          <%= if @memory_context.memory.recent == [] do %>
-            <p class="ck-note">No memory records are available for this session.</p>
-          <% else %>
-            <ul class="ck-mini-list">
-              <%= for record <- @memory_context.memory.recent do %>
-                <li id={"observability-memory-record-#{record.id}"}>
-                  <div class="ck-card-header">
-                    <div>
-                      <p class="ck-mini-label">{record.record_type}</p>
-                      <strong>{record.title}</strong>
-                    </div>
-                    <span class="ck-pill ck-pill-neutral">
-                      {if record.archived, do: "archived", else: "active"}
-                    </span>
-                  </div>
-                  <p>{record.summary}</p>
-                  <p class="ck-note">
-                    Source: {record.source_type || "unknown"} · Tags: {Enum.join(record.tags, ", ")}
-                  </p>
-                </li>
+        <%= if @memory_context.recommendations != [] do %>
+          <div id="observability-memory-recommendations" class="space-y-2">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Recommended next actions
+            </p>
+            <ul class="list-disc pl-5">
+              <%= for recommendation <- @memory_context.recommendations do %>
+                <li class="text-[var(--ck-muted)] text-sm leading-relaxed">{recommendation}</li>
               <% end %>
             </ul>
+          </div>
+        <% end %>
+
+        <div id="observability-memory-records" class="space-y-3">
+          <div class="flex items-center justify-between gap-4">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Recent memory records
+            </p>
+            <.link
+              navigate={~p"/observability/memory-quality"}
+              class="text-sm text-[var(--ck-lime)] font-semibold hover:opacity-80 transition-opacity"
+            >
+              Memory quality →
+            </.link>
+          </div>
+          <%= if @memory_context.memory.recent == [] do %>
+            <p class="text-[var(--ck-muted)] text-sm">No memory records are available for this session.</p>
+          <% else %>
+            <%= for record <- @memory_context.memory.recent do %>
+              <div
+                id={"observability-memory-record-#{record.id}"}
+                class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+              >
+                <div class="flex items-center justify-between gap-4">
+                  <div>
+                    <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                      {record.record_type}
+                    </p>
+                    <p class="text-sm font-semibold text-[var(--ck-text)]">{record.title}</p>
+                  </div>
+                  <span class={neutral_pill_class()}>
+                    {if record.archived, do: "archived", else: "active"}
+                  </span>
+                </div>
+                <p class="text-sm text-[var(--ck-text)] leading-relaxed">{record.summary}</p>
+                <p class="text-[var(--ck-muted)] text-xs">
+                  Source: {record.source_type || "unknown"} · Tags: {Enum.join(record.tags, ", ")}
+                </p>
+              </div>
+            <% end %>
           <% end %>
         </div>
       </section>
-    </Layouts.app>
+    </ObservabilitySessionLayout.session>
     """
   end
+
+  defp neutral_pill_class,
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 
   defp format_frequency(map) when map == %{}, do: "none"
 

--- a/lib/controlkeel_web/live/observability_memory_live.ex
+++ b/lib/controlkeel_web/live/observability_memory_live.ex
@@ -116,32 +116,36 @@ defmodule ControlKeelWeb.ObservabilityMemoryLive do
               Memory quality →
             </.link>
           </div>
-          <%= if @memory_context.memory.recent == [] do %>
-            <p class="text-[var(--ck-muted)] text-sm">No memory records are available for this session.</p>
-          <% else %>
-            <%= for record <- @memory_context.memory.recent do %>
-              <div
-                id={"observability-memory-record-#{record.id}"}
-                class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
-              >
-                <div class="flex items-center justify-between gap-4">
-                  <div>
-                    <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
-                      {record.record_type}
-                    </p>
-                    <p class="text-sm font-semibold text-[var(--ck-text)]">{record.title}</p>
+          <div class="space-y-3 max-h-[550px] overflow-y-auto pr-1">
+            <%= if @memory_context.memory.recent == [] do %>
+              <p class="text-[var(--ck-muted)] text-sm">
+                No memory records are available for this session.
+              </p>
+            <% else %>
+              <%= for record <- @memory_context.memory.recent do %>
+                <div
+                  id={"observability-memory-record-#{record.id}"}
+                  class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+                >
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                        {record.record_type}
+                      </p>
+                      <p class="text-sm font-semibold text-[var(--ck-text)]">{record.title}</p>
+                    </div>
+                    <span class={neutral_pill_class()}>
+                      {if record.archived, do: "archived", else: "active"}
+                    </span>
                   </div>
-                  <span class={neutral_pill_class()}>
-                    {if record.archived, do: "archived", else: "active"}
-                  </span>
+                  <p class="text-sm text-[var(--ck-text)] leading-relaxed">{record.summary}</p>
+                  <p class="text-[var(--ck-muted)] text-xs">
+                    Source: {record.source_type || "unknown"} · Tags: {Enum.join(record.tags, ", ")}
+                  </p>
                 </div>
-                <p class="text-sm text-[var(--ck-text)] leading-relaxed">{record.summary}</p>
-                <p class="text-[var(--ck-muted)] text-xs">
-                  Source: {record.source_type || "unknown"} · Tags: {Enum.join(record.tags, ", ")}
-                </p>
-              </div>
+              <% end %>
             <% end %>
-          <% end %>
+          </div>
         </div>
       </section>
     </ObservabilitySessionLayout.session>

--- a/lib/controlkeel_web/live/observability_persisted_evals_live.ex
+++ b/lib/controlkeel_web/live/observability_persisted_evals_live.ex
@@ -127,7 +127,4 @@ defmodule ControlKeelWeb.ObservabilityPersistedEvalsLive do
     |> Enum.join(", ")
   end
 
-  defp neutral_pill_class,
-    do:
-      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 end

--- a/lib/controlkeel_web/live/observability_persisted_evals_live.ex
+++ b/lib/controlkeel_web/live/observability_persisted_evals_live.ex
@@ -49,7 +49,9 @@ defmodule ControlKeelWeb.ObservabilityPersistedEvalsLive do
             class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
           >
             <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Status</p>
-            <p class="text-lg font-semibold text-[var(--ck-text)]">{format_frequency(@saved.by_status)}</p>
+            <p class="text-lg font-semibold text-[var(--ck-text)]">
+              {format_frequency(@saved.by_status)}
+            </p>
           </div>
           <div
             id="observability-persisted-evals-priority"
@@ -99,7 +101,9 @@ defmodule ControlKeelWeb.ObservabilityPersistedEvalsLive do
                 <p class="text-[var(--ck-muted)] text-xs">
                   {candidate.rule_id} · {candidate.priority} · human gate {candidate.human_gate_required}
                 </p>
-                <p class="text-sm text-[var(--ck-text)] leading-relaxed">{candidate.evidence_summary}</p>
+                <p class="text-sm text-[var(--ck-text)] leading-relaxed">
+                  {candidate.evidence_summary}
+                </p>
                 <p class="text-[var(--ck-muted)] text-xs">Next: {candidate.suggested_action}</p>
                 <p class="text-[var(--ck-muted)] text-xs">
                   Benchmark hint: {candidate.benchmark_hint || "none"}

--- a/lib/controlkeel_web/live/observability_persisted_evals_live.ex
+++ b/lib/controlkeel_web/live/observability_persisted_evals_live.ex
@@ -3,6 +3,9 @@ defmodule ControlKeelWeb.ObservabilityPersistedEvalsLive do
 
   alias ControlKeel.Mission
   alias ControlKeel.Observability
+  alias ControlKeelWeb.CommandPill
+
+  on_mount ControlKeelWeb.CommandPill
 
   @impl true
   def mount(_params, _session, socket) do
@@ -19,75 +22,94 @@ defmodule ControlKeelWeb.ObservabilityPersistedEvalsLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash}>
-      <section id="observability-persisted-evals-page" class="ck-shell ck-shell-tight">
-        <div class="ck-section-header">
+    <ObservabilityLayout.observability flash={@flash} current_path="/observability/evals/persisted">
+      <section
+        id="observability-persisted-evals-page"
+        class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 space-y-5"
+      >
+        <div class="flex items-start justify-between gap-4">
           <div>
-            <p class="ck-kicker">Observability</p>
-            <h1 class="ck-section-title">Saved eval candidates</h1>
-            <p class="ck-lead ck-lead-tight">
+            <h1 class="text-xl font-semibold text-[var(--ck-lime)]">Saved eval candidates</h1>
+            <p class="text-[var(--ck-muted)] text-sm mt-1">
               Local, human-gated candidate records saved from grouped problem feedback loops.
             </p>
           </div>
-          <div class="ck-badge-stack">
-            <span id="observability-persisted-evals-count" class="ck-pill ck-pill-neutral">
+          <div class="flex items-center gap-3 shrink-0">
+            <span id="observability-persisted-evals-count" class={neutral_pill_class()}>
               {@saved.count} saved
             </span>
-            <.link navigate={~p"/observability/evals"} class="ck-link">Advisory evals</.link>
-            <.link navigate={~p"/observability/benchmarks/drafts"} class="ck-link">
-              Benchmark drafts
-            </.link>
-            <.link navigate={~p"/observability"} class="ck-link">Overview</.link>
           </div>
         </div>
 
-        <div class="ck-stat-grid">
-          <div id="observability-persisted-evals-status" class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Status</p>
-            <strong>{format_frequency(@saved.by_status)}</strong>
+        <CommandPill.command_pill command="controlkeel obs evals persisted" />
+
+        <div class="grid grid-cols-2 gap-4">
+          <div
+            id="observability-persisted-evals-status"
+            class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+          >
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Status</p>
+            <p class="text-lg font-semibold text-[var(--ck-text)]">{format_frequency(@saved.by_status)}</p>
           </div>
-          <div id="observability-persisted-evals-priority" class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Priority</p>
-            <strong>{format_frequency(@saved.by_priority)}</strong>
+          <div
+            id="observability-persisted-evals-priority"
+            class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+          >
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Priority</p>
+            <p class="text-lg font-semibold text-[var(--ck-text)]">
+              {format_frequency(@saved.by_priority)}
+            </p>
           </div>
         </div>
 
-        <div id="observability-persisted-evals-recommendations" class="ck-card">
-          <p class="ck-mini-label">Recommendations</p>
-          <ul class="ck-mini-list">
-            <%= for recommendation <- @saved.recommendations do %>
-              <li>{recommendation}</li>
-            <% end %>
-          </ul>
-        </div>
-
-        <div id="observability-persisted-evals-list" class="ck-card">
-          <%= if @saved.candidates == [] do %>
-            <p class="ck-note">No saved eval candidates yet.</p>
-          <% else %>
-            <ul class="ck-mini-list">
-              <%= for candidate <- @saved.candidates do %>
-                <li id={"observability-persisted-eval-#{candidate.id}"}>
-                  <div class="ck-card-header">
-                    <div>
-                      <p class="ck-mini-label">{candidate.category || "uncategorized"}</p>
-                      <strong>{candidate.title}</strong>
-                    </div>
-                    <span class="ck-pill ck-pill-neutral">{candidate.status}</span>
-                  </div>
-                  <p class="ck-note">
-                    {candidate.rule_id} · {candidate.priority} · human gate {candidate.human_gate_required}
-                  </p>
-                  <p>{candidate.evidence_summary}</p>
-                  <p class="ck-note">Next: {candidate.suggested_action}</p>
-                  <p class="ck-note">Benchmark hint: {candidate.benchmark_hint || "none"}</p>
-                </li>
+        <%= if @saved.recommendations != [] do %>
+          <div class="space-y-2">
+            <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+              Recommendations
+            </p>
+            <ul class="list-disc pl-5">
+              <%= for recommendation <- @saved.recommendations do %>
+                <li class="text-[var(--ck-muted)] text-sm leading-relaxed">{recommendation}</li>
               <% end %>
             </ul>
+          </div>
+        <% end %>
+
+        <div id="observability-persisted-evals-list" class="space-y-3">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Saved candidates
+          </p>
+          <%= if @saved.candidates == [] do %>
+            <p class="text-[var(--ck-muted)] text-sm">No saved eval candidates yet.</p>
+          <% else %>
+            <%= for candidate <- @saved.candidates do %>
+              <div
+                id={"observability-persisted-eval-#{candidate.id}"}
+                class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-2"
+              >
+                <div class="flex items-center justify-between gap-4">
+                  <div>
+                    <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                      {candidate.category || "uncategorized"}
+                    </p>
+                    <p class="text-sm font-semibold text-[var(--ck-text)]">{candidate.title}</p>
+                  </div>
+                  <span class={neutral_pill_class()}>{candidate.status}</span>
+                </div>
+                <p class="text-[var(--ck-muted)] text-xs">
+                  {candidate.rule_id} · {candidate.priority} · human gate {candidate.human_gate_required}
+                </p>
+                <p class="text-sm text-[var(--ck-text)] leading-relaxed">{candidate.evidence_summary}</p>
+                <p class="text-[var(--ck-muted)] text-xs">Next: {candidate.suggested_action}</p>
+                <p class="text-[var(--ck-muted)] text-xs">
+                  Benchmark hint: {candidate.benchmark_hint || "none"}
+                </p>
+              </div>
+            <% end %>
           <% end %>
         </div>
       </section>
-    </Layouts.app>
+    </ObservabilityLayout.observability>
     """
   end
 
@@ -100,4 +122,8 @@ defmodule ControlKeelWeb.ObservabilityPersistedEvalsLive do
     |> Enum.map(fn {key, count} -> "#{key}: #{count}" end)
     |> Enum.join(", ")
   end
+
+  defp neutral_pill_class,
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 end

--- a/lib/controlkeel_web/live/observability_problems_live.ex
+++ b/lib/controlkeel_web/live/observability_problems_live.ex
@@ -235,20 +235,4 @@ defmodule ControlKeelWeb.ObservabilityProblemsLive do
     |> String.replace(~r/[^a-zA-Z0-9_-]+/, "-")
     |> String.trim("-")
   end
-
-  defp format_datetime(nil), do: "unknown"
-  defp format_datetime(""), do: "unknown"
-
-  defp format_datetime(%DateTime{} = dt) do
-    Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S UTC")
-  end
-
-  defp format_datetime(value) when is_binary(value) do
-    case DateTime.from_iso8601(value) do
-      {:ok, dt, _offset} -> Calendar.strftime(dt, "%Y-%m-%d %H:%M:%S UTC")
-      _ -> value
-    end
-  end
-
-  defp format_datetime(value), do: to_string(value)
 end

--- a/lib/controlkeel_web/live/observability_regressions_live.ex
+++ b/lib/controlkeel_web/live/observability_regressions_live.ex
@@ -124,7 +124,7 @@ defmodule ControlKeelWeb.ObservabilityRegressionsLive do
                   Catch rate {format_rate(run.catch_rate)} · {run.caught_count}/{run.total_scenarios} scenario(s) · {run.result_count} result(s)
                 </p>
                 <div class="flex items-center gap-4 text-xs">
-                  <p class="text-[var(--ck-muted)]">{run.inserted_at || "unknown"}</p>
+                  <p class="text-[var(--ck-muted)]">{format_datetime(run.inserted_at, "unknown")}</p>
                   <.link
                     navigate={~p"/benchmarks/runs/#{run.id}"}
                     class="text-sm text-[var(--ck-lime)] font-semibold hover:opacity-80 transition-opacity"

--- a/lib/controlkeel_web/live/observability_timeline_live.ex
+++ b/lib/controlkeel_web/live/observability_timeline_live.ex
@@ -110,10 +110,6 @@ defmodule ControlKeelWeb.ObservabilityTimelineLive do
     """
   end
 
-  defp neutral_pill_class,
-    do:
-      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
-
   defp format_frequency(map) when map == %{}, do: "none"
 
   defp format_frequency(map) when is_map(map) do

--- a/lib/controlkeel_web/live/observability_timeline_live.ex
+++ b/lib/controlkeel_web/live/observability_timeline_live.ex
@@ -76,30 +76,34 @@ defmodule ControlKeelWeb.ObservabilityTimelineLive do
           <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
             Event stream
           </p>
-          <%= if @timeline.events == [] do %>
-            <p class="text-[var(--ck-muted)] text-sm">No timeline events recorded yet.</p>
-          <% else %>
-            <%= for event <- @timeline.events do %>
-              <div
-                id={"observability-timeline-event-#{event.id || event.event_type}"}
-                class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
-              >
-                <div class="flex items-center justify-between gap-4">
-                  <div>
-                    <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
-                      {event.actor}
-                    </p>
-                    <p class="text-sm font-semibold text-[var(--ck-text)]">{event.event_type}</p>
+          <div class="space-y-3 max-h-[550px] overflow-y-auto pr-1">
+            <%= if @timeline.events == [] do %>
+              <p class="text-[var(--ck-muted)] text-sm">No timeline events recorded yet.</p>
+            <% else %>
+              <%= for event <- @timeline.events do %>
+                <div
+                  id={"observability-timeline-event-#{event.id || event.event_type}"}
+                  class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+                >
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                        {event.actor}
+                      </p>
+                      <p class="text-sm font-semibold text-[var(--ck-text)]">{event.event_type}</p>
+                    </div>
+                    <span class={neutral_pill_class()}>
+                      {format_datetime(event.inserted_at, "unknown time")}
+                    </span>
                   </div>
-                  <span class={neutral_pill_class()}>{format_datetime(event.inserted_at, "unknown time")}</span>
+                  <p class="text-sm text-[var(--ck-text)] leading-relaxed">{event.summary}</p>
+                  <%= if event.body not in [nil, ""] do %>
+                    <p class="text-[var(--ck-muted)] text-xs">{event.body}</p>
+                  <% end %>
                 </div>
-                <p class="text-sm text-[var(--ck-text)] leading-relaxed">{event.summary}</p>
-                <%= if event.body not in [nil, ""] do %>
-                  <p class="text-[var(--ck-muted)] text-xs">{event.body}</p>
-                <% end %>
-              </div>
+              <% end %>
             <% end %>
-          <% end %>
+          </div>
         </div>
       </section>
     </ObservabilitySessionLayout.session>

--- a/lib/controlkeel_web/live/observability_timeline_live.ex
+++ b/lib/controlkeel_web/live/observability_timeline_live.ex
@@ -91,7 +91,7 @@ defmodule ControlKeelWeb.ObservabilityTimelineLive do
                     </p>
                     <p class="text-sm font-semibold text-[var(--ck-text)]">{event.event_type}</p>
                   </div>
-                  <span class={neutral_pill_class()}>{event.inserted_at || "unknown time"}</span>
+                  <span class={neutral_pill_class()}>{format_datetime(event.inserted_at, "unknown time")}</span>
                 </div>
                 <p class="text-sm text-[var(--ck-text)] leading-relaxed">{event.summary}</p>
                 <%= if event.body not in [nil, ""] do %>

--- a/lib/controlkeel_web/live/observability_timeline_live.ex
+++ b/lib/controlkeel_web/live/observability_timeline_live.ex
@@ -2,6 +2,9 @@ defmodule ControlKeelWeb.ObservabilityTimelineLive do
   use ControlKeelWeb, :live_view
 
   alias ControlKeel.Observability
+  alias ControlKeelWeb.CommandPill
+
+  on_mount ControlKeelWeb.CommandPill
 
   @impl true
   def mount(%{"id" => id}, _session, socket) do
@@ -23,72 +26,89 @@ defmodule ControlKeelWeb.ObservabilityTimelineLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.app flash={@flash}>
-      <section id="observability-timeline-page" class="ck-shell ck-shell-tight">
-        <div class="ck-section-header">
+    <ObservabilitySessionLayout.session
+      flash={@flash}
+      current_path={"/observability/sessions/#{@timeline.session.id}/timeline"}
+      session_id={@timeline.session.id}
+      session_title={@timeline.session.title}
+    >
+      <section
+        id="observability-timeline-page"
+        class="border border-[var(--ck-stroke)] rounded-[1.5rem] backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6 space-y-5"
+      >
+        <div class="flex items-start justify-between gap-4">
           <div>
-            <p class="ck-kicker">Observability</p>
-            <h1 class="ck-section-title">Timeline</h1>
-            <p class="ck-lead ck-lead-tight">
+            <h1 class="text-xl font-semibold text-[var(--ck-lime)]">Timeline</h1>
+            <p class="text-[var(--ck-muted)] text-sm mt-1">
               Recent governed events for {@timeline.session.title}.
             </p>
           </div>
-          <div class="ck-badge-stack">
-            <span id="observability-timeline-total" class="ck-pill ck-pill-neutral">
+          <div class="flex items-center gap-3 shrink-0">
+            <span id="observability-timeline-total" class={neutral_pill_class()}>
               {@timeline.count} event(s)
             </span>
-            <.link navigate={~p"/observability/sessions/#{@timeline.session.id}"} class="ck-link">
-              Run
-            </.link>
-            <.link navigate={~p"/observability"} class="ck-link">Overview</.link>
           </div>
         </div>
 
-        <div id="observability-timeline-summary" class="ck-stat-grid">
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Events</p>
-            <strong>{@timeline.count}</strong>
-            <p class="ck-note">Limit {@timeline.limit}</p>
+        <CommandPill.command_pill command={"controlkeel obs timeline #{@timeline.session.id}"} />
+
+        <div id="observability-timeline-summary" class="grid grid-cols-3 gap-4">
+          <div class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1">
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Events</p>
+            <p class="text-2xl font-semibold text-[var(--ck-text)]">{@timeline.count}</p>
+            <p class="text-[var(--ck-muted)] text-xs">Limit {@timeline.limit}</p>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Event types</p>
-            <strong>{map_size(@timeline.by_event_type)}</strong>
-            <p class="ck-note">{format_frequency(@timeline.by_event_type)}</p>
+          <div class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1">
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Event types</p>
+            <p class="text-2xl font-semibold text-[var(--ck-text)]">
+              {map_size(@timeline.by_event_type)}
+            </p>
+            <p class="text-[var(--ck-muted)] text-xs">{format_frequency(@timeline.by_event_type)}</p>
           </div>
-          <div class="ck-card ck-stat-card">
-            <p class="ck-mini-label">Actors</p>
-            <strong>{map_size(@timeline.by_actor)}</strong>
-            <p class="ck-note">{format_frequency(@timeline.by_actor)}</p>
+          <div class="rounded-xl p-4 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1">
+            <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">Actors</p>
+            <p class="text-2xl font-semibold text-[var(--ck-text)]">{map_size(@timeline.by_actor)}</p>
+            <p class="text-[var(--ck-muted)] text-xs">{format_frequency(@timeline.by_actor)}</p>
           </div>
         </div>
 
-        <div id="observability-timeline-events" class="ck-card">
+        <div id="observability-timeline-events" class="space-y-3">
+          <p class="uppercase tracking-[0.14em] text-xs text-[var(--ck-lime)] font-semibold">
+            Event stream
+          </p>
           <%= if @timeline.events == [] do %>
-            <p class="ck-note">No timeline events recorded yet.</p>
+            <p class="text-[var(--ck-muted)] text-sm">No timeline events recorded yet.</p>
           <% else %>
-            <ul class="ck-mini-list">
-              <%= for event <- @timeline.events do %>
-                <li id={"observability-timeline-event-#{event.id || event.event_type}"}>
-                  <div class="ck-card-header">
-                    <div>
-                      <p class="ck-mini-label">{event.actor}</p>
-                      <strong>{event.event_type}</strong>
-                    </div>
-                    <span class="ck-pill ck-pill-neutral">{event.inserted_at || "unknown time"}</span>
+            <%= for event <- @timeline.events do %>
+              <div
+                id={"observability-timeline-event-#{event.id || event.event_type}"}
+                class="rounded-xl px-4 py-3 border border-[var(--ck-stroke)] bg-[rgba(255,255,255,0.015)] space-y-1"
+              >
+                <div class="flex items-center justify-between gap-4">
+                  <div>
+                    <p class="text-[var(--ck-muted)] uppercase tracking-[0.1em] text-[10px]">
+                      {event.actor}
+                    </p>
+                    <p class="text-sm font-semibold text-[var(--ck-text)]">{event.event_type}</p>
                   </div>
-                  <p>{event.summary}</p>
-                  <%= if event.body not in [nil, ""] do %>
-                    <p class="ck-note">{event.body}</p>
-                  <% end %>
-                </li>
-              <% end %>
-            </ul>
+                  <span class={neutral_pill_class()}>{event.inserted_at || "unknown time"}</span>
+                </div>
+                <p class="text-sm text-[var(--ck-text)] leading-relaxed">{event.summary}</p>
+                <%= if event.body not in [nil, ""] do %>
+                  <p class="text-[var(--ck-muted)] text-xs">{event.body}</p>
+                <% end %>
+              </div>
+            <% end %>
           <% end %>
         </div>
       </section>
-    </Layouts.app>
+    </ObservabilitySessionLayout.session>
     """
   end
+
+  defp neutral_pill_class,
+    do:
+      "inline-flex items-center border border-[var(--ck-stroke)] rounded-full px-3 py-1.5 text-sm bg-[rgba(255,255,255,0.04)] text-[var(--ck-text)]"
 
   defp format_frequency(map) when map == %{}, do: "none"
 

--- a/lib/controlkeel_web/live/proof_browser_live.ex
+++ b/lib/controlkeel_web/live/proof_browser_live.ex
@@ -178,7 +178,9 @@ defmodule ControlKeelWeb.ProofBrowserLive do
               </div>
               <div>
                 <h3>Generated</h3>
-                <p class="text-[var(--ck-muted)]">{format_datetime(@proof.generated_at, "Not recorded")}</p>
+                <p class="text-[var(--ck-muted)]">
+                  {format_datetime(@proof.generated_at, "Not recorded")}
+                </p>
               </div>
               <div>
                 <h3>Open findings</h3>

--- a/lib/controlkeel_web/live/proof_browser_live.ex
+++ b/lib/controlkeel_web/live/proof_browser_live.ex
@@ -178,7 +178,7 @@ defmodule ControlKeelWeb.ProofBrowserLive do
               </div>
               <div>
                 <h3>Generated</h3>
-                <p class="text-[var(--ck-muted)]">{format_datetime(@proof.generated_at)}</p>
+                <p class="text-[var(--ck-muted)]">{format_datetime(@proof.generated_at, "Not recorded")}</p>
               </div>
               <div>
                 <h3>Open findings</h3>
@@ -907,8 +907,6 @@ defmodule ControlKeelWeb.ProofBrowserLive do
   defp format_domain_pack(nil), do: "Unknown"
   defp format_domain_pack(pack) when pack in ["baseline", "cost"], do: String.capitalize(pack)
   defp format_domain_pack(pack), do: Intent.pack_label(pack)
-  defp format_datetime(nil), do: "Not recorded"
-  defp format_datetime(value), do: Calendar.strftime(value, "%Y-%m-%d %H:%M:%S UTC")
 
   defp bundle_get(proof, keys, default \\ nil) do
     if proof, do: get_in(proof.bundle || %{}, keys) || default, else: default

--- a/test/controlkeel/observability_test.exs
+++ b/test/controlkeel/observability_test.exs
@@ -1024,6 +1024,32 @@ defmodule ControlKeel.ObservabilityTest do
     assert drafts.by_status == %{"approved" => 1}
   end
 
+  test "update_benchmark_draft_status/3 refuses drafts outside the scoped workspace" do
+    session = session_fixture()
+    other_workspace = workspace_fixture()
+    other_session = session_fixture(%{workspace: other_workspace})
+
+    finding_fixture(%{
+      session: other_session,
+      title: "Cross-workspace draft status finding",
+      severity: "high",
+      status: "open",
+      category: "security",
+      rule_id: "security.cross_workspace_draft"
+    })
+
+    assert %{stored: 1} = Observability.save_eval_candidates(workspace_id: other_session.workspace_id)
+
+    assert %{stored: 1, drafts: [draft]} =
+             Observability.generate_benchmark_drafts(workspace_id: other_session.workspace_id)
+
+    assert {:error, :forbidden} =
+             Observability.update_benchmark_draft_status(draft.id, "approved",
+               workspace_id: session.workspace_id,
+               reviewed_by: "test"
+             )
+  end
+
   test "regressions/1 warns when drafts exist but no benchmark runs close the loop" do
     session = session_fixture()
 

--- a/test/controlkeel_web/live/observability_overview_live_test.exs
+++ b/test/controlkeel_web/live/observability_overview_live_test.exs
@@ -29,6 +29,11 @@ defmodule ControlKeelWeb.ObservabilityOverviewLiveTest do
     assert html =~ "/observability/imports"
     assert html =~ "/observability/memory-quality"
     assert html =~ "/observability/trends"
+    assert html =~ "/observability/evals"
+    assert html =~ "/observability/evals/persisted"
+    assert html =~ "/observability/benchmarks/drafts"
+    assert html =~ "/observability/benchmarks/scenarios"
+    assert html =~ "/observability/benchmarks/history"
   end
 
   test "overview page scopes recent runs to the latest workspace", %{conn: conn} do


### PR DESCRIPTION
Refactor observability sub-routes: migrate session detail views to a shared `ObservabilitySessionLayout`, re-surface benchmark/eval routes in the nav, consolidate datetime formatting into a shared module, add CommandPill to all pages, and migrate remaining `ck-*` CSS to Tailwind utilities.

**Related issue: #24** 

## Changes

- **Unified navigation** — All observability LiveViews now share a single `ObservabilityLayout` component with persistent nav bar and active-link highlighting. Redundant per-page navigation links removed.
- **Nested routes re-surfaced** — `/observability/benchmarks/*` and `/observability/evals/*` added back to the nav and migrated to `ObservabilityLayout`.
- **New session layout** — `ObservabilitySessionLayout` provides a consistent tab bar (Overview / Timeline / Memory / Export JSON) for `/observability/sessions/:id` and sub-routes.
- **CommandPill** — Added to all observability pages via `on_mount` + template slot.
- **Format consolidation** — Extracted duplicated `format_datetime/1` from `observability_problems_live.ex` and `proof_browser_live.ex` into `ControlKeelWeb.FormatHelpers`, imported globally.
- **Tailwind migration** — All custom `ck-*` CSS classes replaced with Tailwind utility classes across every modified LiveView.

## Breaking Changes

None at the route level. All routes remain registered. UI-only changes; no backend, schema, or database migrations.

## Test

- `mix test`
- `mix compile --warnings-as-errors` — clean
- `mix precommit` — 2000 tests, 0 failures
- Manual smoke test — visit `/observability` and click through each nav link