### PR TITLE
fix: idempotent SQLite migrations + ck_skill_load output schema

### DIFF
--- a/lib/controlkeel/mcp/output_schemas.ex
+++ b/lib/controlkeel/mcp/output_schemas.ex
@@ -517,7 +517,7 @@ defmodule ControlKeel.MCP.OutputSchemas do
       "properties" => %{
         "name" => %{"type" => "string"},
         "content" => %{"type" => "string"},
-        "resources" => %{"type" => "array", "items" => %{"type" => "object"}}
+        "resources" => %{"type" => "array", "items" => %{"type" => "string"}}
       }
     },
     "ck_skill_validate" => %{

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -1152,7 +1152,12 @@ defmodule ControlKeel.Mission do
         "approved_at" => DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
       })
 
-    case update_finding_with_audit(finding, %{status: "approved", metadata: metadata}, :approved, opts) do
+    case update_finding_with_audit(
+           finding,
+           %{status: "approved", metadata: metadata},
+           :approved,
+           opts
+         ) do
       {:ok, updated} ->
         emit_finding_event(:approved, updated)
         record_finding_memory(:approved, updated)
@@ -1215,7 +1220,12 @@ defmodule ControlKeel.Mission do
           DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
       })
 
-    case update_finding_with_audit(finding, %{status: "escalated", metadata: metadata}, :escalated, opts) do
+    case update_finding_with_audit(
+           finding,
+           %{status: "escalated", metadata: metadata},
+           :escalated,
+           opts
+         ) do
       {:ok, updated} ->
         emit_finding_event(:escalated, updated)
         record_finding_memory(:escalated, updated)

--- a/priv/repo/migrations/20260615060000_add_actor_metadata_to_review_audit_events.exs
+++ b/priv/repo/migrations/20260615060000_add_actor_metadata_to_review_audit_events.exs
@@ -1,10 +1,50 @@
 defmodule ControlKeel.Repo.Migrations.AddActorMetadataToReviewAuditEvents do
   use Ecto.Migration
 
-  def change do
-    alter table(:review_audit_events) do
-      add :actor_source, :string
-      add :actor_identifier, :string
+  # SQLite has no `ADD COLUMN IF NOT EXISTS`, so guard each column against the
+  # adapter's live column metadata. Re-running this migration against a
+  # partial/stale DB (or under concurrent boots) otherwise crashes app boot with
+  # "duplicate column name: actor_source".
+  @table :review_audit_events
+
+  def up do
+    existing = columns(@table)
+
+    alter table(@table) do
+      unless MapSet.member?(existing, "actor_source"),
+        do: add(:actor_source, :string)
+
+      unless MapSet.member?(existing, "actor_identifier"),
+        do: add(:actor_identifier, :string)
     end
   end
+
+  def down do
+    alter table(@table) do
+      remove_if_exists(:actor_source, :string)
+      remove_if_exists(:actor_identifier, :string)
+    end
+  end
+
+  defp columns(table) do
+    table = to_string(table)
+
+    rows =
+      if sqlite_repo?() do
+        %{rows: rows} = repo().query!("PRAGMA table_info(\"#{table}\")")
+        Enum.map(rows, fn [_cid, name | _] -> name end)
+      else
+        %{rows: rows} =
+          repo().query!(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = $1",
+            [table]
+          )
+
+        Enum.map(rows, fn [name] -> name end)
+      end
+
+    MapSet.new(rows)
+  end
+
+  defp sqlite_repo?, do: repo().__adapter__() == Ecto.Adapters.SQLite3
 end

--- a/priv/repo/migrations/20260615063000_add_decision_links_to_session_events.exs
+++ b/priv/repo/migrations/20260615063000_add_decision_links_to_session_events.exs
@@ -1,13 +1,55 @@
 defmodule ControlKeel.Repo.Migrations.AddDecisionLinksToSessionEvents do
   use Ecto.Migration
 
-  def change do
-    alter table(:session_events) do
-      add :review_id, references(:reviews, on_delete: :nilify_all)
-      add :finding_id, references(:findings, on_delete: :nilify_all)
+  # Only add the reference columns that are actually missing, and create the
+  # indexes with IF NOT EXISTS, so a partial/stale DB or concurrent boots cannot
+  # crash the application during migration.
+  @table :session_events
+
+  def up do
+    existing = columns(@table)
+
+    alter table(@table) do
+      unless MapSet.member?(existing, "review_id"),
+        do: add(:review_id, references(:reviews, on_delete: :nilify_all))
+
+      unless MapSet.member?(existing, "finding_id"),
+        do: add(:finding_id, references(:findings, on_delete: :nilify_all))
     end
 
-    create index(:session_events, [:review_id, :inserted_at])
-    create index(:session_events, [:finding_id, :inserted_at])
+    create_if_not_exists index(@table, [:review_id, :inserted_at])
+    create_if_not_exists index(@table, [:finding_id, :inserted_at])
   end
+
+  def down do
+    drop_if_exists index(@table, [:review_id, :inserted_at])
+    drop_if_exists index(@table, [:finding_id, :inserted_at])
+
+    alter table(@table) do
+      remove_if_exists(:review_id, references(:reviews, on_delete: :nilify_all))
+      remove_if_exists(:finding_id, references(:findings, on_delete: :nilify_all))
+    end
+  end
+
+  defp columns(table) do
+    table = to_string(table)
+
+    rows =
+      if sqlite_repo?() do
+        %{rows: rows} = repo().query!("PRAGMA table_info(\"#{table}\")")
+        Enum.map(rows, fn [_cid, name | _] -> name end)
+      else
+        %{rows: rows} =
+          repo().query!(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = $1",
+            [table]
+          )
+
+        Enum.map(rows, fn [name] -> name end)
+      end
+
+    MapSet.new(rows)
+  end
+
+  defp sqlite_repo?, do: repo().__adapter__() == Ecto.Adapters.SQLite3
 end

--- a/priv/repo/migrations/20260615165000_create_finding_audit_events.exs
+++ b/priv/repo/migrations/20260615165000_create_finding_audit_events.exs
@@ -1,8 +1,10 @@
 defmodule ControlKeel.Repo.Migrations.CreateFindingAuditEvents do
   use Ecto.Migration
 
+  # SQLite-safe: CREATE TABLE/INDEX IF NOT EXISTS so a partial/stale DB or
+  # concurrent boots cannot crash with "table/index already exists".
   def change do
-    create table(:finding_audit_events) do
+    create_if_not_exists table(:finding_audit_events) do
       add :finding_id, references(:findings, on_delete: :delete_all), null: false
       add :event_type, :string, null: false
       add :previous_status, :string, null: false
@@ -14,7 +16,7 @@ defmodule ControlKeel.Repo.Migrations.CreateFindingAuditEvents do
       add :recorded_at, :utc_datetime, null: false
     end
 
-    create index(:finding_audit_events, [:finding_id, :recorded_at])
-    create index(:finding_audit_events, [:event_type, :recorded_at])
+    create_if_not_exists index(:finding_audit_events, [:finding_id, :recorded_at])
+    create_if_not_exists index(:finding_audit_events, [:event_type, :recorded_at])
   end
 end


### PR DESCRIPTION
## Problem

Three non-idempotent SQLite migrations crash app boot when columns/tables exist but migration records are absent (partial/stale DB, concurrent boots, or dev/prod DB mismatch).

Separately, `ck_skill_load` output schema declared `resources` as `array-of-object`, but the parser returns `array-of-string` (file paths). This caused MCP tool validation to reject the tool output entirely.

## Changes

### Migrations (idempotent)

- **20260615060000**: Guard `actor_source`/`actor_identifier` columns with `PRAGMA table_info` checks; add proper `down/0` with `remove_if_exists`
- **20260615063000**: Guard `review_id`/`finding_id` columns with `PRAGMA table_info`; use `create_if_not_exists` for indexes; add `down/0` with `drop_if_exists`
- **20260615165000**: Use `create_if_not_exists` for table and indexes

### Output schema fix

- `output_schemas.ex` line 520: Change `ck_skill_load` resources schema from `"object"` to `"string"`

### Formatting

- `mission.ex`: Two long-line rewraps via `mix format` (no logic change)

## Verification

- 1982 tests pass (`mix test`)
- `mix precommit` clean
- Re-running migrations against existing DB: no-op (no crashes)
- `ck_skill_load` MCP tool validates and returns structured content successfully
- Built and installed locally (burrito release) to confirm end-to-end
