### PR TITLE
feat(autonomy): governed scheduler + capability-gated shell launcher

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,6 +23,7 @@ config :controlkeel,
   autonomy: [
     enabled: false,
     allow_shell: false,
+    launch_timeout_ms: 300_000,
     workspace_id: nil,
     jobs: []
   ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,7 +16,16 @@ config :controlkeel,
   protocol_access_token_ttl_seconds: 3_600,
   acp_registry_url: "https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json",
   acp_registry_ttl_seconds: 86_400,
-  generators: [timestamp_type: :utc_datetime]
+  generators: [timestamp_type: :utc_datetime],
+  # Governed autonomy scheduler — off by default so existing installs see no
+  # behavior change. Enable via CK_AUTONOMY_SCHEDULER env or `enabled: true`.
+  # See docs/autonomy-scheduler.md and lib/controlkeel/autonomy/scheduler.ex.
+  autonomy: [
+    enabled: false,
+    allow_shell: false,
+    workspace_id: nil,
+    jobs: []
+  ]
 
 # Configure the endpoint
 # Default `code_reloader` so releases match runtime MCP overrides (CK_MCP_MODE).

--- a/docs/autonomy-scheduler.md
+++ b/docs/autonomy-scheduler.md
@@ -1,0 +1,108 @@
+# Governed Autonomy Scheduler
+
+ControlKeel is **reactive** by default: a session starts when an operator or host
+agent triggers it. The autonomy scheduler adds the missing piece — a governed,
+timer-driven heartbeat — so CK can run unattended jobs the way a cron-driven
+agent (e.g. gumclaw) does, but with every wake-up recorded as a governed session.
+
+This closes the one structural gap surfaced by comparing ControlKeel to
+cron-driven agent deployments: "cron fires → wake → work → report" becomes
+"timer fires → governed wake-up → agent runs inside a real session → audit
+trail + recoverable memory."
+
+## How it works
+
+1. A `GenServer` (`ControlKeel.Autonomy.Scheduler`) runs inside the CK
+   application and arms a `Process.send_after` timer per configured job.
+2. When a job's timer fires, the dispatcher creates a **governed wake-up**: a
+   session + task + `autonomy.wake` audit event.
+3. If the job has a launcher **and** shell launching is enabled, the dispatcher
+   also invokes the configured agent program. Otherwise the wake-up is recorded
+   and an external launcher (or a later run) picks it up.
+4. The timer re-arms. The heartbeat continues until the app stops.
+
+Off by default. Never starts inside an MCP stdio server process.
+
+## Configuration
+
+```elixir
+config :controlkeel,
+  autonomy: [
+    enabled: true,
+    allow_shell: false,
+    workspace_id: 1,
+    jobs: [
+      %{
+        name: :daily_triage,
+        interval_ms: :timer.hours(6),
+        title: "Scheduled support triage",
+        task: "Triage open support tickets and close or escalate each one.",
+        agent: :opencode,
+        launcher: %{adapter: :shell, command: "opencode", args: ["run", :task]}
+      }
+    ]
+  ]
+```
+
+| key            | required | meaning                                                              |
+| -------------- | -------- | -------------------------------------------------------------------- |
+| `enabled`      | no       | Arm timers on boot. Also set via `CK_AUTONOMY_SCHEDULER=1`.          |
+| `allow_shell`  | no       | Permit launchers to execute. Also via `CK_AUTONOMY_ALLOW_SHELL=1`.   |
+| `workspace_id` | no       | Workspace wake-up sessions bind to. Falls back to the first org's.   |
+| `jobs`         | yes      | List of job maps (see below).                                        |
+
+### Job fields
+
+| field         | required | type                  | notes                                                       |
+| ------------- | -------- | --------------------- | ----------------------------------------------------------- |
+| `name`        | yes      | atom / string         | Unique identifier.                                          |
+| `interval_ms` | yes      | pos integer           | Time between fires.                                         |
+| `title`       | yes      | string                | Human label; becomes the session title.                     |
+| `task`        | yes      | string                | Task body; becomes the session objective + task text.       |
+| `agent`       | no       | atom / string         | Target agent hint (informational).                          |
+| `launcher`    | no       | map                   | `%{adapter: :shell, command: binary, args: [binary \| :task]}`. |
+
+The `:task` placeholder in `launcher.args` is replaced with the job's task text
+as a **single discrete argv element** — never interpolated into a shell string.
+A launcher may legitimately omit `:task` (e.g. a fixed maintenance command).
+
+## Security model for launchers
+
+The shell launcher is the only module in the autonomy subsystem that executes an
+external process. Its trust boundary is intentionally narrow:
+
+- **argv, not a shell.** `System.cmd/3` with an explicit argument list. No shell,
+  no string interpolation — shell-injection surface is removed entirely.
+- **Explicit opt-in.** Gated on `CK_AUTONOMY_ALLOW_SHELL` or `allow_shell: true`.
+  Disabled → launchers are skipped, wake-ups still recorded.
+- **Trusted template.** `command` and `args` come from operator config (trusted).
+  Only `:task` receives job text, and only as an argv element.
+- **Audited.** Every launch result (exit status + truncated output) is written to
+  the `autonomy.wake` session event.
+
+## Mix task
+
+```
+mix ck.autonomy                # status + job list
+mix ck.autonomy list           # list configured jobs
+mix ck.autonomy status         # enabled / workspace / shell-launch state
+mix ck.autonomy run <name>     # fire a job once now
+mix ck.autonomy run <name> --dry-run   # show what would happen, record nothing
+```
+
+`run` works whether or not the scheduler is enabled.
+
+## Relation to external schedulers
+
+You do not need the BEAM scheduler to run autonomous jobs — an external cron
+calling `mix ck.autonomy run <name>` produces the same governed wake-up. The
+BEAM scheduler is for deployments that want an always-on heartbeat inside the CK
+process, matching cron-driven agent models. Both paths produce identical audit
+trails.
+
+## See also
+
+- `lib/controlkeel/autonomy/scheduler.ex`
+- `lib/controlkeel/autonomy/dispatcher.ex`
+- `lib/controlkeel/autonomy/launcher/shell.ex`
+- `lib/controlkeel/memory/retention_scheduler.ex` (the pattern this mirrors)

--- a/docs/autonomy-scheduler.md
+++ b/docs/autonomy-scheduler.md
@@ -86,6 +86,12 @@ external process. Its trust boundary is intentionally narrow:
 - **Bounded.** Launches time out (five minutes by default; configurable globally
   or per launcher with `timeout_ms`) and timed dispatches run under a
   `Task.Supervisor`, so one slow agent does not block unrelated timers.
+- **Tree-safe timeout.** Each Unix launch runs in its own OS process group
+  (`setsid`, with Python `os.setsid` fallback); timeout signals terminate the
+  entire group. Windows uses `taskkill /T`. Launching fails closed when process
+  tree isolation cannot be established.
+- **No overlap per job.** While a job is in flight, later ticks for that same job
+  are skipped and re-armed rather than duplicating external side effects.
 
 ## Mix task
 

--- a/docs/autonomy-scheduler.md
+++ b/docs/autonomy-scheduler.md
@@ -30,6 +30,7 @@ config :controlkeel,
   autonomy: [
     enabled: true,
     allow_shell: false,
+    launch_timeout_ms: 300_000,
     workspace_id: 1,
     jobs: [
       %{
@@ -48,7 +49,8 @@ config :controlkeel,
 | -------------- | -------- | -------------------------------------------------------------------- |
 | `enabled`      | no       | Arm timers on boot. Also set via `CK_AUTONOMY_SCHEDULER=1`.          |
 | `allow_shell`  | no       | Permit launchers to execute. Also via `CK_AUTONOMY_ALLOW_SHELL=1`.   |
-| `workspace_id` | no       | Workspace wake-up sessions bind to. Falls back to the first org's.   |
+| `launch_timeout_ms` | no  | Default external-launch timeout (5 minutes).                         |
+| `workspace_id` | yes      | Workspace wake-up sessions bind to. No cross-tenant fallback.        |
 | `jobs`         | yes      | List of job maps (see below).                                        |
 
 ### Job fields
@@ -71,14 +73,19 @@ A launcher may legitimately omit `:task` (e.g. a fixed maintenance command).
 The shell launcher is the only module in the autonomy subsystem that executes an
 external process. Its trust boundary is intentionally narrow:
 
-- **argv, not a shell.** `System.cmd/3` with an explicit argument list. No shell,
-  no string interpolation — shell-injection surface is removed entirely.
+- **argv, not an implicit shell.** `System.cmd/3` receives an explicit argument
+  list. ControlKeel does not invoke a shell automatically. An operator who
+  explicitly configures `sh -c`, `bash -c`, or another interpreter can
+  reintroduce shell parsing and owns that trust boundary.
 - **Explicit opt-in.** Gated on `CK_AUTONOMY_ALLOW_SHELL` or `allow_shell: true`.
   Disabled → launchers are skipped, wake-ups still recorded.
 - **Trusted template.** `command` and `args` come from operator config (trusted).
   Only `:task` receives job text, and only as an argv element.
-- **Audited.** Every launch result (exit status + truncated output) is written to
-  the `autonomy.wake` session event.
+- **Audited.** Session + task + pre-launch wake event commit atomically before
+  execution. Launch results are written to a separate audit event.
+- **Bounded.** Launches time out (five minutes by default; configurable globally
+  or per launcher with `timeout_ms`) and timed dispatches run under a
+  `Task.Supervisor`, so one slow agent does not block unrelated timers.
 
 ## Mix task
 

--- a/docs/autonomy-scheduler.md
+++ b/docs/autonomy-scheduler.md
@@ -89,7 +89,10 @@ external process. Its trust boundary is intentionally narrow:
 - **Tree-safe timeout.** Each Unix launch uses a Python `os.setsid()+execv()`
   wrapper so the tracked PID remains its OS process-group leader; timeout signals
   terminate the entire group. Windows uses `taskkill /T`. Launching fails closed
-  when process-tree isolation cannot be established.
+  when process-tree isolation cannot be established. A timeout is returned only
+  after Unix has no runnable process-group members, or Windows reports successful
+  `taskkill /T /F` and the original PID disappears. Signal, `taskkill`, or
+  confirmation failures return an explicit `launch_termination_failed` error.
 - **No overlap per job.** While a job is in flight, later ticks for that same job
   are skipped and re-armed rather than duplicating external side effects.
 

--- a/docs/autonomy-scheduler.md
+++ b/docs/autonomy-scheduler.md
@@ -86,13 +86,19 @@ external process. Its trust boundary is intentionally narrow:
 - **Bounded.** Launches time out (five minutes by default; configurable globally
   or per launcher with `timeout_ms`) and timed dispatches run under a
   `Task.Supervisor`, so one slow agent does not block unrelated timers.
-- **Tree-safe timeout.** Each Unix launch uses a Python `os.setsid()+execv()`
+- **Managed-tree timeout.** Each Unix launch uses a Python `os.setsid()+execv()`
   wrapper so the tracked PID remains its OS process-group leader; timeout signals
-  terminate the entire group. Windows uses `taskkill /T`. Launching fails closed
+  terminate that managed group. Windows uses `taskkill /T`. Launching fails closed
   when process-tree isolation cannot be established. A timeout is returned only
   after Unix has no runnable process-group members, or Windows reports successful
   `taskkill /T /F` and the original PID disappears. Signal, `taskkill`, or
   confirmation failures return an explicit `launch_termination_failed` error.
+- **No daemonizing launchers.** Launcher commands are trusted operator
+  configuration and must remain attached to the managed process group/tree.
+  Calling `setsid`, double-forking, daemonizing, or otherwise deliberately escaping
+  that boundary is unsupported and forbidden. Work that requires daemonization
+  must run under a separately governed sandbox or service manager with its own
+  lifecycle guarantee; ControlKeel should launch only its bounded client/trigger.
 - **No overlap per job.** While a job is in flight, later ticks for that same job
   are skipped and re-armed rather than duplicating external side effects.
 

--- a/docs/autonomy-scheduler.md
+++ b/docs/autonomy-scheduler.md
@@ -86,10 +86,10 @@ external process. Its trust boundary is intentionally narrow:
 - **Bounded.** Launches time out (five minutes by default; configurable globally
   or per launcher with `timeout_ms`) and timed dispatches run under a
   `Task.Supervisor`, so one slow agent does not block unrelated timers.
-- **Tree-safe timeout.** Each Unix launch runs in its own OS process group
-  (`setsid`, with Python `os.setsid` fallback); timeout signals terminate the
-  entire group. Windows uses `taskkill /T`. Launching fails closed when process
-  tree isolation cannot be established.
+- **Tree-safe timeout.** Each Unix launch uses a Python `os.setsid()+execv()`
+  wrapper so the tracked PID remains its OS process-group leader; timeout signals
+  terminate the entire group. Windows uses `taskkill /T`. Launching fails closed
+  when process-tree isolation cannot be established.
 - **No overlap per job.** While a job is in flight, later ticks for that same job
   are skipped and re-armed rather than duplicating external side effects.
 

--- a/lib/controlkeel/application.ex
+++ b/lib/controlkeel/application.ex
@@ -80,6 +80,7 @@ defmodule ControlKeel.Application do
       mailer_test_inbox_children() ++
       retention_scheduler_children() ++
       db_maintenance_children() ++
+      autonomy_scheduler_children() ++
       [ControlKeel.Cloud.RateLimiter, ControlKeel.Cloud.Usage.Meter] ++
       [
         {DNSCluster, query: Application.get_env(:controlkeel, :dns_cluster_query) || :ignore},
@@ -278,6 +279,14 @@ defmodule ControlKeel.Application do
   defp db_maintenance_children do
     if ControlKeel.Ops.Database.enabled?() do
       [ControlKeel.Ops.Database]
+    else
+      []
+    end
+  end
+
+  defp autonomy_scheduler_children do
+    if ControlKeel.Autonomy.Scheduler.enabled?() and not mcp_stdio_mode?() do
+      [ControlKeel.Autonomy.Scheduler]
     else
       []
     end

--- a/lib/controlkeel/application.ex
+++ b/lib/controlkeel/application.ex
@@ -286,7 +286,10 @@ defmodule ControlKeel.Application do
 
   defp autonomy_scheduler_children do
     if ControlKeel.Autonomy.Scheduler.enabled?() and not mcp_stdio_mode?() do
-      [ControlKeel.Autonomy.Scheduler]
+      [
+        {Task.Supervisor, name: ControlKeel.Autonomy.TaskSupervisor},
+        ControlKeel.Autonomy.Scheduler
+      ]
     else
       []
     end

--- a/lib/controlkeel/autonomy/dispatcher.ex
+++ b/lib/controlkeel/autonomy/dispatcher.ex
@@ -1,0 +1,161 @@
+defmodule ControlKeel.Autonomy.Dispatcher do
+  @moduledoc """
+  Default dispatch for a fired autonomy job: produces a governed wake-up.
+
+  A wake-up is a session + task + `autonomy.wake` audit event. When the job has a
+  launcher configured AND shell launching is enabled, the dispatcher also invokes
+  the launcher and records its result in the same event.
+
+  The wake-up is what makes the autonomy heartbeat governed: the next agent run
+  (whether launched here or picked up later) starts inside a real CK session with
+  a task, an audit trail, and recoverable memory — never as an orphan process.
+  """
+
+  require Logger
+
+  alias ControlKeel.Accounts
+  alias ControlKeel.Autonomy.Job
+  alias ControlKeel.Autonomy.Launcher.Shell
+  alias ControlKeel.Mission
+  alias ControlKeel.Mission.SessionTranscript
+
+  @wake_event_type "autonomy.wake"
+  @default_budget_cents 5_000
+  @default_risk_tier "medium"
+
+  @doc """
+  Dispatch `job`.
+
+  Options:
+
+  * `:workspace_id` — workspace to bind the wake-up session to. When omitted, the
+    first workspace of the first org is used (autonomous runs need a home).
+  * `:dry_run` — when `true`, validates and returns the plan without recording
+    anything or launching anything.
+
+  Returns `{:ok, %{session_id, task_id, launched}}` or `{:error, reason}`.
+  """
+  def dispatch(job, opts \\ [])
+
+  def dispatch(%Job{} = job, opts) do
+    with {:ok, workspace_id} <- resolve_workspace(opts) do
+      if opts[:dry_run] do
+        {:ok, %{dry_run: true, job: job.name, workspace_id: workspace_id, launched: false}}
+      else
+        fire(job, workspace_id, opts)
+      end
+    end
+  end
+
+  defp fire(%Job{} = job, workspace_id, _opts) do
+    {:ok, session} = create_session(job, workspace_id)
+    {:ok, task} = create_task(job, session)
+    launched = maybe_launch(job)
+
+    :ok = record_wake_event(session, job, task, launched)
+
+    {:ok,
+     %{session_id: session.id, task_id: task.id, launched: launched, workspace_id: workspace_id}}
+  end
+
+  defp create_session(%Job{} = job, workspace_id) do
+    Mission.create_session(%{
+      title: "[autonomy] " <> job.title,
+      objective: job.task,
+      risk_tier: @default_risk_tier,
+      status: "in_progress",
+      budget_cents: @default_budget_cents,
+      daily_budget_cents: @default_budget_cents,
+      spent_cents: 0,
+      execution_brief: %{"source" => "autonomy.scheduler", "job" => to_string(job.name)},
+      workspace_id: workspace_id
+    })
+  end
+
+  defp create_task(%Job{} = job, session) do
+    Mission.create_task(%{
+      session_id: session.id,
+      title: job.title,
+      status: "pending",
+      estimated_cost_cents: 0,
+      validation_gate: "manual",
+      position: 0,
+      metadata: %{"source" => "autonomy", "job" => to_string(job.name)}
+    })
+  end
+
+  # A job with a launcher launches when shell execution is enabled. Otherwise the
+  # wake-up is recorded and an external launcher (or a later run) picks it up.
+  defp maybe_launch(%Job{launcher: nil}), do: nil
+
+  defp maybe_launch(%Job{} = job) do
+    case Shell.run(job, []) do
+      {:ok, result} ->
+        result
+
+      {:error, :shell_not_allowed} ->
+        Logger.warning(
+          "[autonomy] job #{inspect(job.name)} has a launcher but shell execution is disabled; wake-up recorded without launch"
+        )
+
+        nil
+
+      {:error, reason} ->
+        Logger.warning(
+          "[autonomy] launcher for job #{inspect(job.name)} failed: #{inspect(reason)}"
+        )
+
+        %{error: reason}
+    end
+  end
+
+  defp record_wake_event(session, job, task, launched) do
+    payload = %{
+      job: to_string(job.name),
+      task_id: task.id,
+      agent: to_string(job.agent),
+      launcher: job.launcher != nil,
+      launched: format_launched(launched)
+    }
+
+    {:ok, _event} =
+      SessionTranscript.record(%{
+        session_id: session.id,
+        event_type: @wake_event_type,
+        actor: "autonomy.scheduler",
+        summary: "Autonomy wake-up: " <> job.title,
+        payload: payload
+      })
+
+    :ok
+  end
+
+  defp format_launched(nil), do: false
+  defp format_launched(%{error: _} = err), do: err
+  defp format_launched(result), do: Map.take(result, [:exit_status])
+
+  defp resolve_workspace(opts) do
+    case opts[:workspace_id] do
+      id when is_integer(id) and id > 0 ->
+        {:ok, id}
+
+      _ ->
+        default_workspace_id()
+    end
+  end
+
+  # Autonomous runs need a workspace. When none is configured, fall back to the
+  # first workspace of the first org so a freshly-enabled scheduler can run.
+  defp default_workspace_id do
+    case Accounts.list_orgs() do
+      [org | _] ->
+        case Accounts.list_workspaces_for_org(org.id) do
+          [ws | _] -> {:ok, ws.id}
+          [] -> {:error, :no_workspace_configured}
+        end
+
+      [] ->
+        {:error, :no_workspace_configured}
+    end
+  end
+end

--- a/lib/controlkeel/autonomy/dispatcher.ex
+++ b/lib/controlkeel/autonomy/dispatcher.ex
@@ -2,9 +2,9 @@ defmodule ControlKeel.Autonomy.Dispatcher do
   @moduledoc """
   Default dispatch for a fired autonomy job: produces a governed wake-up.
 
-  A wake-up is a session + task + `autonomy.wake` audit event. When the job has a
-  launcher configured AND shell launching is enabled, the dispatcher also invokes
-  the launcher and records its result in the same event.
+  A wake-up is a session + task + `autonomy.wake` audit event committed in one
+  database transaction. Only after that invariant exists may an external launcher
+  run; its result is recorded as a separate `autonomy.launch.result` event.
 
   The wake-up is what makes the autonomy heartbeat governed: the next agent run
   (whether launched here or picked up later) starts inside a real CK session with
@@ -13,13 +13,15 @@ defmodule ControlKeel.Autonomy.Dispatcher do
 
   require Logger
 
-  alias ControlKeel.Accounts
   alias ControlKeel.Autonomy.Job
   alias ControlKeel.Autonomy.Launcher.Shell
   alias ControlKeel.Mission
   alias ControlKeel.Mission.SessionTranscript
+  alias ControlKeel.Mission.Workspace
+  alias ControlKeel.Repo
 
   @wake_event_type "autonomy.wake"
+  @launch_result_event_type "autonomy.launch.result"
   @default_budget_cents 5_000
   @default_risk_tier "medium"
 
@@ -28,8 +30,7 @@ defmodule ControlKeel.Autonomy.Dispatcher do
 
   Options:
 
-  * `:workspace_id` — workspace to bind the wake-up session to. When omitted, the
-    first workspace of the first org is used (autonomous runs need a home).
+  * `:workspace_id` — required workspace to bind the wake-up session to.
   * `:dry_run` — when `true`, validates and returns the plan without recording
     anything or launching anything.
 
@@ -47,15 +48,37 @@ defmodule ControlKeel.Autonomy.Dispatcher do
     end
   end
 
-  defp fire(%Job{} = job, workspace_id, _opts) do
-    {:ok, session} = create_session(job, workspace_id)
-    {:ok, task} = create_task(job, session)
-    launched = maybe_launch(job)
+  defp fire(%Job{} = job, workspace_id, opts) do
+    with {:ok, %{session: session, task: task}} <- persist_wake_up(job, workspace_id),
+         launched <- maybe_launch(job, opts),
+         :ok <- record_launch_result(session, job, task, launched) do
+      {:ok,
+       %{
+         session_id: session.id,
+         task_id: task.id,
+         launched: launched,
+         workspace_id: workspace_id
+       }}
+    end
+  end
 
-    :ok = record_wake_event(session, job, task, launched)
-
-    {:ok,
-     %{session_id: session.id, task_id: task.id, launched: launched, workspace_id: workspace_id}}
+  defp persist_wake_up(job, workspace_id) do
+    case Repo.transaction(fn ->
+           with {:ok, session} <- create_session(job, workspace_id),
+                {:ok, task} <- create_task(job, session),
+                {:ok, _event} <- record_wake_event(session, job, task) do
+             %{session: session, task: task}
+           else
+             {:error, reason} -> Repo.rollback(reason)
+           end
+         end) do
+      {:ok, result} -> {:ok, result}
+      {:error, reason} -> {:error, {:wake_persistence_failed, reason}}
+    end
+  rescue
+    error -> {:error, {:wake_persistence_failed, Exception.message(error)}}
+  catch
+    kind, reason -> {:error, {:wake_persistence_failed, {kind, inspect(reason)}}}
   end
 
   defp create_session(%Job{} = job, workspace_id) do
@@ -86,10 +109,10 @@ defmodule ControlKeel.Autonomy.Dispatcher do
 
   # A job with a launcher launches when shell execution is enabled. Otherwise the
   # wake-up is recorded and an external launcher (or a later run) picks it up.
-  defp maybe_launch(%Job{launcher: nil}), do: nil
+  defp maybe_launch(%Job{launcher: nil}, _opts), do: nil
 
-  defp maybe_launch(%Job{} = job) do
-    case Shell.run(job, []) do
+  defp maybe_launch(%Job{} = job, opts) do
+    case Shell.run(job, opts) do
       {:ok, result} ->
         result
 
@@ -105,57 +128,69 @@ defmodule ControlKeel.Autonomy.Dispatcher do
           "[autonomy] launcher for job #{inspect(job.name)} failed: #{inspect(reason)}"
         )
 
-        %{error: reason}
+        %{error: inspect(reason)}
     end
   end
 
-  defp record_wake_event(session, job, task, launched) do
+  defp record_wake_event(session, job, task) do
     payload = %{
       job: to_string(job.name),
       task_id: task.id,
-      agent: to_string(job.agent),
+      agent: job.agent,
       launcher: job.launcher != nil,
-      launched: format_launched(launched)
+      phase: "prepared"
     }
 
-    {:ok, _event} =
-      SessionTranscript.record(%{
-        session_id: session.id,
-        event_type: @wake_event_type,
-        actor: "autonomy.scheduler",
-        summary: "Autonomy wake-up: " <> job.title,
-        payload: payload
-      })
-
-    :ok
+    SessionTranscript.record(%{
+      session_id: session.id,
+      task_id: task.id,
+      event_type: @wake_event_type,
+      actor: "autonomy.scheduler",
+      summary: "Autonomy wake-up prepared: " <> job.title,
+      payload: payload
+    })
   end
 
-  defp format_launched(nil), do: false
-  defp format_launched(%{error: _} = err), do: err
-  defp format_launched(result), do: Map.take(result, [:exit_status])
+  defp record_launch_result(_session, %Job{launcher: nil}, _task, nil), do: :ok
+
+  defp record_launch_result(session, job, task, launched) do
+    case SessionTranscript.record(%{
+           session_id: session.id,
+           task_id: task.id,
+           event_type: @launch_result_event_type,
+           actor: "autonomy.scheduler",
+           summary: "Autonomy launcher result: " <> job.title,
+           payload: format_launched(launched)
+         }) do
+      {:ok, _event} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "[autonomy] launch completed but result audit failed for #{inspect(job.name)}: #{inspect(reason)}"
+        )
+
+        {:error, {:launch_result_audit_failed, reason}}
+    end
+  end
+
+  defp format_launched(nil), do: %{"status" => "skipped"}
+
+  defp format_launched(%{error: error}) do
+    %{"status" => "failed", "error" => to_string(error)}
+  end
+
+  defp format_launched(%{exit_status: status, output: output}) do
+    %{"status" => "completed", "exit_status" => status, "output" => output}
+  end
 
   defp resolve_workspace(opts) do
     case opts[:workspace_id] do
       id when is_integer(id) and id > 0 ->
-        {:ok, id}
+        if Repo.get(Workspace, id), do: {:ok, id}, else: {:error, :workspace_not_found}
 
       _ ->
-        default_workspace_id()
-    end
-  end
-
-  # Autonomous runs need a workspace. When none is configured, fall back to the
-  # first workspace of the first org so a freshly-enabled scheduler can run.
-  defp default_workspace_id do
-    case Accounts.list_orgs() do
-      [org | _] ->
-        case Accounts.list_workspaces_for_org(org.id) do
-          [ws | _] -> {:ok, ws.id}
-          [] -> {:error, :no_workspace_configured}
-        end
-
-      [] ->
-        {:error, :no_workspace_configured}
+        {:error, :workspace_id_required}
     end
   end
 end

--- a/lib/controlkeel/autonomy/job.ex
+++ b/lib/controlkeel/autonomy/job.ex
@@ -1,0 +1,157 @@
+defmodule ControlKeel.Autonomy.Job do
+  @moduledoc """
+  A scheduled autonomy job.
+
+  Fires on a fixed interval and produces a governed wake-up (a session + task +
+  audit event). When a `launcher` is configured AND shell launching is enabled,
+  the wake-up also invokes a configured agent program on schedule.
+
+  Jobs are defined in config, never in code, so an operator's filesystem (not the
+  model) decides what runs unattended:
+
+      config :controlkeel,
+        autonomy: [
+          enabled: true,
+          allow_shell: true,
+          workspace_id: 1,
+          jobs: [
+            %{
+              name: :daily_triage,
+              interval_ms: :timer.hours(6),
+              title: "Scheduled support triage",
+              task: "Triage open support tickets and close or escalate each one.",
+              agent: :opencode,
+              launcher: %{adapter: :shell, command: "opencode", args: ["run", :task]}
+            }
+          ]
+        ]
+
+  The `:task` placeholder in `launcher.args` receives the job's task text as a
+  single discrete argv element (never interpolated into a shell string).
+  """
+
+  @enforce_keys [:name, :interval_ms, :title, :task]
+  defstruct [:name, :interval_ms, :title, :task, :agent, :launcher]
+
+  @type launcher :: %{adapter: :shell, command: binary(), args: [binary() | :task]}
+  @type t :: %__MODULE__{
+          name: atom(),
+          interval_ms: pos_integer(),
+          title: String.t(),
+          task: String.t(),
+          agent: atom() | nil,
+          launcher: launcher() | nil
+        }
+
+  @doc """
+  Parse a single job from a config map or keyword list.
+
+  Returns `{:ok, %__MODULE__{}}` or `{:error, reason}`.
+  """
+  def from_config(config) when is_list(config) or is_map(config) do
+    config = normalize(config)
+
+    with {:ok, name} <- parse_name(config[:name]),
+         {:ok, interval_ms} <- parse_interval(config[:interval_ms]),
+         {:ok, title} <- require_string(config[:title], :title),
+         {:ok, task} <- require_string(config[:task], :task),
+         {:ok, launcher} <- parse_launcher(config[:launcher]) do
+      {:ok,
+       %__MODULE__{
+         name: name,
+         interval_ms: interval_ms,
+         title: title,
+         task: task,
+         agent: to_atom(config[:agent]),
+         launcher: launcher
+       }}
+    end
+  end
+
+  @doc """
+  Parse a list of job configs, enforcing unique names.
+
+  Returns `{:ok, [job]}` or `{:error, reason}`.
+  """
+  def from_config_all(list) when is_list(list) do
+    list
+    |> Enum.reduce_while({:ok, [], MapSet.new()}, fn raw, {:ok, acc, seen} ->
+      case from_config(raw) do
+        {:ok, %__MODULE__{name: name} = job} ->
+          if MapSet.member?(seen, name) do
+            {:halt, {:error, {:duplicate_name, name}}}
+          else
+            {:cont, {:ok, [job | acc], MapSet.put(seen, name)}}
+          end
+
+        {:error, _} = err ->
+          {:halt, err}
+      end
+    end)
+    |> case do
+      {:ok, jobs, _seen} -> {:ok, Enum.reverse(jobs)}
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc "Whether this job has a launcher configured."
+  def launcher?(%__MODULE__{launcher: nil}), do: false
+  def launcher?(%__MODULE__{launcher: _}), do: true
+
+  # --- parsers ---
+
+  defp normalize(config) when is_list(config), do: Keyword.new(config)
+  defp normalize(config) when is_map(config), do: Map.to_list(config)
+
+  defp parse_name(nil), do: {:error, {:missing, :name}}
+  defp parse_name(name) when is_atom(name), do: {:ok, name}
+  defp parse_name(name) when is_binary(name), do: {:ok, String.to_atom(name)}
+  defp parse_name(other), do: {:error, {:invalid_name, other}}
+
+  defp parse_interval(nil), do: {:error, {:missing, :interval_ms}}
+
+  defp parse_interval(interval_ms) when is_integer(interval_ms) and interval_ms > 0 do
+    {:ok, interval_ms}
+  end
+
+  defp parse_interval(other), do: {:error, {:invalid_interval_ms, other}}
+
+  defp require_string(nil, field), do: {:error, {:missing, field}}
+
+  defp require_string(value, _field) when is_binary(value) and byte_size(value) > 0 do
+    {:ok, value}
+  end
+
+  defp require_string(other, field), do: {:error, {:invalid, field, other}}
+
+  defp parse_launcher(nil), do: {:ok, nil}
+
+  defp parse_launcher(%{adapter: :shell} = launcher) do
+    command = Map.get(launcher, :command) || Map.get(launcher, "command")
+    args = Map.get(launcher, :args) || Map.get(launcher, "args")
+
+    cond do
+      not is_binary(command) or byte_size(command) == 0 ->
+        {:error, {:invalid_launcher, :command}}
+
+      not is_list(args) or args == [] ->
+        {:error, {:invalid_launcher, :args}}
+
+      not Enum.all?(args, &valid_arg?/1) ->
+        {:error, {:invalid_launcher, :args_template}}
+
+      true ->
+        {:ok, %{adapter: :shell, command: command, args: args}}
+    end
+  end
+
+  defp parse_launcher(other), do: {:error, {:unknown_launcher, other}}
+
+  defp valid_arg?(:task), do: true
+  defp valid_arg?(arg) when is_binary(arg), do: true
+  defp valid_arg?(_), do: false
+
+  defp to_atom(nil), do: nil
+  defp to_atom(value) when is_atom(value), do: value
+  defp to_atom(value) when is_binary(value), do: String.to_atom(value)
+end

--- a/lib/controlkeel/autonomy/job.ex
+++ b/lib/controlkeel/autonomy/job.ex
@@ -33,13 +33,18 @@ defmodule ControlKeel.Autonomy.Job do
   @enforce_keys [:name, :interval_ms, :title, :task]
   defstruct [:name, :interval_ms, :title, :task, :agent, :launcher]
 
-  @type launcher :: %{adapter: :shell, command: binary(), args: [binary() | :task]}
+  @type launcher :: %{
+          adapter: :shell,
+          command: binary(),
+          args: [binary() | :task],
+          timeout_ms: pos_integer() | nil
+        }
   @type t :: %__MODULE__{
-          name: atom(),
+          name: String.t(),
           interval_ms: pos_integer(),
           title: String.t(),
           task: String.t(),
-          agent: atom() | nil,
+          agent: String.t() | nil,
           launcher: launcher() | nil
         }
 
@@ -62,7 +67,7 @@ defmodule ControlKeel.Autonomy.Job do
          interval_ms: interval_ms,
          title: title,
          task: task,
-         agent: to_atom(config[:agent]),
+         agent: normalize_optional_string(config[:agent]),
          launcher: launcher
        }}
     end
@@ -104,8 +109,12 @@ defmodule ControlKeel.Autonomy.Job do
   defp normalize(config) when is_map(config), do: Map.to_list(config)
 
   defp parse_name(nil), do: {:error, {:missing, :name}}
-  defp parse_name(name) when is_atom(name), do: {:ok, name}
-  defp parse_name(name) when is_binary(name), do: {:ok, String.to_atom(name)}
+  defp parse_name(name) when is_atom(name), do: {:ok, Atom.to_string(name)}
+
+  defp parse_name(name) when is_binary(name) and byte_size(name) > 0 do
+    {:ok, name}
+  end
+
   defp parse_name(other), do: {:error, {:invalid_name, other}}
 
   defp parse_interval(nil), do: {:error, {:missing, :interval_ms}}
@@ -129,6 +138,7 @@ defmodule ControlKeel.Autonomy.Job do
   defp parse_launcher(%{adapter: :shell} = launcher) do
     command = Map.get(launcher, :command) || Map.get(launcher, "command")
     args = Map.get(launcher, :args) || Map.get(launcher, "args")
+    timeout_ms = Map.get(launcher, :timeout_ms) || Map.get(launcher, "timeout_ms")
 
     cond do
       not is_binary(command) or byte_size(command) == 0 ->
@@ -140,8 +150,11 @@ defmodule ControlKeel.Autonomy.Job do
       not Enum.all?(args, &valid_arg?/1) ->
         {:error, {:invalid_launcher, :args_template}}
 
+      timeout_ms != nil and (not is_integer(timeout_ms) or timeout_ms <= 0) ->
+        {:error, {:invalid_launcher, :timeout_ms}}
+
       true ->
-        {:ok, %{adapter: :shell, command: command, args: args}}
+        {:ok, %{adapter: :shell, command: command, args: args, timeout_ms: timeout_ms}}
     end
   end
 
@@ -151,7 +164,7 @@ defmodule ControlKeel.Autonomy.Job do
   defp valid_arg?(arg) when is_binary(arg), do: true
   defp valid_arg?(_), do: false
 
-  defp to_atom(nil), do: nil
-  defp to_atom(value) when is_atom(value), do: value
-  defp to_atom(value) when is_binary(value), do: String.to_atom(value)
+  defp normalize_optional_string(nil), do: nil
+  defp normalize_optional_string(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_optional_string(value) when is_binary(value), do: value
 end

--- a/lib/controlkeel/autonomy/launcher/shell.ex
+++ b/lib/controlkeel/autonomy/launcher/shell.ex
@@ -181,7 +181,7 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
         :ok
 
       kill ->
-        _ = System.cmd(kill, ["-#{signal}", "-#{os_pid}"], stderr_to_stdout: true)
+        _ = System.cmd(kill, ["-#{signal}", "--", "-#{os_pid}"], stderr_to_stdout: true)
         :ok
     end
   rescue

--- a/lib/controlkeel/autonomy/launcher/shell.ex
+++ b/lib/controlkeel/autonomy/launcher/shell.ex
@@ -25,7 +25,9 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
   * **Process-tree timeout.** Unix launches use a Python `os.setsid()+execv()`
     wrapper so the tracked PID remains the dedicated process-group leader;
     Windows uses `taskkill /T`. Timeout termination targets the entire tree, not
-    only the BEAM port owner. Launching fails closed when isolation is unavailable.
+    only the BEAM port owner. A timeout is reported only after shutdown is
+    confirmed; otherwise the launcher returns an explicit termination failure.
+    Launching fails closed when isolation is unavailable.
 
   ## Example
 
@@ -42,6 +44,9 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
 
   @max_output_bytes 8_192
   @default_timeout_ms 300_000
+  @termination_grace_ms 100
+  @termination_confirm_ms 500
+  @termination_poll_ms 10
 
   @type launch_result ::
           {:ok, %{exit_status: non_neg_integer(), output: binary()}} | {:error, term()}
@@ -129,9 +134,10 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
         {:ok, %{exit_status: status, output: finalize_output(output)}}
     after
       remaining ->
-        terminate_tree(os_pid, isolation)
-        safe_port_close(port)
-        {:error, {:launch_timeout, timeout_ms}}
+        case terminate_tree(port, os_pid, isolation) do
+          :ok -> {:error, {:launch_timeout, timeout_ms}}
+          {:error, reason} -> {:error, {:launch_termination_failed, timeout_ms, reason}}
+        end
     end
   end
 
@@ -157,35 +163,231 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
                 " assert os.getpgrp() == os.getpid()\n" <>
                 "os.execv(sys.argv[1], sys.argv[1:])"
 
-            {:ok, python, ["-c", script, command_path | args], :unix_process_group}
+            {:ok, python, ["-c", script, command_path | args], {:unix_process_group, python}}
         end
     end
   end
 
-  defp terminate_tree(os_pid, :unix_process_group) do
-    signal_process_group(os_pid, "TERM")
-    Process.sleep(100)
-    signal_process_group(os_pid, "KILL")
+  defp terminate_tree(port, os_pid, {:unix_process_group, python}) do
+    result =
+      with {:ok, kill} <- executable("kill"),
+           :ok <- signal_process_group(kill, python, os_pid, "TERM") do
+        safe_port_close(port)
+        wait(@termination_grace_ms)
+
+        case portable_process_group_alive?(python, os_pid) do
+          {:ok, false} ->
+            :ok
+
+          {:ok, true} ->
+            with :ok <- signal_process_group(kill, python, os_pid, "KILL"),
+                 :ok <- await_process_group_exit(python, os_pid, @termination_confirm_ms) do
+              :ok
+            end
+
+          {:error, _reason} = error ->
+            error
+        end
+      end
+
+    safe_port_close(port)
+    result
   end
 
-  defp terminate_tree(os_pid, :windows_tree) do
-    _ = System.cmd("taskkill", ["/PID", to_string(os_pid), "/T", "/F"], stderr_to_stdout: true)
-    :ok
+  defp terminate_tree(port, os_pid, :windows_tree) do
+    result =
+      with {:ok, taskkill} <- executable("taskkill"),
+           {_output, 0} <-
+             System.cmd(taskkill, ["/PID", to_string(os_pid), "/T", "/F"], stderr_to_stdout: true) do
+        safe_port_close(port)
+        await_windows_process_exit(os_pid, @termination_confirm_ms)
+      else
+        {output, status} when is_integer(status) ->
+          {:error, command_failure(:taskkill_failed, status, output)}
+
+        {:error, _reason} = error ->
+          error
+      end
+
+    safe_port_close(port)
+    result
   rescue
-    _ -> :ok
+    error ->
+      safe_port_close(port)
+      {:error, {:taskkill_exception, Exception.message(error)}}
   end
 
-  defp signal_process_group(os_pid, signal) do
-    case System.find_executable("kill") do
-      nil ->
+  defp executable(name) do
+    case System.find_executable(name) do
+      nil -> {:error, {:executable_unavailable, name}}
+      path -> {:ok, path}
+    end
+  end
+
+  defp signal_process_group(kill, python, os_pid, signal) do
+    case System.cmd(kill, ["-#{signal}", "--", "-#{os_pid}"], stderr_to_stdout: true) do
+      {_output, 0} ->
         :ok
 
-      kill ->
-        _ = System.cmd(kill, ["-#{signal}", "--", "-#{os_pid}"], stderr_to_stdout: true)
-        :ok
+      {output, status} ->
+        case portable_process_group_alive?(python, os_pid) do
+          {:ok, false} -> :ok
+          {:ok, true} -> {:error, command_failure(:signal_failed, status, output)}
+          {:error, _reason} = error -> error
+        end
     end
   rescue
-    _ -> :ok
+    error -> {:error, {:signal_exception, signal, Exception.message(error)}}
+  end
+
+  defp await_process_group_exit(python, os_pid, timeout_ms) do
+    deadline = monotonic_ms() + timeout_ms
+    do_await_process_group_exit(python, os_pid, deadline)
+  end
+
+  defp do_await_process_group_exit(python, os_pid, deadline) do
+    case process_group_alive?(python, os_pid) do
+      {:ok, false} ->
+        :ok
+
+      {:ok, true} ->
+        if monotonic_ms() >= deadline do
+          {:error, :still_running}
+        else
+          receive do
+          after
+            @termination_poll_ms ->
+              do_await_process_group_exit(python, os_pid, deadline)
+          end
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp process_group_alive?(python, os_pid) do
+    if :os.type() == {:unix, :linux} do
+      linux_process_group_alive?(os_pid)
+    else
+      portable_process_group_alive?(python, os_pid)
+    end
+  end
+
+  defp portable_process_group_alive?(python, os_pid) do
+    script =
+      "import os,sys\n" <>
+        "try:\n os.killpg(int(sys.argv[1]), 0)\n" <>
+        "except ProcessLookupError:\n sys.exit(1)\n" <>
+        "except PermissionError:\n sys.exit(2)"
+
+    case System.cmd(python, ["-c", script, to_string(os_pid)], stderr_to_stdout: true) do
+      {_output, 0} -> {:ok, true}
+      {_output, 1} -> {:ok, false}
+      {output, status} -> {:error, command_failure(:liveness_check_failed, status, output)}
+    end
+  rescue
+    error -> {:error, {:liveness_check_failed, Exception.message(error)}}
+  end
+
+  defp linux_process_group_alive?(os_pid) do
+    case File.ls("/proc") do
+      {:ok, entries} ->
+        Enum.reduce_while(entries, {:ok, false}, fn entry, _acc ->
+          result =
+            case Integer.parse(entry) do
+              {_pid, ""} -> runnable_process_group_member?(entry, os_pid)
+              _ -> {:ok, false}
+            end
+
+          case result do
+            {:ok, true} -> {:halt, {:ok, true}}
+            {:ok, false} -> {:cont, {:ok, false}}
+            {:error, _reason} = error -> {:halt, error}
+          end
+        end)
+
+      {:error, reason} ->
+        {:error, {:proc_unavailable, reason}}
+    end
+  end
+
+  defp runnable_process_group_member?(pid, os_pid) do
+    with {:ok, stat} <- File.read("/proc/#{pid}/stat"),
+         {:ok, state, process_group} <- parse_proc_stat(stat),
+         {process_group, ""} <- Integer.parse(process_group) do
+      {:ok, process_group == os_pid and state not in ["Z", "X", "x"]}
+    else
+      {:error, :enoent} -> {:ok, false}
+      {:error, reason} -> {:error, {:proc_stat_unavailable, pid, reason}}
+      _ -> {:error, {:invalid_proc_stat, pid}}
+    end
+  end
+
+  defp parse_proc_stat(stat) do
+    case :binary.matches(stat, ") ") do
+      [] ->
+        {:error, :missing_comm_delimiter}
+
+      matches ->
+        {position, delimiter_size} = List.last(matches)
+        offset = position + delimiter_size
+        remainder = binary_part(stat, offset, byte_size(stat) - offset)
+
+        case remainder |> :binary.split(" ", [:global]) |> Enum.reject(&(&1 == "")) do
+          [state, _parent_pid, process_group | _rest] ->
+            {:ok, state, process_group}
+
+          _ ->
+            {:error, :missing_process_fields}
+        end
+    end
+  end
+
+  defp await_windows_process_exit(os_pid, timeout_ms) do
+    with {:ok, tasklist} <- executable("tasklist") do
+      deadline = monotonic_ms() + timeout_ms
+      do_await_windows_process_exit(tasklist, os_pid, deadline)
+    end
+  end
+
+  defp do_await_windows_process_exit(tasklist, os_pid, deadline) do
+    case System.cmd(
+           tasklist,
+           ["/FI", "PID eq #{os_pid}", "/FO", "CSV", "/NH"],
+           stderr_to_stdout: true
+         ) do
+      {output, 0} ->
+        if Regex.match?(~r/"#{os_pid}"/, output) do
+          if monotonic_ms() >= deadline do
+            {:error, :still_running}
+          else
+            receive do
+            after
+              @termination_poll_ms ->
+                do_await_windows_process_exit(tasklist, os_pid, deadline)
+            end
+          end
+        else
+          :ok
+        end
+
+      {output, status} ->
+        {:error, command_failure(:tasklist_failed, status, output)}
+    end
+  rescue
+    error -> {:error, {:liveness_check_failed, Exception.message(error)}}
+  end
+
+  defp command_failure(kind, status, output) do
+    {kind, status, output |> then(&append_output(<<>>, &1)) |> finalize_output()}
+  end
+
+  defp wait(timeout_ms) do
+    receive do
+    after
+      timeout_ms -> :ok
+    end
   end
 
   defp safe_port_close(port) do

--- a/lib/controlkeel/autonomy/launcher/shell.ex
+++ b/lib/controlkeel/autonomy/launcher/shell.ex
@@ -7,10 +7,12 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
   This is the only module in the autonomy subsystem that executes an external
   process, so its trust boundary is intentionally narrow:
 
-  * **argv, not a shell string.** Execution uses `System.cmd/3` with an explicit
-    argument list. The job's task text is substituted as a *single discrete argv
-    element* via the `:task` placeholder — it is never interpolated into a shell
-    string, which removes the shell-injection surface entirely.
+  * **argv, not an implicit shell string.** Execution uses `System.cmd/3` with an
+    explicit argument list. The job's task text is substituted as a *single
+    discrete argv element* via the `:task` placeholder. ControlKeel does not
+    implicitly invoke a shell; an operator who explicitly configures `sh -c`,
+    `bash -c`, or another interpreter can reintroduce shell parsing and owns that
+    trust boundary.
   * **Explicit opt-in.** Gated on the `CK_AUTONOMY_ALLOW_SHELL` environment
     variable or `config :controlkeel, autonomy: [allow_shell: true]`. When neither
     is set, `run/1` returns `{:error, :shell_not_allowed}` and launches nothing.
@@ -35,6 +37,7 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
   alias ControlKeel.Autonomy.Job
 
   @max_output_bytes 8_192
+  @default_timeout_ms 300_000
 
   @type launch_result ::
           {:ok, %{exit_status: non_neg_integer(), output: binary()}} | {:error, term()}
@@ -54,14 +57,20 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
   @spec run(Job.t(), keyword()) :: launch_result()
   def run(job, opts \\ [])
 
-  def run(%Job{launcher: %{adapter: :shell}} = job, _opts) do
+  def run(%Job{launcher: %{adapter: :shell}} = job, opts) do
     unless enabled?(), do: throw(:shell_not_allowed)
 
     %{command: command, args: template} = job.launcher
     args = resolve_args(template, job)
+    timeout_ms = launch_timeout_ms(job, opts)
 
-    {output, status} = System.cmd(command, args, stderr_to_stdout: true)
-    {:ok, %{exit_status: status, output: truncate(output)}}
+    task = Task.async(fn -> execute(command, args) end)
+
+    case Task.yield(task, timeout_ms) || Task.shutdown(task, :brutal_kill) do
+      {:ok, result} -> result
+      {:exit, reason} -> {:error, {:launch_failed, inspect(reason)}}
+      nil -> {:error, {:launch_timeout, timeout_ms}}
+    end
   catch
     :shell_not_allowed ->
       {:error, :shell_not_allowed}
@@ -75,6 +84,14 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
 
   def run(_job, _opts), do: {:error, :no_shell_launcher}
 
+  defp execute(command, args) do
+    {output, status} = System.cmd(command, args, stderr_to_stdout: true)
+    {:ok, %{exit_status: status, output: truncate(output)}}
+  catch
+    :error, :enoent -> {:error, {:launch_failed, :enoent}}
+    kind, reason -> {:error, {:launch_failed, {kind, inspect(reason)}}}
+  end
+
   defp resolve_args(template, %Job{task: task}) when is_list(template) do
     Enum.map(template, fn
       :task -> task
@@ -83,7 +100,20 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
   end
 
   defp truncate(output) when is_binary(output) do
-    String.slice(output, 0, @max_output_bytes)
+    output =
+      if byte_size(output) > @max_output_bytes do
+        binary_part(output, 0, @max_output_bytes)
+      else
+        output
+      end
+
+    String.replace_invalid(output)
+  end
+
+  defp launch_timeout_ms(job, opts) do
+    Keyword.get(opts, :timeout_ms) || job.launcher.timeout_ms ||
+      Application.get_env(:controlkeel, :autonomy, [])
+      |> Keyword.get(:launch_timeout_ms, @default_timeout_ms)
   end
 
   defp env_enabled? do

--- a/lib/controlkeel/autonomy/launcher/shell.ex
+++ b/lib/controlkeel/autonomy/launcher/shell.ex
@@ -1,0 +1,96 @@
+defmodule ControlKeel.Autonomy.Launcher.Shell do
+  @moduledoc """
+  Capability-gated shell launcher: invokes a configured agent program on schedule.
+
+  ## Security model
+
+  This is the only module in the autonomy subsystem that executes an external
+  process, so its trust boundary is intentionally narrow:
+
+  * **argv, not a shell string.** Execution uses `System.cmd/3` with an explicit
+    argument list. The job's task text is substituted as a *single discrete argv
+    element* via the `:task` placeholder — it is never interpolated into a shell
+    string, which removes the shell-injection surface entirely.
+  * **Explicit opt-in.** Gated on the `CK_AUTONOMY_ALLOW_SHELL` environment
+    variable or `config :controlkeel, autonomy: [allow_shell: true]`. When neither
+    is set, `run/1` returns `{:error, :shell_not_allowed}` and launches nothing.
+  * **Trusted template.** The `command` and `args` template are operator-configured
+    (trusted source). Only the `:task` placeholder receives job-supplied text, and
+    only as an argv element.
+  * **Captured, never streamed.** Output is captured and truncated; every launch
+    result (exit status + truncated output) is returned to the dispatcher, which
+    records it in a governed session event for audit.
+
+  ## Example
+
+      %ControlKeel.Autonomy.Job{
+        launcher: %{adapter: :shell, command: "opencode", args: ["run", :task]}
+      }
+
+  resolves, for `task: "Triage open tickets"`, to:
+
+      System.cmd("opencode", ["run", "Triage open tickets"], stderr_to_stdout: true)
+  """
+
+  alias ControlKeel.Autonomy.Job
+
+  @max_output_bytes 8_192
+
+  @type launch_result ::
+          {:ok, %{exit_status: non_neg_integer(), output: binary()}} | {:error, term()}
+
+  @doc "Whether shell launching is explicitly enabled."
+  def enabled? do
+    env_enabled?() or config_enabled?()
+  end
+
+  @doc """
+  Execute the launcher for `job`.
+
+  Returns `{:ok, %{exit_status, output}}` on execution (including non-zero exits,
+  which are captured, not raised) or `{:error, reason}` when launching is disabled
+  or the program is missing.
+  """
+  @spec run(Job.t(), keyword()) :: launch_result()
+  def run(job, opts \\ [])
+
+  def run(%Job{launcher: %{adapter: :shell}} = job, _opts) do
+    unless enabled?(), do: throw(:shell_not_allowed)
+
+    %{command: command, args: template} = job.launcher
+    args = resolve_args(template, job)
+
+    {output, status} = System.cmd(command, args, stderr_to_stdout: true)
+    {:ok, %{exit_status: status, output: truncate(output)}}
+  catch
+    :shell_not_allowed ->
+      {:error, :shell_not_allowed}
+
+    :error, :enoent ->
+      {:error, {:launch_failed, :enoent}}
+
+    kind, reason ->
+      {:error, {:launch_failed, {kind, reason}}}
+  end
+
+  def run(_job, _opts), do: {:error, :no_shell_launcher}
+
+  defp resolve_args(template, %Job{task: task}) when is_list(template) do
+    Enum.map(template, fn
+      :task -> task
+      other when is_binary(other) -> other
+    end)
+  end
+
+  defp truncate(output) when is_binary(output) do
+    String.slice(output, 0, @max_output_bytes)
+  end
+
+  defp env_enabled? do
+    System.get_env("CK_AUTONOMY_ALLOW_SHELL") in ~w(1 true TRUE yes YES)
+  end
+
+  defp config_enabled? do
+    Application.get_env(:controlkeel, :autonomy, []) |> Keyword.get(:allow_shell, false)
+  end
+end

--- a/lib/controlkeel/autonomy/launcher/shell.ex
+++ b/lib/controlkeel/autonomy/launcher/shell.ex
@@ -22,6 +22,9 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
   * **Captured, never streamed.** Output is captured and truncated; every launch
     result (exit status + truncated output) is returned to the dispatcher, which
     records it in a governed session event for audit.
+  * **Process-tree timeout.** Unix launches run in a dedicated OS process group
+    (`setsid`, with Python `os.setsid` fallback); Windows uses `taskkill /T`.
+    Timeout termination targets the entire tree, not only the BEAM port owner.
 
   ## Example
 
@@ -64,13 +67,7 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
     args = resolve_args(template, job)
     timeout_ms = launch_timeout_ms(job, opts)
 
-    task = Task.async(fn -> execute(command, args) end)
-
-    case Task.yield(task, timeout_ms) || Task.shutdown(task, :brutal_kill) do
-      {:ok, result} -> result
-      {:exit, reason} -> {:error, {:launch_failed, inspect(reason)}}
-      nil -> {:error, {:launch_timeout, timeout_ms}}
-    end
+    execute(command, args, timeout_ms)
   catch
     :shell_not_allowed ->
       {:error, :shell_not_allowed}
@@ -84,30 +81,141 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
 
   def run(_job, _opts), do: {:error, :no_shell_launcher}
 
-  defp execute(command, args) do
-    {output, status} = System.cmd(command, args, stderr_to_stdout: true)
-    {:ok, %{exit_status: status, output: truncate(output)}}
+  defp execute(command, args, timeout_ms) do
+    with command_path when is_binary(command_path) <- System.find_executable(command),
+         {:ok, executable, isolated_args, isolation} <- isolated_command(command_path, args),
+         {:ok, port, os_pid} <- open_port(executable, isolated_args) do
+      collect(port, os_pid, isolation, <<>>, monotonic_ms() + timeout_ms, timeout_ms)
+    else
+      nil -> {:error, {:launch_failed, :enoent}}
+      {:error, _reason} = error -> error
+    end
   catch
-    :error, :enoent -> {:error, {:launch_failed, :enoent}}
     kind, reason -> {:error, {:launch_failed, {kind, inspect(reason)}}}
   end
+
+  defp open_port(executable, args) do
+    port =
+      Port.open(
+        {:spawn_executable, String.to_charlist(executable)},
+        [
+          :binary,
+          :exit_status,
+          :stderr_to_stdout,
+          :use_stdio,
+          args: Enum.map(args, &String.to_charlist/1)
+        ]
+      )
+
+    case Port.info(port, :os_pid) do
+      {:os_pid, pid} ->
+        {:ok, port, pid}
+
+      nil ->
+        safe_port_close(port)
+        {:error, {:launch_failed, :missing_os_pid}}
+    end
+  end
+
+  defp collect(port, os_pid, isolation, output, deadline, timeout_ms) do
+    remaining = max(deadline - monotonic_ms(), 0)
+
+    receive do
+      {^port, {:data, data}} ->
+        collect(port, os_pid, isolation, append_output(output, data), deadline, timeout_ms)
+
+      {^port, {:exit_status, status}} ->
+        {:ok, %{exit_status: status, output: finalize_output(output)}}
+    after
+      remaining ->
+        terminate_tree(os_pid, isolation)
+        safe_port_close(port)
+        {:error, {:launch_timeout, timeout_ms}}
+    end
+  end
+
+  # On Unix, run each launcher in a new session/process group so timeout signals
+  # target the whole tree. `setsid` is preferred; Python's os.setsid wrapper is a
+  # portable fallback on macOS installations without the setsid utility. If
+  # neither exists, fail closed rather than launch a process tree we cannot stop.
+  defp isolated_command(command_path, args) do
+    case :os.type() do
+      {:win32, _} ->
+        {:ok, command_path, args, :windows_tree}
+
+      {:unix, _} ->
+        cond do
+          setsid = System.find_executable("setsid") ->
+            {:ok, setsid, [command_path | args], :unix_process_group}
+
+          python = System.find_executable("python3") ->
+            script =
+              "import os,sys\n" <>
+                "try:\n os.setsid()\n" <>
+                "except PermissionError:\n" <>
+                " assert os.getpgrp() == os.getpid()\n" <>
+                "os.execv(sys.argv[1], sys.argv[1:])"
+
+            {:ok, python, ["-c", script, command_path | args], :unix_process_group}
+
+          true ->
+            {:error, :process_group_unavailable}
+        end
+    end
+  end
+
+  defp terminate_tree(os_pid, :unix_process_group) do
+    signal_process_group(os_pid, "TERM")
+    Process.sleep(100)
+    signal_process_group(os_pid, "KILL")
+  end
+
+  defp terminate_tree(os_pid, :windows_tree) do
+    _ = System.cmd("taskkill", ["/PID", to_string(os_pid), "/T", "/F"], stderr_to_stdout: true)
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp signal_process_group(os_pid, signal) do
+    case System.find_executable("kill") do
+      nil ->
+        :ok
+
+      kill ->
+        _ = System.cmd(kill, ["-#{signal}", "-#{os_pid}"], stderr_to_stdout: true)
+        :ok
+    end
+  rescue
+    _ -> :ok
+  end
+
+  defp safe_port_close(port) do
+    if Port.info(port), do: Port.close(port)
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp append_output(output, data) do
+    remaining = @max_output_bytes - byte_size(output)
+
+    cond do
+      remaining <= 0 -> output
+      byte_size(data) <= remaining -> output <> data
+      true -> output <> binary_part(data, 0, remaining)
+    end
+  end
+
+  defp finalize_output(output), do: String.replace_invalid(output)
+
+  defp monotonic_ms, do: System.monotonic_time(:millisecond)
 
   defp resolve_args(template, %Job{task: task}) when is_list(template) do
     Enum.map(template, fn
       :task -> task
       other when is_binary(other) -> other
     end)
-  end
-
-  defp truncate(output) when is_binary(output) do
-    output =
-      if byte_size(output) > @max_output_bytes do
-        binary_part(output, 0, @max_output_bytes)
-      else
-        output
-      end
-
-    String.replace_invalid(output)
   end
 
   defp launch_timeout_ms(job, opts) do

--- a/lib/controlkeel/autonomy/launcher/shell.ex
+++ b/lib/controlkeel/autonomy/launcher/shell.ex
@@ -24,10 +24,12 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
     records it in a governed session event for audit.
   * **Process-tree timeout.** Unix launches use a Python `os.setsid()+execv()`
     wrapper so the tracked PID remains the dedicated process-group leader;
-    Windows uses `taskkill /T`. Timeout termination targets the entire tree, not
-    only the BEAM port owner. A timeout is reported only after shutdown is
-    confirmed; otherwise the launcher returns an explicit termination failure.
-    Launching fails closed when isolation is unavailable.
+    Windows uses `taskkill /T`. Timeout termination targets the managed process
+    group/tree, not only the BEAM port owner. Launcher commands are trusted
+    configuration and must not deliberately escape that boundary by daemonizing,
+    double-forking, or creating another session. A timeout is reported only after
+    managed shutdown is confirmed; otherwise the launcher returns an explicit
+    termination failure. Launching fails closed when isolation is unavailable.
 
   ## Example
 

--- a/lib/controlkeel/autonomy/launcher/shell.ex
+++ b/lib/controlkeel/autonomy/launcher/shell.ex
@@ -22,9 +22,10 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
   * **Captured, never streamed.** Output is captured and truncated; every launch
     result (exit status + truncated output) is returned to the dispatcher, which
     records it in a governed session event for audit.
-  * **Process-tree timeout.** Unix launches run in a dedicated OS process group
-    (`setsid`, with Python `os.setsid` fallback); Windows uses `taskkill /T`.
-    Timeout termination targets the entire tree, not only the BEAM port owner.
+  * **Process-tree timeout.** Unix launches use a Python `os.setsid()+execv()`
+    wrapper so the tracked PID remains the dedicated process-group leader;
+    Windows uses `taskkill /T`. Timeout termination targets the entire tree, not
+    only the BEAM port owner. Launching fails closed when isolation is unavailable.
 
   ## Example
 
@@ -135,20 +136,20 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
   end
 
   # On Unix, run each launcher in a new session/process group so timeout signals
-  # target the whole tree. `setsid` is preferred; Python's os.setsid wrapper is a
-  # portable fallback on macOS installations without the setsid utility. If
-  # neither exists, fail closed rather than launch a process tree we cannot stop.
+  # target the whole tree. A Python os.setsid()+execv wrapper keeps the tracked
+  # port PID as the process-group leader (unlike the setsid utility, which may
+  # fork). Fail closed when the isolation helper is unavailable.
   defp isolated_command(command_path, args) do
     case :os.type() do
       {:win32, _} ->
         {:ok, command_path, args, :windows_tree}
 
       {:unix, _} ->
-        cond do
-          setsid = System.find_executable("setsid") ->
-            {:ok, setsid, [command_path | args], :unix_process_group}
+        case System.find_executable("python3") do
+          nil ->
+            {:error, :process_group_unavailable}
 
-          python = System.find_executable("python3") ->
+          python ->
             script =
               "import os,sys\n" <>
                 "try:\n os.setsid()\n" <>
@@ -157,9 +158,6 @@ defmodule ControlKeel.Autonomy.Launcher.Shell do
                 "os.execv(sys.argv[1], sys.argv[1:])"
 
             {:ok, python, ["-c", script, command_path | args], :unix_process_group}
-
-          true ->
-            {:error, :process_group_unavailable}
         end
     end
   end

--- a/lib/controlkeel/autonomy/scheduler.ex
+++ b/lib/controlkeel/autonomy/scheduler.ex
@@ -92,31 +92,64 @@ defmodule ControlKeel.Autonomy.Scheduler do
   def init(opts) do
     case Job.from_config_all(config_jobs()) do
       {:ok, jobs} ->
-        state = %{timers: arm_jobs(jobs), workspace_id: workspace_opt(opts), config_error: nil}
+        state = %{
+          timers: arm_jobs(jobs),
+          in_flight: %{},
+          workspace_id: workspace_opt(opts),
+          config_error: nil
+        }
+
         {:ok, state}
 
       {:error, reason} ->
         Logger.error("[autonomy] invalid job config; scheduler started inert: #{inspect(reason)}")
 
-        {:ok, %{timers: %{}, workspace_id: workspace_opt(opts), config_error: reason}}
+        {:ok,
+         %{timers: %{}, in_flight: %{}, workspace_id: workspace_opt(opts), config_error: reason}}
     end
   end
 
   @impl true
   def handle_info({:fire, name}, state) do
+    state =
+      if Map.has_key?(state.in_flight, name) do
+        Logger.warning(
+          "[autonomy] job #{inspect(name)} is already running; skipped overlapping tick"
+        )
+
+        state
+      else
+        start_dispatch(name, state)
+      end
+
+    {:noreply, rearm(name, state)}
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    in_flight =
+      state.in_flight
+      |> Enum.reject(fn {_name, monitor_ref} -> monitor_ref == ref end)
+      |> Map.new()
+
+    {:noreply, %{state | in_flight: in_flight}}
+  end
+
+  defp start_dispatch(name, state) do
     opts = workspace_opts(state)
 
     case Task.Supervisor.start_child(@task_supervisor, fn -> dispatch_and_log(name, opts) end) do
-      {:ok, _pid} ->
-        :ok
+      {:ok, pid} ->
+        ref = Process.monitor(pid)
+        %{state | in_flight: Map.put(state.in_flight, name, ref)}
 
       {:error, reason} ->
         Logger.warning(
           "[autonomy] could not start dispatch task for #{inspect(name)}: #{inspect(reason)}"
         )
-    end
 
-    {:noreply, rearm(name, state)}
+        state
+    end
   end
 
   defp dispatch_and_log(name, opts) do

--- a/lib/controlkeel/autonomy/scheduler.ex
+++ b/lib/controlkeel/autonomy/scheduler.ex
@@ -1,0 +1,167 @@
+defmodule ControlKeel.Autonomy.Scheduler do
+  @moduledoc """
+  Governed, BEAM-native autonomy scheduler.
+
+  Fires configured `ControlKeel.Autonomy.Job`s on a timer and dispatches each
+  through `ControlKeel.Autonomy.Dispatcher`, producing a governed wake-up
+  (session + task + audit event) and optionally launching an agent.
+
+  This is ControlKeel's answer to cron-driven autonomy: an external scheduler
+  (gumclaw's model) becomes a governed heartbeat that records every wake-up.
+
+  ## Configuration
+
+      config :controlkeel,
+        autonomy: [
+          enabled: true,
+          allow_shell: false,
+          workspace_id: 1,
+          jobs: [
+            %{name: :daily_triage, interval_ms: :timer.hours(6),
+              title: "Triage", task: "Triage open support tickets."}
+          ]
+        ]
+
+  Enabled via `CK_AUTONOMY_SCHEDULER` env var or `autonomy: [enabled: true]`.
+  Never starts inside an MCP stdio server process.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias ControlKeel.Autonomy.Dispatcher
+  alias ControlKeel.Autonomy.Job
+
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :permanent,
+      type: :worker
+    }
+  end
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc "Whether the autonomy scheduler is explicitly enabled."
+  def enabled? do
+    env_enabled?() or config_enabled?()
+  end
+
+  @doc "Parsed configured jobs, or `[]` when none/invalid (errors are logged)."
+  def jobs do
+    case Job.from_config_all(config_jobs()) do
+      {:ok, jobs} ->
+        jobs
+
+      {:error, reason} ->
+        Logger.warning("[autonomy] job config invalid: #{inspect(reason)}")
+        []
+    end
+  end
+
+  @doc "Workspace id resolved from config, or nil."
+  def workspace_id do
+    autonomy_config() |> Keyword.get(:workspace_id)
+  end
+
+  @doc """
+  Fire a single job by name now, regardless of its timer. Safe to call without
+  the GenServer running (used by `mix ck.autonomy run` and tests).
+
+  Options: `:dry_run`, `:workspace_id`.
+  """
+  def run_once(name, opts \\ []) when is_atom(name) do
+    opts = put_workspace_opt(opts)
+
+    case Enum.find(jobs(), &(&1.name == name)) do
+      nil -> {:error, {:unknown_job, name}}
+      job -> Dispatcher.dispatch(job, opts)
+    end
+  end
+
+  # --- GenServer callbacks ---
+
+  @impl true
+  def init(opts) do
+    case Job.from_config_all(config_jobs()) do
+      {:ok, jobs} ->
+        state = %{timers: arm_jobs(jobs), workspace_id: workspace_opt(opts)}
+        {:ok, state}
+
+      {:error, reason} ->
+        Logger.error("[autonomy] refusing to start — invalid job config: #{inspect(reason)}")
+        {:stop, {:invalid_jobs, reason}}
+    end
+  end
+
+  @impl true
+  def handle_info({:fire, name}, state) do
+    opts = workspace_opts(state)
+
+    case run_once(name, opts) do
+      {:ok, %{session_id: sid}} ->
+        Logger.debug("[autonomy] job #{inspect(name)} fired -> session ##{sid}")
+
+      {:error, reason} ->
+        Logger.warning("[autonomy] job #{inspect(name)} failed: #{inspect(reason)}")
+    end
+
+    {:noreply, rearm(name, state)}
+  end
+
+  defp rearm(name, %{timers: timers} = state) do
+    case Enum.find(jobs(), &(&1.name == name)) do
+      %Job{interval_ms: ms} ->
+        %{state | timers: Map.put(timers, name, Process.send_after(self(), {:fire, name}, ms))}
+
+      nil ->
+        # Job removed from config mid-flight; leave disarmed.
+        state
+    end
+  end
+
+  defp arm_jobs(jobs) do
+    Enum.reduce(jobs, %{}, fn job, acc ->
+      Map.put(acc, job.name, arm_timer(job))
+    end)
+  end
+
+  defp arm_timer(%Job{interval_ms: interval_ms, name: name}) do
+    Process.send_after(self(), {:fire, name}, interval_ms)
+  end
+
+  defp workspace_opts(%{workspace_id: id}) when is_integer(id), do: [workspace_id: id]
+  defp workspace_opts(_), do: []
+
+  defp workspace_opt(opts) do
+    Keyword.get(opts, :workspace_id) || workspace_id()
+  end
+
+  defp put_workspace_opt(opts) do
+    if Keyword.has_key?(opts, :workspace_id) do
+      opts
+    else
+      Keyword.put(opts, :workspace_id, workspace_id())
+    end
+  end
+
+  defp env_enabled? do
+    System.get_env("CK_AUTONOMY_SCHEDULER") in ~w(1 true TRUE yes YES)
+  end
+
+  defp config_enabled? do
+    autonomy_config() |> Keyword.get(:enabled, false)
+  end
+
+  defp config_jobs do
+    autonomy_config() |> Keyword.get(:jobs, [])
+  end
+
+  defp autonomy_config do
+    Application.get_env(:controlkeel, :autonomy, [])
+  end
+end

--- a/lib/controlkeel/autonomy/scheduler.ex
+++ b/lib/controlkeel/autonomy/scheduler.ex
@@ -33,6 +33,8 @@ defmodule ControlKeel.Autonomy.Scheduler do
   alias ControlKeel.Autonomy.Dispatcher
   alias ControlKeel.Autonomy.Job
 
+  @task_supervisor ControlKeel.Autonomy.TaskSupervisor
+
   def child_spec(opts) do
     %{
       id: __MODULE__,
@@ -74,8 +76,9 @@ defmodule ControlKeel.Autonomy.Scheduler do
 
   Options: `:dry_run`, `:workspace_id`.
   """
-  def run_once(name, opts \\ []) when is_atom(name) do
+  def run_once(name, opts \\ []) when is_atom(name) or is_binary(name) do
     opts = put_workspace_opt(opts)
+    name = to_string(name)
 
     case Enum.find(jobs(), &(&1.name == name)) do
       nil -> {:error, {:unknown_job, name}}
@@ -89,12 +92,13 @@ defmodule ControlKeel.Autonomy.Scheduler do
   def init(opts) do
     case Job.from_config_all(config_jobs()) do
       {:ok, jobs} ->
-        state = %{timers: arm_jobs(jobs), workspace_id: workspace_opt(opts)}
+        state = %{timers: arm_jobs(jobs), workspace_id: workspace_opt(opts), config_error: nil}
         {:ok, state}
 
       {:error, reason} ->
-        Logger.error("[autonomy] refusing to start — invalid job config: #{inspect(reason)}")
-        {:stop, {:invalid_jobs, reason}}
+        Logger.error("[autonomy] invalid job config; scheduler started inert: #{inspect(reason)}")
+
+        {:ok, %{timers: %{}, workspace_id: workspace_opt(opts), config_error: reason}}
     end
   end
 
@@ -102,6 +106,20 @@ defmodule ControlKeel.Autonomy.Scheduler do
   def handle_info({:fire, name}, state) do
     opts = workspace_opts(state)
 
+    case Task.Supervisor.start_child(@task_supervisor, fn -> dispatch_and_log(name, opts) end) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "[autonomy] could not start dispatch task for #{inspect(name)}: #{inspect(reason)}"
+        )
+    end
+
+    {:noreply, rearm(name, state)}
+  end
+
+  defp dispatch_and_log(name, opts) do
     case run_once(name, opts) do
       {:ok, %{session_id: sid}} ->
         Logger.debug("[autonomy] job #{inspect(name)} fired -> session ##{sid}")
@@ -109,8 +127,6 @@ defmodule ControlKeel.Autonomy.Scheduler do
       {:error, reason} ->
         Logger.warning("[autonomy] job #{inspect(name)} failed: #{inspect(reason)}")
     end
-
-    {:noreply, rearm(name, state)}
   end
 
   defp rearm(name, %{timers: timers} = state) do

--- a/lib/mix/tasks/ck.autonomy.ex
+++ b/lib/mix/tasks/ck.autonomy.ex
@@ -1,0 +1,123 @@
+defmodule Mix.Tasks.Ck.Autonomy do
+  @shortdoc "List, run, and inspect governed autonomy jobs"
+
+  @moduledoc """
+  Operates the governed autonomy scheduler.
+
+  ## Usage
+
+      mix ck.autonomy              # list configured jobs + scheduler status (default)
+      mix ck.autonomy list         # list configured jobs
+      mix ck.autonomy status       # show enabled state + workspace resolution
+      mix ck.autonomy run <name>   # fire a job once now
+      mix ck.autonomy run <name> --dry-run   # show what would happen, record nothing
+
+  Jobs are defined in `config :controlkeel, autonomy: [jobs: [...]]`. The
+  scheduler must be enabled (`CK_AUTONOMY_SCHEDULER=1` or `autonomy: [enabled: true]`)
+  to arm timers automatically; `run` works regardless.
+  """
+
+  use Mix.Task
+
+  alias ControlKeel.Autonomy.Scheduler
+
+  @impl true
+  def run(args) do
+    Mix.Task.run("app.start")
+    {opts, argv, _} = OptionParser.parse(args, strict: [dry_run: :boolean])
+
+    shell = Mix.shell()
+
+    case {argv, opts[:dry_run]} do
+      {["list" | _], _} ->
+        print_jobs(shell)
+
+      {["status" | _], _} ->
+        print_status(shell)
+
+      {["run", name | _], dry?} ->
+        run_job(shell, name, dry?)
+
+      {[], _} ->
+        print_status(shell)
+        shell.info("")
+        print_jobs(shell)
+
+      _ ->
+        shell.info(@moduledoc)
+    end
+  end
+
+  defp print_jobs(shell) do
+    jobs = Scheduler.jobs()
+
+    if jobs == [] do
+      shell.info("No autonomy jobs configured.")
+    else
+      shell.info(String.duplicate("─", 70))
+      shell.info("Autonomy jobs (#{length(jobs)})")
+
+      Enum.each(jobs, fn job ->
+        shell.info(
+          "  • #{String.pad_trailing(to_string(job.name), 24)} " <>
+            "every #{format_ms(job.interval_ms)}  " <>
+            if(ControlKeel.Autonomy.Job.launcher?(job),
+              do: "[launcher]",
+              else: ""
+            )
+        )
+
+        shell.info("      #{String.slice(job.title, 0, 64)}")
+      end)
+
+      shell.info(String.duplicate("─", 70))
+    end
+  end
+
+  defp print_status(shell) do
+    enabled = Scheduler.enabled?()
+    workspace = Scheduler.workspace_id()
+
+    shell.info("Autonomy scheduler")
+    shell.info(String.duplicate("─", 70))
+    shell.info("  enabled?       #{format_bool(enabled)}")
+    shell.info("  workspace_id   #{workspace || "(resolved per-run)"}")
+    shell.info("  shell launch   #{format_bool(ControlKeel.Autonomy.Launcher.Shell.enabled?())}")
+    shell.info(String.duplicate("─", 70))
+  end
+
+  defp run_job(shell, name, dry?) do
+    opts = if dry?, do: [dry_run: true], else: []
+
+    case Scheduler.run_once(String.to_atom(name), opts) do
+      {:ok, %{dry_run: true} = result} ->
+        shell.info("DRY RUN — nothing recorded, nothing launched.")
+        shell.info("  job:           #{result.job}")
+        shell.info("  workspace_id:  #{result.workspace_id}")
+        shell.info("  would launch:  #{result.launched}")
+
+      {:ok, %{session_id: sid, task_id: tid, launched: launched}} ->
+        shell.info("Fired -> session ##{sid}, task ##{tid}")
+        shell.info("  launched: #{format_launched(launched)}")
+
+      {:error, {:unknown_job, name}} ->
+        Mix.raise("Unknown autonomy job: #{inspect(name)}")
+
+      {:error, reason} ->
+        Mix.raise("Autonomy run failed: #{inspect(reason)}")
+    end
+  end
+
+  defp format_ms(ms) when ms >= 3_600_000, do: "#{div(ms, 3_600_000)}h"
+  defp format_ms(ms) when ms >= 60_000, do: "#{div(ms, 60_000)}m"
+  defp format_ms(ms), do: "#{ms}ms"
+
+  defp format_bool(true), do: "yes"
+  defp format_bool(_), do: "no"
+
+  defp format_launched(nil), do: "no (wake-up only)"
+  defp format_launched(false), do: "no (wake-up only)"
+  defp format_launched(%{exit_status: 0}), do: "yes (exit 0)"
+  defp format_launched(%{exit_status: n}), do: "yes (exit #{n})"
+  defp format_launched(%{error: _} = err), do: "failed (#{inspect(err)})"
+end

--- a/lib/mix/tasks/ck.autonomy.ex
+++ b/lib/mix/tasks/ck.autonomy.ex
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Ck.Autonomy do
   defp run_job(shell, name, dry?) do
     opts = if dry?, do: [dry_run: true], else: []
 
-    case Scheduler.run_once(String.to_atom(name), opts) do
+    case Scheduler.run_once(name, opts) do
       {:ok, %{dry_run: true} = result} ->
         shell.info("DRY RUN — nothing recorded, nothing launched.")
         shell.info("  job:           #{result.job}")

--- a/test/controlkeel/autonomy/dispatcher_test.exs
+++ b/test/controlkeel/autonomy/dispatcher_test.exs
@@ -157,6 +157,7 @@ defmodule ControlKeel.Autonomy.DispatcherTest do
   end
 
   describe "wake-up transaction" do
+    @tag :sqlite_only
     test "rolls back session and task when the required wake event cannot persist", %{
       job: job,
       workspace: ws

--- a/test/controlkeel/autonomy/dispatcher_test.exs
+++ b/test/controlkeel/autonomy/dispatcher_test.exs
@@ -8,6 +8,7 @@ defmodule ControlKeel.Autonomy.DispatcherTest do
   alias ControlKeel.Autonomy.Job
   alias ControlKeel.Mission
   alias ControlKeel.Mission.SessionTranscript
+  alias ControlKeel.Repo
 
   setup do
     org = org_fixture()
@@ -28,7 +29,7 @@ defmodule ControlKeel.Autonomy.DispatcherTest do
     test "returns the plan without recording anything", %{job: job, workspace: ws} do
       ws_id = ws.id
 
-      assert {:ok, %{dry_run: true, job: :test_job, workspace_id: ^ws_id, launched: false}} =
+      assert {:ok, %{dry_run: true, job: "test_job", workspace_id: ^ws_id, launched: false}} =
                Dispatcher.dispatch(job, workspace_id: ws.id, dry_run: true)
 
       # Nothing was recorded.
@@ -52,9 +53,8 @@ defmodule ControlKeel.Autonomy.DispatcherTest do
       assert %{} = Mission.get_task(tid)
     end
 
-    test "falls back to the first workspace when none is given", %{job: job, workspace: ws} do
-      assert {:ok, %{workspace_id: id}} = Dispatcher.dispatch(job, [])
-      assert id == ws.id
+    test "requires explicit workspace binding", %{job: job} do
+      assert {:error, :workspace_id_required} = Dispatcher.dispatch(job, [])
     end
   end
 
@@ -72,8 +72,17 @@ defmodule ControlKeel.Autonomy.DispatcherTest do
             launcher: %{adapter: :shell, command: "echo", args: [:task]}
           })
 
-        assert {:ok, %{launched: %{exit_status: 0}}} =
+        assert {:ok, %{session_id: sid, launched: %{exit_status: 0}}} =
                  Dispatcher.dispatch(job, workspace_id: ws.id)
+
+        events = SessionTranscript.recent_events(sid, limit: 5)
+        wake = Enum.find(events, &(&1["event_type"] == "autonomy.wake"))
+        result = Enum.find(events, &(&1["event_type"] == "autonomy.launch.result"))
+
+        assert wake["payload"]["phase"] == "prepared"
+        assert result["payload"]["status"] == "completed"
+        assert result["payload"]["exit_status"] == 0
+        assert result["id"] > wake["id"]
       end)
     end
 
@@ -90,7 +99,43 @@ defmodule ControlKeel.Autonomy.DispatcherTest do
             launcher: %{adapter: :shell, command: "echo", args: [:task]}
           })
 
-        assert {:ok, %{launched: nil}} = Dispatcher.dispatch(job, workspace_id: ws.id)
+        assert {:ok, %{session_id: sid, launched: nil}} =
+                 Dispatcher.dispatch(job, workspace_id: ws.id)
+
+        result =
+          sid
+          |> SessionTranscript.recent_events(limit: 5)
+          |> Enum.find(&(&1["event_type"] == "autonomy.launch.result"))
+
+        assert result["payload"] == %{"status" => "skipped"}
+      end)
+    end
+
+    test "records missing-binary failures as JSON-safe strings", %{workspace: ws} do
+      restore_env(fn ->
+        System.put_env("CK_AUTONOMY_ALLOW_SHELL", "1")
+
+        {:ok, job} =
+          Job.from_config(%{
+            name: :missing,
+            interval_ms: 1,
+            title: "Missing",
+            task: "run",
+            launcher: %{adapter: :shell, command: "does-not-exist-xyz", args: [:task]}
+          })
+
+        assert {:ok, %{session_id: sid, launched: %{error: error}}} =
+                 Dispatcher.dispatch(job, workspace_id: ws.id)
+
+        assert is_binary(error)
+
+        result =
+          sid
+          |> SessionTranscript.recent_events(limit: 5)
+          |> Enum.find(&(&1["event_type"] == "autonomy.launch.result"))
+
+        assert result["payload"]["status"] == "failed"
+        assert is_binary(result["payload"]["error"])
       end)
     end
   end
@@ -104,6 +149,36 @@ defmodule ControlKeel.Autonomy.DispatcherTest do
 
       assert {:ok, %{workspace_id: id}} = Dispatcher.dispatch(job, workspace_id: other.id)
       assert id == other.id
+    end
+
+    test "rejects a nonexistent workspace instead of falling back across tenants", %{job: job} do
+      assert {:error, :workspace_not_found} = Dispatcher.dispatch(job, workspace_id: 999_999)
+    end
+  end
+
+  describe "wake-up transaction" do
+    test "rolls back session and task when the required wake event cannot persist", %{
+      job: job,
+      workspace: ws
+    } do
+      before_ids = Mission.list_sessions() |> Enum.map(& &1.id) |> MapSet.new()
+
+      Repo.query!("""
+      CREATE TEMP TRIGGER fail_autonomy_wake
+      BEFORE INSERT ON session_events
+      WHEN NEW.event_type = 'autonomy.wake'
+      BEGIN
+        SELECT RAISE(ABORT, 'forced wake event failure');
+      END;
+      """)
+
+      assert {:error, {:wake_persistence_failed, _reason}} =
+               Dispatcher.dispatch(job, workspace_id: ws.id)
+
+      after_ids = Mission.list_sessions() |> Enum.map(& &1.id) |> MapSet.new()
+      assert after_ids == before_ids
+
+      Repo.query!("DROP TRIGGER fail_autonomy_wake")
     end
   end
 

--- a/test/controlkeel/autonomy/dispatcher_test.exs
+++ b/test/controlkeel/autonomy/dispatcher_test.exs
@@ -1,0 +1,121 @@
+defmodule ControlKeel.Autonomy.DispatcherTest do
+  use ControlKeel.DataCase, async: false
+
+  import ControlKeel.AccountsFixtures
+  import ControlKeel.MissionFixtures
+
+  alias ControlKeel.Autonomy.Dispatcher
+  alias ControlKeel.Autonomy.Job
+  alias ControlKeel.Mission
+  alias ControlKeel.Mission.SessionTranscript
+
+  setup do
+    org = org_fixture()
+    ws = workspace_fixture(%{org_id: org.id})
+
+    {:ok, job} =
+      Job.from_config(%{
+        name: :test_job,
+        interval_ms: 1_000,
+        title: "Test job",
+        task: "Do the test thing."
+      })
+
+    {:ok, org: org, workspace: ws, job: job}
+  end
+
+  describe "dispatch/2 dry_run" do
+    test "returns the plan without recording anything", %{job: job, workspace: ws} do
+      ws_id = ws.id
+
+      assert {:ok, %{dry_run: true, job: :test_job, workspace_id: ^ws_id, launched: false}} =
+               Dispatcher.dispatch(job, workspace_id: ws.id, dry_run: true)
+
+      # Nothing was recorded.
+      assert Mission.list_session_events(-1) == []
+    end
+  end
+
+  describe "dispatch/2 wake-up (no launcher)" do
+    test "creates a session + task + autonomy.wake event", %{job: job, workspace: ws} do
+      assert {:ok, %{session_id: sid, task_id: tid, launched: nil}} =
+               Dispatcher.dispatch(job, workspace_id: ws.id)
+
+      assert %{title: "[autonomy] Test job", objective: "Do the test thing."} =
+               Mission.get_session(sid)
+
+      events = SessionTranscript.recent_events(sid, limit: 5)
+      assert Enum.any?(events, &(&1["event_type"] == "autonomy.wake"))
+      assert Enum.any?(events, &(&1["actor"] == "autonomy.scheduler"))
+
+      # The task is bound to the wake-up session.
+      assert %{} = Mission.get_task(tid)
+    end
+
+    test "falls back to the first workspace when none is given", %{job: job, workspace: ws} do
+      assert {:ok, %{workspace_id: id}} = Dispatcher.dispatch(job, [])
+      assert id == ws.id
+    end
+  end
+
+  describe "dispatch/2 with launcher" do
+    test "records the launcher result when shell is enabled", %{workspace: ws} do
+      restore_env(fn ->
+        System.put_env("CK_AUTONOMY_ALLOW_SHELL", "1")
+
+        {:ok, job} =
+          Job.from_config(%{
+            name: :launching,
+            interval_ms: 1,
+            title: "Launch",
+            task: "echo me",
+            launcher: %{adapter: :shell, command: "echo", args: [:task]}
+          })
+
+        assert {:ok, %{launched: %{exit_status: 0}}} =
+                 Dispatcher.dispatch(job, workspace_id: ws.id)
+      end)
+    end
+
+    test "records wake-up without launching when shell is disabled", %{workspace: ws} do
+      restore_env(fn ->
+        System.delete_env("CK_AUTONOMY_ALLOW_SHELL")
+
+        {:ok, job} =
+          Job.from_config(%{
+            name: :gated,
+            interval_ms: 1,
+            title: "Gated",
+            task: "echo me",
+            launcher: %{adapter: :shell, command: "echo", args: [:task]}
+          })
+
+        assert {:ok, %{launched: nil}} = Dispatcher.dispatch(job, workspace_id: ws.id)
+      end)
+    end
+  end
+
+  describe "dispatch/2 workspace resolution" do
+    test "honours an explicit workspace_id even when it differs from the first", %{
+      job: job,
+      org: org
+    } do
+      other = workspace_fixture(%{org_id: org.id})
+
+      assert {:ok, %{workspace_id: id}} = Dispatcher.dispatch(job, workspace_id: other.id)
+      assert id == other.id
+    end
+  end
+
+  defp restore_env(fun) do
+    prev = System.get_env("CK_AUTONOMY_ALLOW_SHELL")
+
+    try do
+      fun.()
+    after
+      if prev,
+        do: System.put_env("CK_AUTONOMY_ALLOW_SHELL", prev),
+        else: System.delete_env("CK_AUTONOMY_ALLOW_SHELL")
+    end
+  end
+end

--- a/test/controlkeel/autonomy/job_test.exs
+++ b/test/controlkeel/autonomy/job_test.exs
@@ -1,0 +1,176 @@
+defmodule ControlKeel.Autonomy.JobTest do
+  use ExUnit.Case, async: true
+
+  alias ControlKeel.Autonomy.Job
+
+  describe "from_config/1" do
+    test "parses a valid map config" do
+      assert {:ok, %Job{} = job} =
+               Job.from_config(%{
+                 name: :daily_triage,
+                 interval_ms: :timer.hours(6),
+                 title: "Triage",
+                 task: "Triage open tickets.",
+                 agent: :opencode,
+                 launcher: %{adapter: :shell, command: "opencode", args: ["run", :task]}
+               })
+
+      assert job.name == :daily_triage
+      assert job.interval_ms == 21_600_000
+      assert job.agent == :opencode
+      assert job.launcher.command == "opencode"
+      assert job.launcher.args == ["run", :task]
+    end
+
+    test "parses a keyword-list config and string name" do
+      assert {:ok, %Job{name: :nightly}} =
+               Job.from_config(
+                 name: "nightly",
+                 interval_ms: 60_000,
+                 title: "Nightly",
+                 task: "Run nightly."
+               )
+    end
+
+    test "accepts a job with no launcher (default safe dispatch)" do
+      assert {:ok, %Job{launcher: nil}} =
+               Job.from_config(%{
+                 name: :bare,
+                 interval_ms: 1_000,
+                 title: "Bare",
+                 task: "Do a thing."
+               })
+    end
+
+    test "rejects missing required fields" do
+      assert {:error, {:missing, :name}} =
+               Job.from_config(%{interval_ms: 1, title: "x", task: "y"})
+
+      assert {:error, {:missing, :interval_ms}} =
+               Job.from_config(%{name: :a, title: "x", task: "y"})
+
+      assert {:error, {:missing, :title}} =
+               Job.from_config(%{name: :a, interval_ms: 1, task: "y"})
+
+      assert {:error, {:missing, :task}} =
+               Job.from_config(%{name: :a, interval_ms: 1, title: "x"})
+    end
+
+    test "rejects non-positive interval_ms" do
+      assert {:error, {:invalid_interval_ms, 0}} =
+               Job.from_config(%{name: :a, interval_ms: 0, title: "x", task: "y"})
+
+      assert {:error, {:invalid_interval_ms, -1}} =
+               Job.from_config(%{name: :a, interval_ms: -1, title: "x", task: "y"})
+    end
+
+    test "rejects blank strings" do
+      assert {:error, {:invalid, :title, ""}} =
+               Job.from_config(%{name: :a, interval_ms: 1, title: "", task: "y"})
+    end
+  end
+
+  describe "launcher validation" do
+    test "accepts args with or without the :task placeholder" do
+      # The task text only ever enters argv via :task (as a discrete element);
+      # a launcher may legitimately run a fixed command with no task input.
+      assert {:ok, _} =
+               Job.from_config(%{
+                 name: :a,
+                 interval_ms: 1,
+                 title: "x",
+                 task: "y",
+                 launcher: %{adapter: :shell, command: "opencode", args: ["run", :task]}
+               })
+
+      assert {:ok, _} =
+               Job.from_config(%{
+                 name: :b,
+                 interval_ms: 1,
+                 title: "x",
+                 task: "y",
+                 launcher: %{adapter: :shell, command: "bin/maintenance", args: ["--quiet"]}
+               })
+    end
+
+    test "rejects unknown launcher adapters" do
+      assert {:error, {:unknown_launcher, _}} =
+               Job.from_config(%{
+                 name: :a,
+                 interval_ms: 1,
+                 title: "x",
+                 task: "y",
+                 launcher: %{adapter: :kubernetes, command: "x", args: [:task]}
+               })
+    end
+
+    test "rejects missing command or empty args" do
+      assert {:error, {:invalid_launcher, :command}} =
+               Job.from_config(%{
+                 name: :a,
+                 interval_ms: 1,
+                 title: "x",
+                 task: "y",
+                 launcher: %{adapter: :shell, command: "", args: [:task]}
+               })
+
+      assert {:error, {:invalid_launcher, :args}} =
+               Job.from_config(%{
+                 name: :a,
+                 interval_ms: 1,
+                 title: "x",
+                 task: "y",
+                 launcher: %{adapter: :shell, command: "opencode", args: []}
+               })
+    end
+  end
+
+  describe "from_config_all/1" do
+    test "parses multiple jobs preserving order" do
+      configs = [
+        %{name: :a, interval_ms: 1_000, title: "A", task: "ta"},
+        %{name: :b, interval_ms: 2_000, title: "B", task: "tb"}
+      ]
+
+      assert {:ok, [%Job{name: :a}, %Job{name: :b}]} = Job.from_config_all(configs)
+    end
+
+    test "rejects duplicate names" do
+      configs = [
+        %{name: :dup, interval_ms: 1_000, title: "A", task: "ta"},
+        %{name: :dup, interval_ms: 2_000, title: "B", task: "tb"}
+      ]
+
+      assert {:error, {:duplicate_name, :dup}} = Job.from_config_all(configs)
+    end
+
+    test "returns [] for empty list" do
+      assert {:ok, []} = Job.from_config_all([])
+    end
+
+    test "propagates parse errors" do
+      assert {:error, {:missing, :name}} =
+               Job.from_config_all([%{interval_ms: 1, title: "x", task: "y"}])
+    end
+  end
+
+  describe "launcher?/1" do
+    test "true when a launcher is configured" do
+      {:ok, job} =
+        Job.from_config(%{
+          name: :a,
+          interval_ms: 1,
+          title: "x",
+          task: "y",
+          launcher: %{adapter: :shell, command: "x", args: [:task]}
+        })
+
+      assert Job.launcher?(job)
+    end
+
+    test "false when no launcher" do
+      {:ok, job} = Job.from_config(%{name: :a, interval_ms: 1, title: "x", task: "y"})
+      refute Job.launcher?(job)
+    end
+  end
+end

--- a/test/controlkeel/autonomy/job_test.exs
+++ b/test/controlkeel/autonomy/job_test.exs
@@ -15,15 +15,15 @@ defmodule ControlKeel.Autonomy.JobTest do
                  launcher: %{adapter: :shell, command: "opencode", args: ["run", :task]}
                })
 
-      assert job.name == :daily_triage
+      assert job.name == "daily_triage"
       assert job.interval_ms == 21_600_000
-      assert job.agent == :opencode
+      assert job.agent == "opencode"
       assert job.launcher.command == "opencode"
       assert job.launcher.args == ["run", :task]
     end
 
     test "parses a keyword-list config and string name" do
-      assert {:ok, %Job{name: :nightly}} =
+      assert {:ok, %Job{name: "nightly"}} =
                Job.from_config(
                  name: "nightly",
                  interval_ms: 60_000,
@@ -132,7 +132,7 @@ defmodule ControlKeel.Autonomy.JobTest do
         %{name: :b, interval_ms: 2_000, title: "B", task: "tb"}
       ]
 
-      assert {:ok, [%Job{name: :a}, %Job{name: :b}]} = Job.from_config_all(configs)
+      assert {:ok, [%Job{name: "a"}, %Job{name: "b"}]} = Job.from_config_all(configs)
     end
 
     test "rejects duplicate names" do
@@ -141,7 +141,7 @@ defmodule ControlKeel.Autonomy.JobTest do
         %{name: :dup, interval_ms: 2_000, title: "B", task: "tb"}
       ]
 
-      assert {:error, {:duplicate_name, :dup}} = Job.from_config_all(configs)
+      assert {:error, {:duplicate_name, "dup"}} = Job.from_config_all(configs)
     end
 
     test "returns [] for empty list" do

--- a/test/controlkeel/autonomy/launcher_test.exs
+++ b/test/controlkeel/autonomy/launcher_test.exs
@@ -106,6 +106,33 @@ defmodule ControlKeel.Autonomy.Launcher.ShellTest do
                  )
       end)
     end
+
+    test "timeout terminates descendant processes in the launch process group" do
+      with_shell_enabled(fn ->
+        pid_file =
+          Path.join(
+            System.tmp_dir!(),
+            "controlkeel-launch-child-#{System.unique_integer([:positive])}.pid"
+          )
+
+        on_exit(fn -> File.rm(pid_file) end)
+
+        script = "sleep 30 & echo $! > #{pid_file}; wait"
+
+        assert {:error, {:launch_timeout, 200}} =
+                 Shell.run(
+                   job("ignored",
+                     command: "sh",
+                     args: ["-c", script],
+                     timeout_ms: 200
+                   )
+                 )
+
+        child_pid = pid_file |> File.read!() |> String.trim()
+        {_output, status} = System.cmd("kill", ["-0", child_pid], stderr_to_stdout: true)
+        refute status == 0
+      end)
+    end
   end
 
   describe "run/1 missing program" do

--- a/test/controlkeel/autonomy/launcher_test.exs
+++ b/test/controlkeel/autonomy/launcher_test.exs
@@ -15,7 +15,8 @@ defmodule ControlKeel.Autonomy.Launcher.ShellTest do
         launcher: %{
           adapter: :shell,
           command: Keyword.get(opts, :command, "echo"),
-          args: Keyword.get(opts, :args, [:task])
+          args: Keyword.get(opts, :args, [:task]),
+          timeout_ms: Keyword.get(opts, :timeout_ms)
         }
       })
 
@@ -81,6 +82,28 @@ defmodule ControlKeel.Autonomy.Launcher.ShellTest do
 
         assert {:ok, %{output: output}} = Shell.run(j)
         assert byte_size(output) <= 8_192
+      end)
+    end
+
+    test "returns valid UTF-8 when command output contains invalid bytes" do
+      with_shell_enabled(fn ->
+        assert {:ok, %{output: output}} =
+                 Shell.run(job("ignored", command: "sh", args: ["-c", "printf '\\377'"]))
+
+        assert String.valid?(output)
+      end)
+    end
+
+    test "terminates a launcher that exceeds its timeout" do
+      with_shell_enabled(fn ->
+        assert {:error, {:launch_timeout, 20}} =
+                 Shell.run(
+                   job("ignored",
+                     command: "sh",
+                     args: ["-c", "sleep 2"],
+                     timeout_ms: 20
+                   )
+                 )
       end)
     end
   end

--- a/test/controlkeel/autonomy/launcher_test.exs
+++ b/test/controlkeel/autonomy/launcher_test.exs
@@ -129,8 +129,7 @@ defmodule ControlKeel.Autonomy.Launcher.ShellTest do
                  )
 
         child_pid = pid_file |> File.read!() |> String.trim()
-        {_output, status} = System.cmd("kill", ["-0", child_pid], stderr_to_stdout: true)
-        refute status == 0
+        refute process_running?(child_pid)
       end)
     end
   end
@@ -157,6 +156,21 @@ defmodule ControlKeel.Autonomy.Launcher.ShellTest do
       System.put_env("CK_AUTONOMY_ALLOW_SHELL", "1")
       fun.()
     end)
+  end
+
+  defp process_running?(pid) do
+    {_output, status} = System.cmd("kill", ["-0", pid], stderr_to_stdout: true)
+
+    status == 0 and proc_state(pid) not in ["Z", "X"]
+  end
+
+  defp proc_state(pid) do
+    with {:ok, stat} <- File.read("/proc/#{pid}/stat"),
+         [_, state] <- Regex.run(~r/^\d+ \(.*\) ([A-Z]) /, stat) do
+      state
+    else
+      _ -> nil
+    end
   end
 
   defp restore_env(fun) do

--- a/test/controlkeel/autonomy/launcher_test.exs
+++ b/test/controlkeel/autonomy/launcher_test.exs
@@ -1,0 +1,126 @@
+defmodule ControlKeel.Autonomy.Launcher.ShellTest do
+  use ExUnit.Case, async: true
+
+  alias ControlKeel.Autonomy.Job
+  alias ControlKeel.Autonomy.Launcher.Shell
+
+  # Build a job without touching Application env; launcher.enable? reads env+config.
+  defp job(task, opts \\ []) do
+    {:ok, job} =
+      Job.from_config(%{
+        name: :launch_test,
+        interval_ms: 1_000,
+        title: "Launch",
+        task: task,
+        launcher: %{
+          adapter: :shell,
+          command: Keyword.get(opts, :command, "echo"),
+          args: Keyword.get(opts, :args, [:task])
+        }
+      })
+
+    job
+  end
+
+  describe "run/1 gating" do
+    test "returns {:error, :shell_not_allowed} when shell launching is disabled" do
+      restore_env(fn ->
+        System.delete_env("CK_AUTONOMY_ALLOW_SHELL")
+
+        prev = Application.get_env(:controlkeel, :autonomy, [])
+        Application.put_env(:controlkeel, :autonomy, Keyword.put(prev, :allow_shell, false))
+
+        assert {:error, :shell_not_allowed} = Shell.run(job("hello"))
+      end)
+    end
+  end
+
+  describe "run/1 argv substitution" do
+    test "substitutes :task as a single argv element via System.cmd (no shell)" do
+      with_shell_enabled(fn ->
+        # `echo` prints its args joined by spaces; we assert the task text appears
+        # verbatim, proving it was passed as an argv element rather than shell-parsed.
+        task = "Triage open tickets; rm -rf / && whoami"
+        assert {:ok, %{exit_status: 0, output: output}} = Shell.run(job(task))
+        assert output =~ "Triage open tickets"
+        # The literal `&&` survives because it never reached a shell.
+        assert output =~ "&&"
+      end)
+    end
+
+    test "captures non-zero exit status instead of raising" do
+      with_shell_enabled(fn ->
+        # `false` always exits 1.
+        {:ok, j} =
+          Job.from_config(%{
+            name: :failing,
+            interval_ms: 1,
+            title: "F",
+            task: "ignored",
+            launcher: %{adapter: :shell, command: "sh", args: ["-c", "exit 3"]}
+          })
+
+        assert {:ok, %{exit_status: 3}} = Shell.run(j)
+      end)
+    end
+
+    test "truncates large output" do
+      with_shell_enabled(fn ->
+        {:ok, j} =
+          Job.from_config(%{
+            name: :noisy,
+            interval_ms: 1,
+            title: "N",
+            task: "ignored",
+            launcher: %{
+              adapter: :shell,
+              command: "sh",
+              args: ["-c", "printf 'x%.0s' $(seq 1 20000)"]
+            }
+          })
+
+        assert {:ok, %{output: output}} = Shell.run(j)
+        assert byte_size(output) <= 8_192
+      end)
+    end
+  end
+
+  describe "run/1 missing program" do
+    test "returns {:error, {:launch_failed, :enoent}} for a missing binary" do
+      with_shell_enabled(fn ->
+        {:ok, j} =
+          Job.from_config(%{
+            name: :missing,
+            interval_ms: 1,
+            title: "M",
+            task: "ignored",
+            launcher: %{adapter: :shell, command: "this-binary-does-not-exist-xyz", args: [:task]}
+          })
+
+        assert {:error, {:launch_failed, :enoent}} = Shell.run(j)
+      end)
+    end
+  end
+
+  defp with_shell_enabled(fun) do
+    restore_env(fn ->
+      System.put_env("CK_AUTONOMY_ALLOW_SHELL", "1")
+      fun.()
+    end)
+  end
+
+  defp restore_env(fun) do
+    prev_env = System.get_env("CK_AUTONOMY_ALLOW_SHELL")
+    prev_cfg = Application.get_env(:controlkeel, :autonomy, [])
+
+    try do
+      fun.()
+    after
+      if prev_env,
+        do: System.put_env("CK_AUTONOMY_ALLOW_SHELL", prev_env),
+        else: System.delete_env("CK_AUTONOMY_ALLOW_SHELL")
+
+      Application.put_env(:controlkeel, :autonomy, prev_cfg)
+    end
+  end
+end

--- a/test/controlkeel/autonomy/launcher_test.exs
+++ b/test/controlkeel/autonomy/launcher_test.exs
@@ -1,5 +1,5 @@
 defmodule ControlKeel.Autonomy.Launcher.ShellTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias ControlKeel.Autonomy.Job
   alias ControlKeel.Autonomy.Launcher.Shell
@@ -131,6 +131,66 @@ defmodule ControlKeel.Autonomy.Launcher.ShellTest do
         child_pid = pid_file |> File.read!() |> String.trim()
         refute process_running?(child_pid)
       end)
+    end
+
+    test "reports termination failure when the process group cannot be signaled" do
+      if match?({:unix, _}, :os.type()) do
+        with_shell_enabled(fn ->
+          original_path = System.fetch_env!("PATH")
+          python = System.find_executable("python3")
+          shell = System.find_executable("sh")
+          kill = System.find_executable("kill")
+
+          bin_dir =
+            Path.join(
+              System.tmp_dir!(),
+              "controlkeel-failing-kill-#{System.unique_integer([:positive])}"
+            )
+
+          pid_file = Path.join(bin_dir, "group.pid")
+          File.mkdir_p!(bin_dir)
+          File.ln_s!(python, Path.join(bin_dir, "python3"))
+          File.ln_s!(shell, Path.join(bin_dir, "sh"))
+          File.write!(Path.join(bin_dir, "kill"), "#!/bin/sh\nexit 1\n")
+          File.chmod!(Path.join(bin_dir, "kill"), 0o755)
+
+          on_exit(fn ->
+            case File.read(pid_file) do
+              {:ok, pid} ->
+                {_output, status} =
+                  System.cmd(
+                    kill,
+                    ["-KILL", "--", "-#{String.trim(pid)}"],
+                    stderr_to_stdout: true
+                  )
+
+                if status != 0 and process_running?(String.trim(pid)) do
+                  raise "failed to clean up test process group #{String.trim(pid)}"
+                end
+
+              _ ->
+                :ok
+            end
+
+            File.rm_rf!(bin_dir)
+          end)
+
+          try do
+            System.put_env("PATH", bin_dir)
+
+            assert {:error, {:launch_termination_failed, 100, _reason}} =
+                     Shell.run(
+                       job("ignored",
+                         command: "sh",
+                         args: ["-c", "echo $$ > #{pid_file}; /bin/sleep 2"],
+                         timeout_ms: 100
+                       )
+                     )
+          after
+            System.put_env("PATH", original_path)
+          end
+        end)
+      end
     end
   end
 

--- a/test/controlkeel/autonomy/scheduler_test.exs
+++ b/test/controlkeel/autonomy/scheduler_test.exs
@@ -48,7 +48,7 @@ defmodule ControlKeel.Autonomy.SchedulerTest do
       )
 
       names = Enum.map(Scheduler.jobs(), & &1.name)
-      assert names == [:a, :b]
+      assert names == ["a", "b"]
     end
 
     test "returns [] on invalid config (logged, not raised)" do
@@ -78,7 +78,7 @@ defmodule ControlKeel.Autonomy.SchedulerTest do
 
     test "returns {:error, {:unknown_job, name}} for an unknown job" do
       Application.put_env(:controlkeel, :autonomy, enabled: false, jobs: [])
-      assert {:error, {:unknown_job, :nope}} = Scheduler.run_once(:nope, [])
+      assert {:error, {:unknown_job, "nope"}} = Scheduler.run_once(:nope, [])
     end
 
     test "dry_run records nothing", %{workspace: ws} do
@@ -104,10 +104,10 @@ defmodule ControlKeel.Autonomy.SchedulerTest do
       # it reached a viable state with the timer armed.
       pid = start_supervised!(Scheduler)
       state = :sys.get_state(pid)
-      assert Map.has_key?(state.timers, :armed)
+      assert Map.has_key?(state.timers, "armed")
     end
 
-    test "refuses to start on invalid job config" do
+    test "starts inert on invalid job config instead of aborting the application" do
       Application.put_env(:controlkeel, :autonomy,
         enabled: true,
         jobs: [
@@ -116,17 +116,45 @@ defmodule ControlKeel.Autonomy.SchedulerTest do
         ]
       )
 
-      # init/1 returns {:stop, {:invalid_jobs, reason}}; with start_link the
-      # terminating child can signal its caller, so trap exits and drain.
-      Process.flag(:trap_exit, true)
+      pid = start_supervised!(Scheduler)
+      state = :sys.get_state(pid)
 
-      assert {:error, {:invalid_jobs, {:duplicate_name, :dup}}} = Scheduler.start_link([])
+      assert state.timers == %{}
+      assert state.config_error == {:duplicate_name, "dup"}
+    end
 
-      receive do
-        {:EXIT, _, _} -> :ok
-      after
-        0 -> :ok
-      end
+    test "slow launchers do not block the scheduler mailbox", %{workspace: ws} do
+      previous_shell = System.get_env("CK_AUTONOMY_ALLOW_SHELL")
+      System.put_env("CK_AUTONOMY_ALLOW_SHELL", "1")
+
+      on_exit(fn ->
+        if previous_shell,
+          do: System.put_env("CK_AUTONOMY_ALLOW_SHELL", previous_shell),
+          else: System.delete_env("CK_AUTONOMY_ALLOW_SHELL")
+      end)
+
+      Application.put_env(:controlkeel, :autonomy,
+        enabled: true,
+        workspace_id: ws.id,
+        jobs: [
+          %{
+            name: :slow,
+            interval_ms: 60_000,
+            title: "Slow",
+            task: "wait",
+            launcher: %{adapter: :shell, command: "sh", args: ["-c", "sleep 1"]}
+          }
+        ]
+      )
+
+      start_supervised!({Task.Supervisor, name: ControlKeel.Autonomy.TaskSupervisor})
+      pid = start_supervised!(Scheduler)
+
+      send(pid, {:fire, "slow"})
+
+      # If dispatch ran synchronously in handle_info, this 100ms call would time out.
+      state = :sys.get_state(pid, 100)
+      assert Map.has_key?(state.timers, "slow")
     end
   end
 

--- a/test/controlkeel/autonomy/scheduler_test.exs
+++ b/test/controlkeel/autonomy/scheduler_test.exs
@@ -155,6 +155,13 @@ defmodule ControlKeel.Autonomy.SchedulerTest do
       # If dispatch ran synchronously in handle_info, this 100ms call would time out.
       state = :sys.get_state(pid, 100)
       assert Map.has_key?(state.timers, "slow")
+      assert map_size(state.in_flight) == 1
+
+      send(pid, {:fire, "slow"})
+      state = :sys.get_state(pid, 100)
+
+      # The second tick is skipped while the first run remains in flight.
+      assert map_size(state.in_flight) == 1
     end
   end
 

--- a/test/controlkeel/autonomy/scheduler_test.exs
+++ b/test/controlkeel/autonomy/scheduler_test.exs
@@ -1,0 +1,152 @@
+defmodule ControlKeel.Autonomy.SchedulerTest do
+  use ControlKeel.DataCase, async: false
+
+  import ControlKeel.AccountsFixtures
+  import ControlKeel.MissionFixtures
+
+  alias ControlKeel.Autonomy.Scheduler
+
+  setup do
+    org = org_fixture()
+    ws = workspace_fixture(%{org_id: org.id})
+
+    on_exit(fn ->
+      System.delete_env("CK_AUTONOMY_SCHEDULER")
+      Application.put_env(:controlkeel, :autonomy, enabled: false, jobs: [])
+    end)
+
+    {:ok, org: org, workspace: ws}
+  end
+
+  describe "enabled?/0" do
+    test "true when env var is set" do
+      System.put_env("CK_AUTONOMY_SCHEDULER", "1")
+      assert Scheduler.enabled?()
+    end
+
+    test "true when config enabled is true" do
+      System.delete_env("CK_AUTONOMY_SCHEDULER")
+      Application.put_env(:controlkeel, :autonomy, enabled: true, jobs: [])
+      assert Scheduler.enabled?()
+    end
+
+    test "false by default" do
+      System.delete_env("CK_AUTONOMY_SCHEDULER")
+      Application.put_env(:controlkeel, :autonomy, enabled: false, jobs: [])
+      refute Scheduler.enabled?()
+    end
+  end
+
+  describe "jobs/0" do
+    test "returns parsed configured jobs" do
+      Application.put_env(:controlkeel, :autonomy,
+        enabled: false,
+        jobs: [
+          %{name: :a, interval_ms: 1_000, title: "A", task: "ta"},
+          %{name: :b, interval_ms: 2_000, title: "B", task: "tb"}
+        ]
+      )
+
+      names = Enum.map(Scheduler.jobs(), & &1.name)
+      assert names == [:a, :b]
+    end
+
+    test "returns [] on invalid config (logged, not raised)" do
+      Application.put_env(:controlkeel, :autonomy,
+        enabled: false,
+        jobs: [
+          %{name: :dup, interval_ms: 1, title: "A", task: "ta"},
+          %{name: :dup, interval_ms: 1, title: "B", task: "tb"}
+        ]
+      )
+
+      assert Scheduler.jobs() == []
+    end
+  end
+
+  describe "run_once/2" do
+    test "fires a job by name without the GenServer running", %{workspace: ws} do
+      Application.put_env(:controlkeel, :autonomy,
+        enabled: false,
+        workspace_id: ws.id,
+        jobs: [%{name: :oneshot, interval_ms: 60_000, title: "Once", task: "Do it."}]
+      )
+
+      assert {:ok, %{session_id: _, task_id: _, launched: nil}} =
+               Scheduler.run_once(:oneshot, [])
+    end
+
+    test "returns {:error, {:unknown_job, name}} for an unknown job" do
+      Application.put_env(:controlkeel, :autonomy, enabled: false, jobs: [])
+      assert {:error, {:unknown_job, :nope}} = Scheduler.run_once(:nope, [])
+    end
+
+    test "dry_run records nothing", %{workspace: ws} do
+      Application.put_env(:controlkeel, :autonomy,
+        enabled: false,
+        workspace_id: ws.id,
+        jobs: [%{name: :dry, interval_ms: 60_000, title: "Dry", task: "Nothing."}]
+      )
+
+      assert {:ok, %{dry_run: true}} = Scheduler.run_once(:dry, dry_run: true)
+    end
+  end
+
+  describe "GenServer lifecycle" do
+    test "starts and arms timers when enabled with valid jobs", %{workspace: ws} do
+      Application.put_env(:controlkeel, :autonomy,
+        enabled: true,
+        workspace_id: ws.id,
+        jobs: [%{name: :armed, interval_ms: 60_000, title: "Armed", task: "Wait."}]
+      )
+
+      # start_supervised! owns the lifecycle (teardown included); we only assert
+      # it reached a viable state with the timer armed.
+      pid = start_supervised!(Scheduler)
+      state = :sys.get_state(pid)
+      assert Map.has_key?(state.timers, :armed)
+    end
+
+    test "refuses to start on invalid job config" do
+      Application.put_env(:controlkeel, :autonomy,
+        enabled: true,
+        jobs: [
+          %{name: :dup, interval_ms: 1, title: "A", task: "ta"},
+          %{name: :dup, interval_ms: 1, title: "B", task: "tb"}
+        ]
+      )
+
+      # init/1 returns {:stop, {:invalid_jobs, reason}}; with start_link the
+      # terminating child can signal its caller, so trap exits and drain.
+      Process.flag(:trap_exit, true)
+
+      assert {:error, {:invalid_jobs, {:duplicate_name, :dup}}} = Scheduler.start_link([])
+
+      receive do
+        {:EXIT, _, _} -> :ok
+      after
+        0 -> :ok
+      end
+    end
+  end
+
+  describe "application wiring" do
+    test "the autonomy scheduler is NOT registered as a child in MCP stdio mode" do
+      # The application.ex gate checks `not mcp_stdio_mode?()`. We assert the
+      # function exists and reads the env; full integration is covered by the
+      # app not crashing on boot with autonomy enabled.
+      System.put_env("CK_MCP_MODE", "1")
+      System.put_env("CK_AUTONOMY_SCHEDULER", "1")
+
+      try do
+        # In stdio mode the scheduler must not start even if autonomy is enabled.
+        # We can't easily boot the whole app here, but assert the gating predicate
+        # combination: enabled? true, mcp_stdio true -> should be skipped.
+        assert Scheduler.enabled?()
+      after
+        System.delete_env("CK_MCP_MODE")
+        System.delete_env("CK_AUTONOMY_SCHEDULER")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a governed, BEAM-native autonomy scheduler that fires configured jobs on intervals, atomically creates a governed wake-up (session + task + pre-launch `autonomy.wake` event), and optionally launches an external agent through a capability-gated, bounded launcher.

Off by default; never starts in MCP stdio mode.

## Safety and invariants

- **Atomic before execution:** session + task + wake audit event commit in one transaction. Any persistence failure rolls everything back; no orphan sessions/tasks.
- **Audit before launch:** external execution begins only after the wake event is durable. Results are recorded separately as `autonomy.launch.result`.
- **Explicit tenant binding:** `workspace_id` is required and verified. No first-org/first-workspace fallback.
- **Non-blocking scheduler:** timer dispatches run under `Task.Supervisor`; one slow job cannot block unrelated timers.
- **Bounded launch:** default 5-minute timeout, configurable globally/per launcher.
- **No implicit shell:** `System.cmd/3` receives argv. Operators who explicitly configure `sh -c`/`bash -c` can reintroduce shell parsing and own that boundary.
- **Atom safe:** job names and agent hints normalize to strings; CLI input never reaches `String.to_atom/1`.
- **Output safe:** byte-bounded output with invalid UTF-8 replacement; failure payloads are JSON-safe strings.
- **Config failures are contained:** malformed jobs start the scheduler inert instead of aborting the application.

## Operator surface

```
mix ck.autonomy list
mix ck.autonomy status
mix ck.autonomy run <name>
mix ck.autonomy run <name> --dry-run
```

Config defaults:

```elixir
autonomy: [
  enabled: false,
  allow_shell: false,
  launch_timeout_ms: 300_000,
  workspace_id: nil,
  jobs: []
]
```

## Verification

- `mix precommit` green
- **2063 tests, 0 failures**
- New coverage includes transactional rollback, audit-before-launch ordering, JSON-safe failures, explicit workspace fail-closed behavior, non-blocking scheduler mailbox, timeout handling, invalid output bytes, config isolation, and CLI atom safety.

Closes the cron-driven autonomy gap identified in the gumclaw comparison while preserving CK governance invariants.