### PR TITLE
feat(observability): deterministic promotion path for recurring agent behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ If you're using an AI agent today, you probably have an `*.md` telling it how to
 4. **Persist evidence** — findings, reviews, proofs, memory, cost, and task outcomes survive host switches.
 5. **Improve with evals** — traces and recurring failures become bounded regression evidence for specific suites and subjects.
 
+The operating rule is simple: spend tokens on discovery, not rediscovery.
+Recurring behavior moves through a human-gated deterministic promotion path;
+once its regression evidence passes, checks, APIs, CLIs, or workflows handle
+the known case and agents handle only exceptions and genuinely new uncertainty.
+
 ControlKeel transforms your domain knowledge from "raw" intent and "shelfware" documentation into a living system that remembers, enforces, and evolves.
 
 ## Quick start

--- a/docs/cost-governance.md
+++ b/docs/cost-governance.md
@@ -12,6 +12,24 @@ ControlKeel treats model usage as a governed resource, not an unlimited side eff
 - **Circuit breakers**: agent monitors can trip on API-call rate, file-modification rate, error rate, consecutive failures, and budget-burn rate.
 - **Provider trust/routing**: provider status distinguishes CK-owned providers, host-managed bridges, local Ollama, and heuristic fallback.
 
+## Deterministic promotion boundary
+
+Agents are for discovery, ambiguity, and exceptions. Once a behavior is
+understood, CK should stop paying an agent to rediscover it. The repeatable
+path is:
+
+1. Observe a recurring problem and save it as an eval candidate.
+2. Approve bounded benchmark coverage through the existing human gate.
+3. Require passing evidence before promotion.
+4. Run the deterministic check or workflow by default; send only misses and
+   genuinely novel cases back to an agent.
+
+`ControlKeel.Observability.Promotion` makes this boundary explicit with a pure,
+side-effect-free decision: `discover`, `review`, `promote`, or `reopen`.
+Failed or flaky evidence always reopens the candidate. A passing benchmark
+without recorded approval remains `review`; CK never silently promotes a
+high-impact behavior because a model suggested it.
+
 ## What providers and hosts still own
 
 CK cannot reliably know every user subscription quota for Claude Code, Codex, Cursor, Copilot, Cline, Roo, Continue, or other host-owned plans. These products often use rolling windows, weekly caps, premium-request pools, token multipliers, or auto-model fallbacks that are not exposed through a stable local API.
@@ -45,6 +63,10 @@ For overnight or AFK work, decide which loop you are actually running before lau
 
 - **Closed loop**: the answer is known enough that the agent should finish a bounded slice by morning.
 - **Open loop**: the answer is not known yet, so the agent should only optimize a named metric or shrink a search space by a bounded amount.
+
+For closed loops, prefer a deterministic command, API, test, or workflow after
+the promotion gate. Keep the agent in the loop only for exceptions, failures,
+and discovery of new cases.
 
 If you cannot state the finish condition or acceptable progress condition clearly, the loop is probably too open to run unattended without waste.
 

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -322,15 +322,23 @@ defmodule ControlKeel.Observability do
         {new_status, lifecycle_key} = lifecycle_transition(all_matched)
         now = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
 
+        # Monotonic per-candidate sequence so the promotion policy can order
+        # transitions that share a second-precision closed_at. Old rows without
+        # lifecycle_seq start at 0; the counter only moves forward.
+        prev_metadata = candidate.metadata || %{}
+        next_seq = (prev_metadata["lifecycle_seq"] || 0) + 1
+
         metadata =
-          (candidate.metadata || %{})
+          prev_metadata
+          |> Map.put("lifecycle_seq", next_seq)
           |> Map.put(lifecycle_key, %{
             "run_id" => run.id,
             "scenario_id" => scenario.id,
             "scenario_slug" => scenario.slug,
             "all_matched" => all_matched,
             "result_count" => length(results),
-            "closed_at" => now
+            "closed_at" => now,
+            "seq" => next_seq
           })
 
         candidate

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -11,7 +11,7 @@ defmodule ControlKeel.Observability do
   alias ControlKeel.Memory.Record, as: MemoryRecord
   alias ControlKeel.Mission
   alias ControlKeel.MCP.Tools.CkTokenAudit
-  alias ControlKeel.Observability.{BenchmarkDraft, EvalCandidate, ImportedEnvelope}
+  alias ControlKeel.Observability.{BenchmarkDraft, EvalCandidate, ImportedEnvelope, Promotion}
   alias ControlKeel.Mission.{Finding, Invocation, Session, SessionEvent}
   alias ControlKeel.Repo
 
@@ -2719,6 +2719,7 @@ defmodule ControlKeel.Observability do
       session_id: candidate.session_id,
       finding_id: candidate.finding_id,
       metadata: candidate.metadata || %{},
+      promotion: Promotion.evaluate(candidate),
       inserted_at: format_datetime(candidate.inserted_at)
     }
   end

--- a/lib/controlkeel/observability/promotion.ex
+++ b/lib/controlkeel/observability/promotion.ex
@@ -115,12 +115,13 @@ defmodule ControlKeel.Observability.Promotion do
     reopened = metadata["lifecycle_reopened_by_run"]
     closed = metadata["lifecycle_closed_by_run"]
 
-    # Reopen wins only when strictly newer than the closed marker. A same-second
-    # tie (:eq) resolves in favor of recovery, because lifecycle timestamps are
-    # truncated to second precision (see
-    # Observability.close_eval_candidate_lifecycle_from_run!/1) and a genuine
-    # regression is captured by the next distinct-second reopen marker.
-    reopened != nil and compare_marker_timestamps(closed, reopened) == :lt
+    # Reopen wins when it is at least as recent as the closed marker. Real
+    # transitions never tie because each marker carries a monotonic `seq`
+    # (see compare_marker_timestamps/2 and Observability.close_eval_candidate_lifecycle_from_run!/1),
+    # so this branch is only reached on :lt (reopened is newer). Hand-built
+    # markers without seq fall back to :eq, which we conservatively treat as
+    # regressed so the policy never silently promotes on ambiguous ordering.
+    reopened != nil and compare_marker_timestamps(closed, reopened) != :gt
   end
 
   defp passing?(evidence, metadata) do
@@ -159,18 +160,32 @@ defmodule ControlKeel.Observability.Promotion do
 
   defp metadata_value(metadata, key), do: Map.get(metadata, key)
 
-  # Compares the `closed_at` timestamps of the closed vs reopened markers.
-  # Returns :gt when closed is newer, :lt when reopened is newer, :eq on ties
-  # or when either marker is missing/unparseable.
+  # Compares the (closed_at, seq) ordering of the closed vs reopened markers.
+  # Returns :gt when closed is newer, :lt when reopened is newer, :eq only when
+  # both markers are missing/unparseable or genuinely identical (impossible for
+  # markers written after lifecycle_seq was introduced). `seq` is a monotonic
+  # per-candidate counter recorded by Observability.close_eval_candidate_lifecycle_from_run!/1
+  # so same-second transitions never tie; it falls back to 0 for legacy rows.
   defp compare_marker_timestamps(nil, _reopened), do: :lt
   defp compare_marker_timestamps(_closed, nil), do: :gt
 
   defp compare_marker_timestamps(closed, reopened) do
-    with {:ok, closed_at, _} <- DateTime.from_iso8601(closed["closed_at"] || ""),
-         {:ok, reopened_at, _} <- DateTime.from_iso8601(reopened["closed_at"] || "") do
-      DateTime.compare(closed_at, reopened_at)
-    else
-      _ -> :eq
+    closed_order = {parse_closed_at(closed["closed_at"]), closed["seq"] || 0}
+    reopened_order = {parse_closed_at(reopened["closed_at"]), reopened["seq"] || 0}
+
+    cond do
+      closed_order > reopened_order -> :gt
+      closed_order < reopened_order -> :lt
+      true -> :eq
+    end
+  end
+
+  defp parse_closed_at(nil), do: nil
+
+  defp parse_closed_at(iso8601) do
+    case DateTime.from_iso8601(iso8601) do
+      {:ok, datetime, _} -> datetime
+      _ -> nil
     end
   end
 

--- a/lib/controlkeel/observability/promotion.ex
+++ b/lib/controlkeel/observability/promotion.ex
@@ -6,6 +6,22 @@ defmodule ControlKeel.Observability.Promotion do
   This module intentionally does not mutate candidates, run benchmarks, or
   invoke an agent. It turns existing candidate and benchmark evidence into a
   stable decision that callers can use to choose the next workflow step.
+
+  ## Lifecycle marker semantics
+
+  `Observability.close_eval_candidate_lifecycle_from_run!/1` overwrites the
+  candidate `status` on every benchmark run (`archived` on pass, `open` on a
+  miss) and appends a timestamped marker to `metadata`:
+
+    * `lifecycle_closed_by_run` — set with `all_matched: true` on a passing run.
+    * `lifecycle_reopened_by_run` — set with `all_matched: false` on a failing run.
+
+  Old markers are **never deleted**, so the *current* lifecycle state is derived
+  by comparing marker `closed_at` timestamps, not by key presence alone. This
+  means a candidate that fails once and later passes again correctly recovers
+  to `promote`, and a passing candidate whose approval was overwritten to
+  `archived` still counts as approved (only approved candidates are ever
+  materialized into benchmark scenarios).
   """
 
   @type decision :: %{
@@ -16,14 +32,14 @@ defmodule ControlKeel.Observability.Promotion do
           human_gate_required: boolean()
         }
 
-  @spec evaluate(map() | nil, map()) :: decision()
+  @spec evaluate(map() | nil, map() | nil) :: decision()
   def evaluate(candidate, evidence \\ %{}) do
     candidate = candidate || %{}
     evidence = evidence || %{}
     metadata = field(candidate, :metadata) || %{}
 
     cond do
-      failed_evidence?(evidence) or reopened?(metadata) ->
+      regressed?(metadata, evidence) ->
         decision(
           "reopen",
           "benchmark evidence failed or the candidate was reopened after a regression",
@@ -31,7 +47,7 @@ defmodule ControlKeel.Observability.Promotion do
           true
         )
 
-      passed_evidence?(evidence, metadata) and approved?(candidate, evidence, metadata) ->
+      passing?(evidence, metadata) and approved?(candidate, evidence, metadata) ->
         decision(
           "promote",
           "human approval and passing benchmark evidence are both recorded",
@@ -39,7 +55,7 @@ defmodule ControlKeel.Observability.Promotion do
           false
         )
 
-      passed_evidence?(evidence, metadata) ->
+      passing?(evidence, metadata) ->
         decision(
           "review",
           "benchmark evidence passes but human approval is not recorded",
@@ -83,29 +99,74 @@ defmodule ControlKeel.Observability.Promotion do
     }
   end
 
-  defp failed_evidence?(evidence) do
+  # A candidate is currently regressed when live evidence reports a failure or
+  # the latest retained lifecycle marker is a reopen. We compare `closed_at`
+  # timestamps because old markers are retained, not deleted.
+  defp regressed?(metadata, evidence) do
+    live_failure?(evidence) or latest_marker_is_reopen?(metadata)
+  end
+
+  defp live_failure?(evidence) do
     field(evidence, :outcome) in ["failed", "flaky"] or
       field(evidence, :all_matched) == false
   end
 
-  defp passed_evidence?(evidence, metadata) do
-    field(evidence, :outcome) == "passed" or
-      field(evidence, :all_matched) == true or
-      metadata_value(metadata, "lifecycle_closed_by_run", "all_matched") == true
+  defp latest_marker_is_reopen?(metadata) do
+    reopened = metadata["lifecycle_reopened_by_run"]
+    closed = metadata["lifecycle_closed_by_run"]
+
+    reopened != nil and compare_marker_timestamps(closed, reopened) != :gt
   end
 
-  defp reopened?(metadata), do: Map.has_key?(metadata, "lifecycle_reopened_by_run")
+  defp passing?(evidence, metadata) do
+    live_pass?(evidence) or closed_lifecycle_passes?(metadata)
+  end
+
+  defp live_pass?(evidence) do
+    field(evidence, :outcome) == "passed" or field(evidence, :all_matched) == true
+  end
+
+  # A current closed marker (not overridden by a later reopen) proves a passing
+  # benchmark run. `all_matched` is always true for closed markers in production,
+  # but we check it defensively.
+  defp closed_lifecycle_passes?(metadata) do
+    closed = metadata["lifecycle_closed_by_run"]
+    reopened = metadata["lifecycle_reopened_by_run"]
+
+    closed != nil and
+      closed["all_matched"] != false and
+      compare_marker_timestamps(closed, reopened) != :lt
+  end
 
   defp approved?(candidate, evidence, metadata) do
     field(candidate, :status) == "approved" or
       field(evidence, :human_approved) == true or
-      metadata_value(metadata, "human_approved") == true
+      metadata_value(metadata, "human_approved") == true or
+      approved_by_closed_lifecycle?(metadata)
   end
 
-  defp metadata_value(metadata, key, nested_key \\ nil) do
-    value = Map.get(metadata, key)
+  # Only approved candidates are materialized into benchmark scenarios, so a
+  # current closed marker also proves prior human approval even though the
+  # `status` field was overwritten to `archived` by the lifecycle transition.
+  defp approved_by_closed_lifecycle?(metadata) do
+    closed_lifecycle_passes?(metadata)
+  end
 
-    if nested_key && is_map(value), do: Map.get(value, nested_key), else: value
+  defp metadata_value(metadata, key), do: Map.get(metadata, key)
+
+  # Compares the `closed_at` timestamps of the closed vs reopened markers.
+  # Returns :gt when closed is newer, :lt when reopened is newer, :eq on ties
+  # or when either marker is missing/unparseable.
+  defp compare_marker_timestamps(nil, _reopened), do: :lt
+  defp compare_marker_timestamps(_closed, nil), do: :gt
+
+  defp compare_marker_timestamps(closed, reopened) do
+    with {:ok, closed_at, _} <- DateTime.from_iso8601(closed["closed_at"] || ""),
+         {:ok, reopened_at, _} <- DateTime.from_iso8601(reopened["closed_at"] || "") do
+      DateTime.compare(closed_at, reopened_at)
+    else
+      _ -> :eq
+    end
   end
 
   defp field(map, key) do

--- a/lib/controlkeel/observability/promotion.ex
+++ b/lib/controlkeel/observability/promotion.ex
@@ -1,0 +1,118 @@
+defmodule ControlKeel.Observability.Promotion do
+  @moduledoc """
+  Pure policy for deciding when recurring agent work is ready to become a
+  deterministic check.
+
+  This module intentionally does not mutate candidates, run benchmarks, or
+  invoke an agent. It turns existing candidate and benchmark evidence into a
+  stable decision that callers can use to choose the next workflow step.
+  """
+
+  @type decision :: %{
+          state: String.t(),
+          reason: String.t(),
+          next_action: String.t(),
+          deterministic: true,
+          human_gate_required: boolean()
+        }
+
+  @spec evaluate(map() | nil, map()) :: decision()
+  def evaluate(candidate, evidence \\ %{}) do
+    candidate = candidate || %{}
+    evidence = evidence || %{}
+    metadata = field(candidate, :metadata) || %{}
+
+    cond do
+      failed_evidence?(evidence) or reopened?(metadata) ->
+        decision(
+          "reopen",
+          "benchmark evidence failed or the candidate was reopened after a regression",
+          "Investigate the miss, update the guardrail, and rerun the bounded regression flow.",
+          true
+        )
+
+      passed_evidence?(evidence, metadata) and approved?(candidate, evidence, metadata) ->
+        decision(
+          "promote",
+          "human approval and passing benchmark evidence are both recorded",
+          "Use the deterministic check or workflow as the default path; reserve the agent for exceptions.",
+          false
+        )
+
+      passed_evidence?(evidence, metadata) ->
+        decision(
+          "review",
+          "benchmark evidence passes but human approval is not recorded",
+          "Obtain human approval before promoting this behavior into a deterministic workflow.",
+          true
+        )
+
+      field(candidate, :status) == "rejected" ->
+        decision(
+          "discover",
+          "the candidate was rejected and has no approved repeatable contract",
+          "Keep the work agent-led until a narrower, reviewable behavior is identified.",
+          true
+        )
+
+      field(candidate, :human_gate_required) == false ->
+        decision(
+          "discover",
+          "repeatability has not been proven yet",
+          "Collect bounded evidence before encoding the behavior as a deterministic check.",
+          false
+        )
+
+      true ->
+        decision(
+          "review",
+          "a recurring behavior is identified but its promotion gate is incomplete",
+          "Review the candidate and create bounded regression coverage before promotion.",
+          true
+        )
+    end
+  end
+
+  defp decision(state, reason, next_action, human_gate_required) do
+    %{
+      state: state,
+      reason: reason,
+      next_action: next_action,
+      deterministic: true,
+      human_gate_required: human_gate_required
+    }
+  end
+
+  defp failed_evidence?(evidence) do
+    field(evidence, :outcome) in ["failed", "flaky"] or
+      field(evidence, :all_matched) == false
+  end
+
+  defp passed_evidence?(evidence, metadata) do
+    field(evidence, :outcome) == "passed" or
+      field(evidence, :all_matched) == true or
+      metadata_value(metadata, "lifecycle_closed_by_run", "all_matched") == true
+  end
+
+  defp reopened?(metadata), do: Map.has_key?(metadata, "lifecycle_reopened_by_run")
+
+  defp approved?(candidate, evidence, metadata) do
+    field(candidate, :status) == "approved" or
+      field(evidence, :human_approved) == true or
+      metadata_value(metadata, "human_approved") == true
+  end
+
+  defp metadata_value(metadata, key, nested_key \\ nil) do
+    value = Map.get(metadata, key)
+
+    if nested_key && is_map(value), do: Map.get(value, nested_key), else: value
+  end
+
+  defp field(map, key) do
+    cond do
+      Map.has_key?(map, key) -> Map.get(map, key)
+      Map.has_key?(map, Atom.to_string(key)) -> Map.get(map, Atom.to_string(key))
+      true -> nil
+    end
+  end
+end

--- a/lib/controlkeel/observability/promotion.ex
+++ b/lib/controlkeel/observability/promotion.ex
@@ -115,7 +115,12 @@ defmodule ControlKeel.Observability.Promotion do
     reopened = metadata["lifecycle_reopened_by_run"]
     closed = metadata["lifecycle_closed_by_run"]
 
-    reopened != nil and compare_marker_timestamps(closed, reopened) != :gt
+    # Reopen wins only when strictly newer than the closed marker. A same-second
+    # tie (:eq) resolves in favor of recovery, because lifecycle timestamps are
+    # truncated to second precision (see
+    # Observability.close_eval_candidate_lifecycle_from_run!/1) and a genuine
+    # regression is captured by the next distinct-second reopen marker.
+    reopened != nil and compare_marker_timestamps(closed, reopened) == :lt
   end
 
   defp passing?(evidence, metadata) do

--- a/lib/controlkeel_web/live/organization_settings_live.ex
+++ b/lib/controlkeel_web/live/organization_settings_live.ex
@@ -199,7 +199,7 @@ defmodule ControlKeelWeb.OrganizationSettingsLive do
           navigate={~p"/organizations/#{@org.slug}"}
           class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-medium text-zinc-300 transition hover:bg-white/[0.08] hover:text-white"
         >
-          <.icon name="hero-arrow-left" class="size-4" />           Back to organization details
+          <.icon name="hero-arrow-left" class="size-4" /> Back to organization details
         </.link>
       </div>
 

--- a/lib/controlkeel_web/live/organizations_live.ex
+++ b/lib/controlkeel_web/live/organizations_live.ex
@@ -272,7 +272,9 @@ defmodule ControlKeelWeb.OrganizationsLive do
         @role == "admin" && "bg-sky-400/10 text-sky-200 ring-sky-300/20",
         @role == "member" && "bg-zinc-400/10 text-zinc-200 ring-zinc-300/20",
         @role == "viewer" && "bg-zinc-400/10 text-zinc-400 ring-zinc-500/20"
-      ]}>{@role}</span>
+      ]}>
+        {@role}
+      </span>
     <% else %>
       <span class="text-xs text-zinc-600">—</span>
     <% end %>

--- a/test/controlkeel/accounts_test.exs
+++ b/test/controlkeel/accounts_test.exs
@@ -116,10 +116,15 @@ defmodule ControlKeel.AccountsTest do
       {:ok, other} = Accounts.create_user(%{email: "other@example.com"})
 
       {:ok, _owned} = Accounts.create_org_with_owner(owner.id, %{name: "Owned", slug: "owned"})
-      {:ok, other_org} = Accounts.create_org_with_owner(other.id, %{name: "Other Org", slug: "other-org"})
+
+      {:ok, other_org} =
+        Accounts.create_org_with_owner(other.id, %{name: "Other Org", slug: "other-org"})
 
       {:ok, _, token} =
-        Accounts.invite_member(owner.id, other_org.id, role: "member", invited_by_user_id: other.id)
+        Accounts.invite_member(owner.id, other_org.id,
+          role: "member",
+          invited_by_user_id: other.id
+        )
 
       {:ok, _} = Accounts.accept_invitation(token, owner.id)
 

--- a/test/controlkeel/observability_promotion_test.exs
+++ b/test/controlkeel/observability_promotion_test.exs
@@ -3,6 +3,9 @@ defmodule ControlKeel.Observability.PromotionTest do
 
   alias ControlKeel.Observability.Promotion
 
+  @earlier "2026-07-23T10:00:00Z"
+  @later "2026-07-23T12:00:00Z"
+
   test "keeps unproven behavior in review" do
     assert %{state: "review", deterministic: true, human_gate_required: true} =
              Promotion.evaluate(%{status: "open", human_gate_required: true})
@@ -31,14 +34,63 @@ defmodule ControlKeel.Observability.PromotionTest do
   end
 
   test "reopens when a previously closed candidate records a regression" do
+    # Only a reopen marker exists (no prior closed marker) → currently regressed.
     assert %{state: "reopen"} =
              Promotion.evaluate(%{
-               status: "archived",
+               status: "open",
                metadata: %{"lifecycle_reopened_by_run" => %{"run_id" => 7}}
              })
   end
 
-  test "uses lifecycle evidence without requiring database access" do
+  test "reopens when pass-then-fail leaves the reopen marker as the latest" do
+    # Both markers present; the reopen happened after the close → regressed.
+    assert %{state: "reopen"} =
+             Promotion.evaluate(%{
+               status: "open",
+               metadata: %{
+                 "lifecycle_closed_by_run" => %{"all_matched" => true, "closed_at" => @earlier},
+                 "lifecycle_reopened_by_run" => %{"all_matched" => false, "closed_at" => @later}
+               }
+             })
+  end
+
+  test "promotes an approved candidate after a passing run archives it" do
+    # Production transition overwrites status from "approved" to "archived" on a
+    # passing run. The closed marker must still imply prior approval.
+    result =
+      Promotion.evaluate(%{
+        status: "archived",
+        metadata: %{
+          "lifecycle_closed_by_run" => %{"all_matched" => true, "closed_at" => @earlier}
+        }
+      })
+
+    assert result.state == "promote"
+    refute result.human_gate_required
+  end
+
+  test "recovers to promote after a fail-then-pass lifecycle sequence" do
+    # Both markers present; the close happened after the reopen → recovered.
+    result =
+      Promotion.evaluate(%{
+        status: "archived",
+        metadata: %{
+          "lifecycle_reopened_by_run" => %{"all_matched" => false, "closed_at" => @earlier},
+          "lifecycle_closed_by_run" => %{"all_matched" => true, "closed_at" => @later}
+        }
+      })
+
+    assert result.state == "promote"
+  end
+
+  test "explicit human approval with passing evidence promotes without lifecycle markers" do
+    result =
+      Promotion.evaluate(%{status: "open"}, %{outcome: "passed", human_approved: true})
+
+    assert result.state == "promote"
+  end
+
+  test "explicit human_approved metadata with a closed marker promotes" do
     result =
       Promotion.evaluate(%{
         status: "archived",
@@ -49,5 +101,9 @@ defmodule ControlKeel.Observability.PromotionTest do
       })
 
     assert result.state == "promote"
+  end
+
+  test "nil candidate and evidence do not crash" do
+    assert %{state: "review"} = Promotion.evaluate(nil, nil)
   end
 end

--- a/test/controlkeel/observability_promotion_test.exs
+++ b/test/controlkeel/observability_promotion_test.exs
@@ -83,6 +83,25 @@ defmodule ControlKeel.Observability.PromotionTest do
     assert result.state == "promote"
   end
 
+  test "recovers to promote when fail-then-pass lands in the same wall-clock second" do
+    # Lifecycle timestamps are truncated to second precision, so a fail followed
+    # by a pass within the same second produces equal closed_at values. The tie
+    # must resolve in favor of recovery instead of permanently blocking
+    # promotion (see Greptile P1 on PR #43).
+    tie = "2026-07-23T12:00:00Z"
+
+    result =
+      Promotion.evaluate(%{
+        status: "archived",
+        metadata: %{
+          "lifecycle_reopened_by_run" => %{"all_matched" => false, "closed_at" => tie},
+          "lifecycle_closed_by_run" => %{"all_matched" => true, "closed_at" => tie}
+        }
+      })
+
+    assert result.state == "promote"
+  end
+
   test "explicit human approval with passing evidence promotes without lifecycle markers" do
     result =
       Promotion.evaluate(%{status: "open"}, %{outcome: "passed", human_approved: true})

--- a/test/controlkeel/observability_promotion_test.exs
+++ b/test/controlkeel/observability_promotion_test.exs
@@ -1,0 +1,53 @@
+defmodule ControlKeel.Observability.PromotionTest do
+  use ExUnit.Case, async: true
+
+  alias ControlKeel.Observability.Promotion
+
+  test "keeps unproven behavior in review" do
+    assert %{state: "review", deterministic: true, human_gate_required: true} =
+             Promotion.evaluate(%{status: "open", human_gate_required: true})
+  end
+
+  test "requires approval even when benchmark evidence passes" do
+    result = Promotion.evaluate(%{status: "open"}, %{outcome: "passed"})
+
+    assert result.state == "review"
+    assert result.human_gate_required
+  end
+
+  test "promotes only approved passing behavior" do
+    result = Promotion.evaluate(%{status: "approved"}, %{outcome: "passed"})
+
+    assert result.state == "promote"
+    refute result.human_gate_required
+    assert result.deterministic
+  end
+
+  test "reopens on failed or flaky evidence" do
+    for outcome <- ["failed", "flaky"] do
+      assert %{state: "reopen"} =
+               Promotion.evaluate(%{status: "approved"}, %{outcome: outcome})
+    end
+  end
+
+  test "reopens when a previously closed candidate records a regression" do
+    assert %{state: "reopen"} =
+             Promotion.evaluate(%{
+               status: "archived",
+               metadata: %{"lifecycle_reopened_by_run" => %{"run_id" => 7}}
+             })
+  end
+
+  test "uses lifecycle evidence without requiring database access" do
+    result =
+      Promotion.evaluate(%{
+        status: "archived",
+        metadata: %{
+          "lifecycle_closed_by_run" => %{"all_matched" => true},
+          "human_approved" => true
+        }
+      })
+
+    assert result.state == "promote"
+  end
+end

--- a/test/controlkeel/observability_promotion_test.exs
+++ b/test/controlkeel/observability_promotion_test.exs
@@ -84,22 +84,37 @@ defmodule ControlKeel.Observability.PromotionTest do
   end
 
   test "recovers to promote when fail-then-pass lands in the same wall-clock second" do
-    # Lifecycle timestamps are truncated to second precision, so a fail followed
-    # by a pass within the same second produces equal closed_at values. The tie
-    # must resolve in favor of recovery instead of permanently blocking
-    # promotion (see Greptile P1 on PR #43).
+    # Lifecycle closed_at is truncated to second precision, so a fail followed
+    # by a pass within the same second produces equal timestamps. The monotonic
+    # `seq` counter disambiguates the ordering (see PR #43 Greptile P1).
     tie = "2026-07-23T12:00:00Z"
 
     result =
       Promotion.evaluate(%{
         status: "archived",
         metadata: %{
-          "lifecycle_reopened_by_run" => %{"all_matched" => false, "closed_at" => tie},
-          "lifecycle_closed_by_run" => %{"all_matched" => true, "closed_at" => tie}
+          "lifecycle_reopened_by_run" => %{"all_matched" => false, "closed_at" => tie, "seq" => 1},
+          "lifecycle_closed_by_run" => %{"all_matched" => true, "closed_at" => tie, "seq" => 2}
         }
       })
 
     assert result.state == "promote"
+  end
+
+  test "reopens when pass-then-fail lands in the same wall-clock second" do
+    # Symmetric to the recovery case: the later failing transition must win.
+    tie = "2026-07-23T12:00:00Z"
+
+    result =
+      Promotion.evaluate(%{
+        status: "open",
+        metadata: %{
+          "lifecycle_closed_by_run" => %{"all_matched" => true, "closed_at" => tie, "seq" => 1},
+          "lifecycle_reopened_by_run" => %{"all_matched" => false, "closed_at" => tie, "seq" => 2}
+        }
+      })
+
+    assert result.state == "reopen"
   end
 
   test "explicit human approval with passing evidence promotes without lifecycle markers" do

--- a/test/controlkeel/observability_test.exs
+++ b/test/controlkeel/observability_test.exs
@@ -1564,6 +1564,63 @@ defmodule ControlKeel.ObservabilityTest do
       assert updated.metadata["lifecycle_reopened_by_run"]
     end
 
+    test "records a monotonic lifecycle_seq so same-second transitions never tie", %{
+      candidate: _candidate,
+      scenario: scenario,
+      run: run
+    } do
+      insert_result = fn r, matched ->
+        %ControlKeel.Benchmark.Result{}
+        |> ControlKeel.Benchmark.Result.changeset(%{
+          run_id: r.id,
+          scenario_id: scenario.id,
+          subject: "controlkeel_validate",
+          subject_type: "controlkeel",
+          status: "completed",
+          decision: if(matched, do: "block", else: "allow"),
+          findings_count: if(matched, do: 1, else: 0),
+          matched_expected: matched,
+          payload: %{},
+          metadata: %{}
+        })
+        |> Repo.insert()
+      end
+
+      # First transition: passing run archives the candidate with seq 1.
+      {:ok, _} = insert_result.(run, true)
+      [first] = Observability.close_eval_candidate_lifecycle_from_run!(run)
+
+      assert first.status == "archived"
+      assert first.metadata["lifecycle_seq"] == 1
+      assert first.metadata["lifecycle_closed_by_run"]["seq"] == 1
+
+      # Second transition: a failing run on a new run reopens with seq 2.
+      {:ok, run2} =
+        %Run{}
+        |> Run.changeset(%{
+          suite_id: run.suite_id,
+          status: "completed",
+          baseline_subject: "controlkeel_validate",
+          subjects: ["controlkeel_validate"],
+          started_at: DateTime.utc_now(),
+          total_scenarios: 1,
+          caught_count: 0,
+          blocked_count: 0,
+          catch_rate: 0.0,
+          metadata: %{}
+        })
+        |> Repo.insert()
+
+      {:ok, _} = insert_result.(run2, false)
+      [second] = Observability.close_eval_candidate_lifecycle_from_run!(run2)
+
+      assert second.status == "open"
+      assert second.metadata["lifecycle_seq"] == 2
+      assert second.metadata["lifecycle_reopened_by_run"]["seq"] == 2
+      # The earlier closed marker is retained and still carries its own seq.
+      assert second.metadata["lifecycle_closed_by_run"]["seq"] == 1
+    end
+
     test "ignores runs with no eval-candidate-linked scenarios" do
       _session = session_fixture()
       suite = benchmark_suite_fixture()

--- a/test/controlkeel_web/live/organizations_live_test.exs
+++ b/test/controlkeel_web/live/organizations_live_test.exs
@@ -149,9 +149,12 @@ defmodule ControlKeelWeb.OrganizationsLiveTest do
       {:ok, _view, html} = live(conn, ~p"/organizations")
 
       # Header is present, and the owner role badge is rendered (not the muted placeholder).
+      # The role text is rendered on its own line by HEEx, so assert on the
+      # owner-specific lime styling and role text rather than a literal `>owner<`.
       assert html =~ ">Role<"
       assert html =~ "Owned"
-      assert html =~ ~s(>owner<)
+      assert html =~ "ring-lime-300/20"
+      assert html =~ "owner"
       refute html =~ "—"
     end
 


### PR DESCRIPTION
## Summary

> Spend tokens on discovery, not rediscovery. Once a behavior becomes understood and repeatable, capture it in deterministic code, APIs, CLIs, tools, or workflows. Agents handle uncertainty, exploration, and exceptions.

This PR makes that principle operational in ControlKeel by adding an explicit, **pure** promotion decision for recurring agent work, so proven behaviors stop burning tokens on nondeterministic rediscovery.

## What changed

### `ControlKeel.Observability.Promotion` (new, pure)
A side-effect-free policy that classifies a saved eval candidate and its benchmark evidence into a stable decision:

| State | Meaning |
|-------|---------|
| `discover` | Behavior not yet proven; keep it agent-led. |
| `review` | Recurring behavior identified, but the human gate / benchmark evidence is incomplete. |
| `promote` | Human approval **and** passing benchmark evidence recorded → use the deterministic check/workflow; agent handles only exceptions. |
| `reopen` | Failed, flaky, or regressed evidence → block promotion and revisit. |

**Invariants enforced by the policy:**
- Promotion requires **both** human approval and passing evidence.
- Failed / flaky / reopened regression evidence **always** blocks promotion.
- A passing benchmark without recorded approval stays `review` — CK never silently promotes a high-impact behavior because a model suggested it.
- No mutation, no agent calls, no DB writes from the policy itself.

### Integration & docs
- Exposed `promotion` posture in saved eval candidate summaries.
- Documented the discovery-vs-repeatability boundary in `README.md` and `docs/cost-governance.md`.
- Added the closed-loop rule: prefer a deterministic command/API/test/workflow after the promotion gate; keep the agent in the loop only for exceptions and new discovery.

### Test alignment (commit 2)
A prior `mix format` pass moved the role badge text onto its own line, which broke the literal `>owner<` assertion. Updated the assertion to match the owner-specific lime styling plus role text (whitespace-independent and precise). Included the remaining formatter output.

## Verification

| Check | Command | Result |
|-------|---------|--------|
| Promotion + observability tests | `mix test test/controlkeel/observability_promotion_test.exs test/controlkeel/observability_test.exs` | **82 tests, 0 failures** |
| Format | `mix format --check-formatted` | passed |
| Full suite | `mix precommit` | **2099 tests, 0 failures** |

## What is NOT changed
- No provider, network, shell, deploy, or model-routing behavior changes.
- No automatic high-impact promotion — the human gate is preserved.
- No changes to existing candidate / benchmark lifecycle statuses.

## Out of scope
Automatic workflow/code generation, autonomous deploys, provider scheduling, and deleting agent functionality.