### PR TITLE
fix(cloud): route cloud-mode queries to Postgres via runtime dispatcher

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,12 @@ import Config
 
 config :controlkeel,
   namespace: ControlKeel,
-  ecto_repos: [ControlKeel.Repo],
+  # `ControlKeel.Repo` is a runtime dispatcher (see lib/controlkeel/repo.ex);
+  # the underlying SQLite repo is `ControlKeel.Repo.Local`. Local-mode
+  # migrations and `mix ecto.migrate` target `:ecto_repos`. Cloud-mode
+  # migrations target `:cloud_ecto_repos` and run via `Release.migrate/0`
+  # and `ControlKeel.Application.run_migrations/0`.
+  ecto_repos: [ControlKeel.Repo.Local],
   cloud_ecto_repos: [ControlKeel.CloudRepo],
   runtime_mode: :local,
   pdf_renderer: :chromic,
@@ -37,6 +42,13 @@ config :controlkeel,
     workspace_id: nil,
     jobs: []
   ]
+
+# Pin the migration directory to the historical `priv/repo/migrations` path.
+# `ControlKeel.Repo.Local` is the renamed `ControlKeel.Repo`; without this
+# Ecto would derive `priv/local/migrations` from the module name and orphan
+# the 59 existing migrations.
+config :controlkeel, ControlKeel.Repo.Local, priv: "priv/repo"
+config :controlkeel, ControlKeel.CloudRepo, priv: "priv/repo"
 
 # Configure the endpoint
 # Default `code_reloader` so releases match runtime MCP overrides (CK_MCP_MODE).

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,7 @@
 import Config
 
 # Configure your database
-config :controlkeel, ControlKeel.Repo,
+config :controlkeel, ControlKeel.Repo.Local,
   database: Path.expand("../priv/repo/controlkeel_dev.db", __DIR__),
   pool_size: 10,
   # Avoid long waits when another process (e.g. phx.server + MCP) holds SQLite.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -44,7 +44,7 @@ if System.get_env("CK_MCP_MODE") in ~w(1 true TRUE yes YES) or
   # Anything on stdout after Content-Length framing corrupts the stream; clients then
   # hang and abort (~10s). Repo SQL logs default to :debug in dev and were observed on stdout.
   # CLI commands should avoid debug SQL noise for cleaner output.
-  config :controlkeel, ControlKeel.Repo, log: false
+  config :controlkeel, ControlKeel.Repo.Local, log: false
   config :controlkeel, ControlKeel.CloudRepo, log: false
 
   # OTP :logger default handler uses type :standard_io (stdout). Cursor parses stdout as
@@ -182,28 +182,43 @@ if config_env() == :prod do
   # opens. No-op for already-migrated projects or explicit DATABASE_PATH.
   ControlKeel.Runtime.Defaults.maybe_seed_project_database()
 
-  config :controlkeel, ControlKeel.Repo,
-    database: database_path,
-    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-    journal_mode: :wal,
-    synchronous: :normal,
-    # Wait for a held SQLite lock instead of failing immediately. Multiple
-    # controlkeel processes (CLI exports, the MCP server, hooks) share one
-    # WAL database; without this, brief startup overlap surfaces as transient
-    # "database is locked" errors. Dev/test already set this; prod did not.
-    busy_timeout: String.to_integer(System.get_env("CONTROLKEEL_BUSY_TIMEOUT") || "15000"),
-    queue_target: 50,
-    queue_interval: 1_000
+  # Postgres is configured whenever a remote mode (`:cloud` or `:self_hosted`)
+  # is paired with a `DATABASE_URL`. In that case the local SQLite repo is
+  # intentionally NOT configured — the dispatcher (lib/controlkeel/repo.ex)
+  # must not be able to silently fall back to a laptop-local file when the
+  # Postgres connection is misconfigured. If anything tries to use the local
+  # repo directly it will fail loudly instead of writing to the wrong database.
+  #
+  # `:cloud` mode requires `DATABASE_URL` outright (raises). `:self_hosted`
+  # may run without it during the self-host smoke test and laptop dev-runner
+  # scenarios, in which case it falls through to the SQLite branch below.
+  database_url = System.get_env("DATABASE_URL")
 
-  if runtime_mode == :cloud do
-    database_url =
-      System.get_env("DATABASE_URL") ||
-        raise "DATABASE_URL is required when CONTROLKEEL_RUNTIME_MODE=cloud"
-
+  if runtime_mode in [:cloud, :self_hosted] and database_url != nil do
     config :controlkeel, ControlKeel.CloudRepo,
       url: database_url,
       pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
       ssl: System.get_env("ECTO_USE_SSL", "false") == "true"
+  else
+    if runtime_mode == :cloud do
+      raise "DATABASE_URL is required when CONTROLKEEL_RUNTIME_MODE=cloud"
+    end
+
+    # Local mode, or :self_hosted dev-runner without DATABASE_URL. SQLite is
+    # the source of truth; laptops sync to the hosted plane via
+    # `controlkeel cloud push/pull`.
+    config :controlkeel, ControlKeel.Repo.Local,
+      database: database_path,
+      pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+      journal_mode: :wal,
+      synchronous: :normal,
+      # Wait for a held SQLite lock instead of failing immediately. Multiple
+      # controlkeel processes (CLI exports, the MCP server, hooks) share one
+      # WAL database; without this, brief startup overlap surfaces as transient
+      # "database is locked" errors. Dev/test already set this; prod did not.
+      busy_timeout: String.to_integer(System.get_env("CONTROLKEEL_BUSY_TIMEOUT") || "15000"),
+      queue_target: 50,
+      queue_interval: 1_000
   end
 
   if endpoint = System.get_env("CONTROLKEEL_CLOUD_TELEMETRY_ENDPOINT") do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -72,12 +72,13 @@ config :controlkeel, ControlKeel.Proxy,
   semgrep_bin: System.get_env("CONTROLKEEL_SEMGREP_BIN") || "semgrep",
   timeout_ms: String.to_integer(System.get_env("CONTROLKEEL_PROXY_TIMEOUT_MS", "15000"))
 
+# Parse the runtime mode through ControlKeel.Runtime.Mode.parse/1 so this stays
+# in sync with Mode.current/0. A previous inline `case` only mapped "cloud" and
+# sent "self_hosted" to :local, which made a self_hosted + DATABASE_URL release
+# enter the SQLite branch and silently use SQLite instead of Postgres.
 runtime_mode =
-  case System.get_env("CONTROLKEEL_RUNTIME_MODE", "local") do
-    "cloud" -> :cloud
-    :cloud -> :cloud
-    _ -> :local
-  end
+  System.get_env("CONTROLKEEL_RUNTIME_MODE", "local")
+  |> ControlKeel.Runtime.Mode.parse()
 
 config :controlkeel,
   runtime_mode: runtime_mode

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,16 +14,16 @@ if System.get_env("CK_DB_ADAPTER") == "postgres" do
     System.get_env("DATABASE_URL") ||
       raise "DATABASE_URL is required when CK_DB_ADAPTER=postgres"
 
-  config :controlkeel, ControlKeel.Repo,
+  config :controlkeel, ControlKeel.Repo.Local,
     url: database_url,
     pool: Ecto.Adapters.SQL.Sandbox,
-    pool_size: String.to_integer(System.get_env("POOL_SIZE", "10"))
+    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
 else
   test_database =
     System.get_env("CK_TEST_DB") ||
       Path.expand("../priv/repo/controlkeel_test.db", __DIR__)
 
-  config :controlkeel, ControlKeel.Repo,
+  config :controlkeel, ControlKeel.Repo.Local,
     database: test_database,
     busy_timeout: 15_000,
     # SQLite-backed tests are more stable with a single pooled connection because

--- a/lib/controlkeel/application.ex
+++ b/lib/controlkeel/application.ex
@@ -72,7 +72,7 @@ defmodule ControlKeel.Application do
 
   defp late_children do
     [
-      ControlKeel.Repo
+      ControlKeel.Repo.Local
     ] ++
       cloud_repo_children() ++
       analytics_children() ++
@@ -106,7 +106,7 @@ defmodule ControlKeel.Application do
 
   defp mcp_stdio_rest_children do
     [
-      ControlKeel.Repo
+      ControlKeel.Repo.Local
     ] ++
       cloud_repo_children() ++
       analytics_children() ++
@@ -222,7 +222,20 @@ defmodule ControlKeel.Application do
   end
 
   defp run_migrations do
-    Application.fetch_env!(:controlkeel, :ecto_repos)
+    # Migrate the active repo for the current runtime mode. In :local mode that
+    # is `ControlKeel.Repo.Local` (SQLite). In :cloud / :self_hosted mode it is
+    # `ControlKeel.CloudRepo` (Postgres). Routing through the dispatcher's
+    # `active/0` guarantees the same repo serves queries and owns migrations,
+    # so a cloud deploy can no longer auto-migrate SQLite while serving reads
+    # from Postgres (the original issue #44 defect).
+    repos =
+      if ControlKeel.Runtime.cloud_repo_enabled?() do
+        [ControlKeel.CloudRepo]
+      else
+        [ControlKeel.Repo.Local]
+      end
+
+    repos
     |> Enum.reduce_while(:ok, fn repo, :ok ->
       case Ecto.Migrator.with_repo(
              repo,

--- a/lib/controlkeel/application.ex
+++ b/lib/controlkeel/application.ex
@@ -71,9 +71,7 @@ defmodule ControlKeel.Application do
   end
 
   defp late_children do
-    [
-      ControlKeel.Repo.Local
-    ] ++
+    local_repo_children() ++
       cloud_repo_children() ++
       analytics_children() ++
       cloud_emitter_children() ++
@@ -105,9 +103,7 @@ defmodule ControlKeel.Application do
   end
 
   defp mcp_stdio_rest_children do
-    [
-      ControlKeel.Repo.Local
-    ] ++
+    local_repo_children() ++
       cloud_repo_children() ++
       analytics_children() ++
       cloud_emitter_children() ++
@@ -263,6 +259,14 @@ defmodule ControlKeel.Application do
     else
       []
     end
+  end
+
+  # Only start the SQLite repo when it is actually configured. A prod
+  # cloud/self-hosted release intentionally leaves Repo.Local without a
+  # :database/:url, so starting it unconditionally would crash boot. See
+  # ControlKeel.Runtime.local_repo_configured?/0.
+  defp local_repo_children do
+    if ControlKeel.Runtime.local_repo_configured?(), do: [ControlKeel.Repo.Local], else: []
   end
 
   defp cloud_emitter_children do

--- a/lib/controlkeel/cloud/doctor.ex
+++ b/lib/controlkeel/cloud/doctor.ex
@@ -109,12 +109,26 @@ defmodule ControlKeel.Cloud.Doctor do
           detail: "Runtime.mode is :cloud but DATABASE_URL is not set"
         }
 
+      ControlKeel.Repo.active() != CloudRepo ->
+        # The dispatcher (lib/controlkeel/repo.ex) decides where every query
+        # goes. If it does not resolve to CloudRepo in cloud mode, context
+        # modules will silently route to the local SQLite — the original
+        # issue #44 defect. Surface this as an error, not just a config check.
+        %{
+          id: :cloud_repo,
+          label: "Cloud repo",
+          status: :error,
+          detail:
+            "CloudRepo is configured but ControlKeel.Repo.active/0 resolves to " <>
+              "#{inspect(ControlKeel.Repo.active())} — queries will not reach Postgres"
+        }
+
       true ->
         %{
           id: :cloud_repo,
           label: "Cloud repo",
           status: :ok,
-          detail: "configured (DATABASE_URL set)"
+          detail: "configured and active (DATABASE_URL set; dispatcher routes to Postgres)"
         }
     end
   end

--- a/lib/controlkeel/memory/store/pgvector.ex
+++ b/lib/controlkeel/memory/store/pgvector.ex
@@ -38,7 +38,7 @@ defmodule ControlKeel.Memory.Store.Pgvector do
         LIMIT $6
         """
 
-        case SQL.query(Repo, sql, [
+        case SQL.query(Repo.active(), sql, [
                vector,
                opts[:workspace_id],
                opts[:session_id],
@@ -79,7 +79,11 @@ defmodule ControlKeel.Memory.Store.Pgvector do
   end
 
   defp pgvector_enabled? do
-    case SQL.query(Repo, "SELECT 1 FROM pg_extension WHERE extname = 'vector' LIMIT 1", []) do
+    case SQL.query(
+           Repo.active(),
+           "SELECT 1 FROM pg_extension WHERE extname = 'vector' LIMIT 1",
+           []
+         ) do
       {:ok, %{rows: [[1]]}} -> true
       _ -> false
     end

--- a/lib/controlkeel/memory/store/sqlite.ex
+++ b/lib/controlkeel/memory/store/sqlite.ex
@@ -17,14 +17,28 @@ defmodule ControlKeel.Memory.Store.Sqlite do
   end
 
   defp check_fts_availability do
-    case SQL.query(
-           Repo.active(),
-           "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_records_fts'",
-           []
-         ) do
-      {:ok, %{rows: [[_name]]}} -> true
-      _ -> false
+    # The FTS probe is SQLite-specific (queries sqlite_master). In cloud mode
+    # Repo.active()/0 is CloudRepo (Postgres), where this query would error and
+    # spam logs. Short-circuit when the active adapter is not SQLite3; the
+    # search path then degrades to fallback_records, which targets the active
+    # repo through Ecto and works on Postgres. Matches the adapter check in
+    # ControlKeel.Ops.Database.
+    if sqlite_active?() do
+      case SQL.query(
+             Repo.active(),
+             "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_records_fts'",
+             []
+           ) do
+        {:ok, %{rows: [[_name]]}} -> true
+        _ -> false
+      end
+    else
+      false
     end
+  end
+
+  defp sqlite_active? do
+    to_string(Repo.__adapter__()) == "Elixir.Ecto.Adapters.SQLite3"
   end
 
   defp sqlite_fts_available? do

--- a/lib/controlkeel/memory/store/sqlite.ex
+++ b/lib/controlkeel/memory/store/sqlite.ex
@@ -18,7 +18,7 @@ defmodule ControlKeel.Memory.Store.Sqlite do
 
   defp check_fts_availability do
     case SQL.query(
-           Repo,
+           Repo.active(),
            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_records_fts'",
            []
          ) do
@@ -102,7 +102,7 @@ defmodule ControlKeel.Memory.Store.Sqlite do
       LIMIT ?
       """
 
-      case SQL.query(Repo, sql, filter_params(match, opts) ++ [limit]) do
+      case SQL.query(Repo.active(), sql, filter_params(match, opts) ++ [limit]) do
         {:ok, %{rows: rows}} ->
           rows
           |> Enum.with_index(1)

--- a/lib/controlkeel/ops/entry_point.ex
+++ b/lib/controlkeel/ops/entry_point.ex
@@ -68,11 +68,11 @@ defmodule ControlKeel.Ops.EntryPoint do
 
     # Repo SQL and Logger default to noisy stdout in dev; stdio MCP must keep
     # stdout JSON-only (see config/runtime.exs CK_MCP_MODE).
-    repo_cfg = Application.get_env(:controlkeel, ControlKeel.Repo) || []
+    repo_cfg = Application.get_env(:controlkeel, ControlKeel.Repo.Local) || []
 
     Application.put_env(
       :controlkeel,
-      ControlKeel.Repo,
+      ControlKeel.Repo.Local,
       Keyword.put(repo_cfg, :log, false)
     )
 
@@ -108,11 +108,11 @@ defmodule ControlKeel.Ops.EntryPoint do
         |> Keyword.put(:live_reload, web_console_logger: false, patterns: [])
       )
 
-      repo_cfg = Application.get_env(:controlkeel, ControlKeel.Repo) || []
+      repo_cfg = Application.get_env(:controlkeel, ControlKeel.Repo.Local) || []
 
       Application.put_env(
         :controlkeel,
-        ControlKeel.Repo,
+        ControlKeel.Repo.Local,
         Keyword.put(repo_cfg, :log, false)
       )
 

--- a/lib/controlkeel/ops/release.ex
+++ b/lib/controlkeel/ops/release.ex
@@ -28,11 +28,15 @@ defmodule ControlKeel.Ops.Release do
   end
 
   defp repos do
-    runtime_mode = Application.get_env(@app, :runtime_mode, :local)
-
-    case runtime_mode do
-      :cloud -> [ControlKeel.CloudRepo]
-      _ -> [ControlKeel.Repo.Local]
+    # Match the boot-time migration path in ControlKeel.Application.run_migrations/0:
+    # migrate the repo the dispatcher will actually serve. A `:self_hosted`
+    # release with DATABASE_URL must migrate CloudRepo (Postgres), not the
+    # laptop-local SQLite file. Routing through cloud_repo_enabled?/0 keeps the
+    # release command consistent with query routing (issue #44).
+    if ControlKeel.Runtime.cloud_repo_enabled?() do
+      [ControlKeel.CloudRepo]
+    else
+      [ControlKeel.Repo.Local]
     end
   end
 

--- a/lib/controlkeel/ops/release.ex
+++ b/lib/controlkeel/ops/release.ex
@@ -9,7 +9,7 @@ defmodule ControlKeel.Ops.Release do
   ## Usage
 
       bin/controlkeel eval "ControlKeel.Ops.Release.migrate()"
-      bin/controlkeel eval "ControlKeel.Ops.Release.rollback(ControlKeel.Repo, 20260524004330)"
+      bin/controlkeel eval "ControlKeel.Ops.Release.rollback(ControlKeel.CloudRepo, 20260524004330)"
   """
 
   @app :controlkeel
@@ -32,7 +32,7 @@ defmodule ControlKeel.Ops.Release do
 
     case runtime_mode do
       :cloud -> [ControlKeel.CloudRepo]
-      _ -> [ControlKeel.Repo]
+      _ -> [ControlKeel.Repo.Local]
     end
   end
 

--- a/lib/controlkeel/repo.ex
+++ b/lib/controlkeel/repo.ex
@@ -1,10 +1,133 @@
 defmodule ControlKeel.Repo do
-  @adapter (case System.get_env("CK_DB_ADAPTER", "sqlite3") do
-              "postgres" -> Ecto.Adapters.Postgres
-              _ -> Ecto.Adapters.SQLite3
-            end)
+  @moduledoc """
+  Public Ecto repo API for ControlKeel.
 
-  use Ecto.Repo,
-    otp_app: :controlkeel,
-    adapter: @adapter
+  All context modules, LiveViews, controllers, and CLI tooling call this module
+  (`Repo.all/2`, `Repo.insert/2`, …). It forwards each call to the active
+  underlying repo at runtime:
+
+    * `:local` runtime mode → `ControlKeel.Repo.Local` (SQLite)
+    * `:cloud` / `:self_hosted` runtime mode → `ControlKeel.CloudRepo` (Postgres)
+
+  Selection goes through `ControlKeel.Runtime.cloud_repo_enabled?/0`, which
+  requires a non-empty `ControlKeel.CloudRepo` config **and** a remote runtime
+  mode. This means a misconfigured cloud deployment fails closed against
+  Postgres instead of silently falling back to a local SQLite file.
+
+  ## Why a dispatcher instead of a single Repo with a runtime adapter
+
+  `use Ecto.Repo, adapter:` binds the adapter at compile time. A single Phoenix
+  release must serve both SQLite (local laptops) and Postgres (cloud), so the
+  adapter cannot be baked in. Routing to two compiled repos at runtime is the
+  minimal-risk fix and leaves every call site unchanged.
+
+  ## Transaction consistency
+
+  `Runtime.mode/0` is process-stable for the lifetime of a transaction, so
+  every inner `Repo.*` call inside a `Repo.transaction/2` resolves to the same
+  underlying repo. Ecto tracks the live transaction in the process dictionary
+  keyed by repo module, so `Repo.transaction` + inner `Repo.insert` stay bound
+  to the same connection.
+
+  ## Forwarded surface
+
+  Forwards the full query/write/transaction API used across the codebase
+  (`all`, `aggregate`, `get`, `get!`, `get_by`, `get_by!`, `one`, `one!`,
+  `preload`, `query`, `query!`, `insert`, `insert!`, `insert_all`,
+  `insert_or_update`, `insert_or_update!`, `update`, `update!`, `update_all`,
+  `delete`, `delete!`, `delete_all`, `transaction`, `rollback`) plus the
+  introspection callbacks `__adapter__/0` and `config/0` used by
+  `ControlKeel.Ops.Database` and `ControlKeel.Memory.Store.PgVector`.
+
+  Callers that need a real `Ecto.Repo` for adapter-level APIs
+  (`Ecto.Adapters.SQL.query/4`, sandbox, connection checkout) must use
+  `ControlKeel.Repo.active/0` — the dispatcher itself is not registered with
+  `Ecto.Repo.Registry`.
+  """
+
+  alias ControlKeel.Repo.Local
+  alias ControlKeel.CloudRepo
+
+  @doc """
+  Resolve the active underlying repo for the current runtime mode.
+
+  Returns `ControlKeel.CloudRepo` when cloud-mode is enabled (remote runtime
+  mode and CloudRepo configured), otherwise `ControlKeel.Repo.Local`.
+  """
+  @spec active() :: module()
+  def active do
+    if ControlKeel.Runtime.cloud_repo_enabled?(), do: CloudRepo, else: Local
+  end
+
+  # -- Introspection ---------------------------------------------------------
+
+  def __adapter__, do: active().__adapter__()
+  def config, do: active().config()
+
+  # -- Read ------------------------------------------------------------------
+
+  def all(queryable, opts \\ []), do: active().all(queryable, opts)
+
+  def one(queryable, opts \\ []), do: active().one(queryable, opts)
+  def one!(queryable, opts \\ []), do: active().one!(queryable, opts)
+
+  def aggregate(queryable, aggregate, opts \\ []),
+    do: active().aggregate(queryable, aggregate, opts)
+
+  def get(queryable, id, opts \\ []), do: active().get(queryable, id, opts)
+
+  def get!(queryable, id, opts \\ []), do: active().get!(queryable, id, opts)
+
+  def get_by(queryable, clauses, opts \\ []),
+    do: active().get_by(queryable, clauses, opts)
+
+  def get_by!(queryable, clauses, opts \\ []),
+    do: active().get_by!(queryable, clauses, opts)
+
+  def preload(struct_or_structs, preloads, opts \\ []),
+    do: active().preload(struct_or_structs, preloads, opts)
+
+  def query(sql, params \\ [], opts \\ []), do: active().query(sql, params, opts)
+  def query!(sql, params \\ [], opts \\ []), do: active().query!(sql, params, opts)
+
+  # -- Write -----------------------------------------------------------------
+
+  def insert(struct_or_changeset, opts \\ []),
+    do: active().insert(struct_or_changeset, opts)
+
+  def insert!(struct_or_changeset, opts \\ []),
+    do: active().insert!(struct_or_changeset, opts)
+
+  def insert_all(schema_or_source, entries, opts \\ []),
+    do: active().insert_all(schema_or_source, entries, opts)
+
+  def insert_or_update(struct_or_changeset, opts \\ []),
+    do: active().insert_or_update(struct_or_changeset, opts)
+
+  def insert_or_update!(struct_or_changeset, opts \\ []),
+    do: active().insert_or_update!(struct_or_changeset, opts)
+
+  def update(struct_or_changeset, opts \\ []),
+    do: active().update(struct_or_changeset, opts)
+
+  def update!(struct_or_changeset, opts \\ []),
+    do: active().update!(struct_or_changeset, opts)
+
+  def update_all(queryable, updates, opts \\ []),
+    do: active().update_all(queryable, updates, opts)
+
+  def delete(struct_or_changeset, opts \\ []),
+    do: active().delete(struct_or_changeset, opts)
+
+  def delete!(struct_or_changeset, opts \\ []),
+    do: active().delete!(struct_or_changeset, opts)
+
+  def delete_all(queryable, opts \\ []), do: active().delete_all(queryable, opts)
+
+  # -- Transactions ----------------------------------------------------------
+
+  def transaction(fun_or_multi, opts \\ []),
+    do: active().transaction(fun_or_multi, opts)
+
+  def rollback(value), do: active().rollback(value)
 end

--- a/lib/controlkeel/repo.ex
+++ b/lib/controlkeel/repo.ex
@@ -10,9 +10,10 @@ defmodule ControlKeel.Repo do
     * `:cloud` / `:self_hosted` runtime mode → `ControlKeel.CloudRepo` (Postgres)
 
   Selection goes through `ControlKeel.Runtime.cloud_repo_enabled?/0`, which
-  requires a non-empty `ControlKeel.CloudRepo` config **and** a remote runtime
-  mode. This means a misconfigured cloud deployment fails closed against
-  Postgres instead of silently falling back to a local SQLite file.
+  requires a remote runtime mode **and** a configured `ControlKeel.CloudRepo`
+  `:url`. This means a misconfigured cloud deployment fails closed against
+  Postgres instead of silently falling back to a local SQLite file, and a
+  `:self_hosted` box without `DATABASE_URL` keeps using SQLite as intended.
 
   ## Why a dispatcher instead of a single Repo with a runtime adapter
 

--- a/lib/controlkeel/repo/local.ex
+++ b/lib/controlkeel/repo/local.ex
@@ -1,0 +1,19 @@
+defmodule ControlKeel.Repo.Local do
+  @moduledoc """
+  SQLite-backed Ecto repo used in local runtime mode.
+
+  The adapter is selected at compile time via the `CK_DB_ADAPTER` env var so the
+  test suite can run against Postgres in the `test-postgres` CI lane. Production
+  cloud mode does **not** go through this module — it routes through
+  `ControlKeel.Repo` to `ControlKeel.CloudRepo`. See `lib/controlkeel/repo.ex`.
+  """
+
+  @adapter (case System.get_env("CK_DB_ADAPTER", "sqlite3") do
+              "postgres" -> Ecto.Adapters.Postgres
+              _ -> Ecto.Adapters.SQLite3
+            end)
+
+  use Ecto.Repo,
+    otp_app: :controlkeel,
+    adapter: @adapter
+end

--- a/lib/controlkeel/runtime.ex
+++ b/lib/controlkeel/runtime.ex
@@ -22,8 +22,35 @@ defmodule ControlKeel.Runtime do
   end
 
   def cloud_repo_enabled? do
-    remote?() and Application.get_env(:controlkeel, ControlKeel.CloudRepo, []) != []
+    remote?() and cloud_repo_url_configured?()
   end
+
+  @doc """
+  Whether the local SQLite repo has enough config to be started safely.
+
+  Used to gate `ControlKeel.Repo.Local` supervision: a prod cloud/self-hosted
+  release intentionally leaves `Repo.Local` without a `:database`/`:url` (see
+  `config/runtime.exs`), so starting it would crash boot before the app can
+  serve traffic. Local mode and the test suite always configure it.
+  """
+  def local_repo_configured? do
+    env = Application.get_env(:controlkeel, ControlKeel.Repo.Local, [])
+    Keyword.has_key?(env, :database) or Keyword.has_key?(env, :url)
+  end
+
+  # CloudRepo counts as enabled only when it has a real connection string.
+  # A bare `priv` entry (always present from config/config.exs) must NOT count,
+  # otherwise a self-hosted box without DATABASE_URL would route queries to an
+  # unconfigured Postgres repo instead of the SQLite database runtime.exs set up.
+  defp cloud_repo_url_configured? do
+    Application.get_env(:controlkeel, ControlKeel.CloudRepo, [])
+    |> Keyword.get(:url)
+    |> cloud_repo_url_present?()
+  end
+
+  defp cloud_repo_url_present?(nil), do: false
+  defp cloud_repo_url_present?(""), do: false
+  defp cloud_repo_url_present?(_url), do: true
 
   def memory_store_mode do
     if cloud_repo_enabled?(), do: :pgvector, else: :sqlite

--- a/lib/controlkeel/runtime/defaults.ex
+++ b/lib/controlkeel/runtime/defaults.ex
@@ -30,14 +30,17 @@ defmodule ControlKeel.Runtime.Defaults do
   end
 
   @doc """
-  Reconfigures `ControlKeel.Repo` to point at the resolved project/runtime
+  Reconfigures `ControlKeel.Repo.Local` to point at the resolved project/runtime
   database, so inspection tooling (`mix ck.findings`, `ck.context`, …) reads the
   SAME database the MCP server governs and the commit gate gates on.
 
+  Local-mode only. In cloud mode the dispatcher routes reads to
+  `ControlKeel.CloudRepo` and there is no local SQLite file to bind.
+
   Must be called BEFORE `Mix.Task.run("app.start")` so the Repo pool opens
   against the governed database. No-op when the configured database already
-  matches, when no project database resolves, or when the resolved file does not
-  exist yet (e.g. a fresh project that has never been run by the MCP server).
+  matches, when no project database resolves, or when the resolved file does
+  not exist yet (e.g. a fresh project that has never been run by the MCP server).
 
   Returns `{:redirected, path}`, `:noop`, or
   `{:repo_already_started, path}`.
@@ -45,7 +48,7 @@ defmodule ControlKeel.Runtime.Defaults do
   def bind_inspection_database do
     resolved = database_path()
 
-    current = Application.get_env(:controlkeel, ControlKeel.Repo, [])
+    current = Application.get_env(:controlkeel, ControlKeel.Repo.Local, [])
     current_path = Keyword.get(current, :database)
 
     cond do
@@ -65,7 +68,7 @@ defmodule ControlKeel.Runtime.Defaults do
         # only swap the database path.
         Application.put_env(
           :controlkeel,
-          ControlKeel.Repo,
+          ControlKeel.Repo.Local,
           Keyword.put(current, :database, resolved)
         )
 

--- a/scripts/self_host_smoke.sh
+++ b/scripts/self_host_smoke.sh
@@ -53,8 +53,8 @@ trap cleanup EXIT
 echo "▶ Self-host smoke: PHX_HOST=$PHX_HOST RUNTIME_MODE=$CONTROLKEEL_RUNTIME_MODE PORT=$PORT"
 echo "▶ DB: $DATABASE_PATH"
 
-mix ecto.create -r ControlKeel.Repo >/dev/null
-mix ecto.migrate -r ControlKeel.Repo >/dev/null
+mix ecto.create -r ControlKeel.Repo.Local >/dev/null
+mix ecto.migrate -r ControlKeel.Repo.Local >/dev/null
 
 # ── 2. Boot the Phoenix endpoint ────────────────────────────────────
 

--- a/test/controlkeel/benchmark_test.exs
+++ b/test/controlkeel/benchmark_test.exs
@@ -10,7 +10,7 @@ defmodule ControlKeel.BenchmarkTest do
   alias ControlKeel.Repo
 
   setup_all do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(ControlKeel.Repo, shared: true)
+    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(ControlKeel.Repo.Local, shared: true)
     on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
     :ok
   end

--- a/test/controlkeel/bin_wrapper_test.exs
+++ b/test/controlkeel/bin_wrapper_test.exs
@@ -28,7 +28,10 @@ defmodule ControlKeel.BinWrapperTest do
     # Checkpoint the WAL into the main DB file so the copy is self-contained,
     # then copy the main file (schema is committed data, independent of any
     # open sandbox transaction).
-    Sandbox.unboxed_run(Repo, fn -> Repo.query!("PRAGMA wal_checkpoint(TRUNCATE)") end)
+    Sandbox.unboxed_run(ControlKeel.Repo.Local, fn ->
+      Repo.query!("PRAGMA wal_checkpoint(TRUNCATE)")
+    end)
+
     File.cp!(source_db, tmp_db)
 
     on_exit(fn ->

--- a/test/controlkeel/cloud/doctor_test.exs
+++ b/test/controlkeel/cloud/doctor_test.exs
@@ -119,15 +119,20 @@ defmodule ControlKeel.Cloud.DoctorTest do
       assert cloud_repo.status == :ok
     end
 
-    test "service-account check returns ok when none are configured" do
+    test "service-account check reports unavailable when CloudRepo is not reachable" do
+      # CloudRepo is configured with a placeholder URL but never started in the
+      # test sandbox. Before the issue #44 fix, Platform.list_all_service_accounts/0
+      # silently routed to the local SQLite sandbox and reported "none configured"
+      # — masking the fact that the doctor could not actually reach Postgres.
+      # The routing fix surfaces this honestly as :info / unavailable.
       Application.put_env(:controlkeel, ControlKeel.CloudRepo, url: "postgres://placeholder")
       System.put_env("DATABASE_URL", "postgres://example/db")
 
       report = Doctor.report()
       sa = find_check(report, :service_accounts)
 
-      assert sa.status in [:ok, :info]
-      assert sa.detail =~ "none configured" or sa.detail =~ "configured"
+      assert sa.status == :info
+      assert sa.detail =~ "unavailable"
     end
   end
 

--- a/test/controlkeel/cloud/telemetry/sender_periodic_test.exs
+++ b/test/controlkeel/cloud/telemetry/sender_periodic_test.exs
@@ -198,7 +198,7 @@ defmodule ControlKeel.Cloud.Telemetry.Sender.PeriodicTest do
   end
 
   defp allow_sandbox(pid) do
-    Ecto.Adapters.SQL.Sandbox.allow(ControlKeel.Repo, self(), pid)
+    Ecto.Adapters.SQL.Sandbox.allow(ControlKeel.Repo.Local, self(), pid)
   end
 
   defp wait_until(fun, timeout_ms) do

--- a/test/controlkeel/repo_test.exs
+++ b/test/controlkeel/repo_test.exs
@@ -1,0 +1,95 @@
+defmodule ControlKeel.RepoTest do
+  use ControlKeel.DataCase, async: false
+
+  alias ControlKeel.{Repo, Runtime}
+
+  # `Repo.active/0` is the routing primitive that issue #44 hinged on. If it
+  # silently resolves to SQLite in cloud mode, every context module in the
+  # app reads and writes the wrong database.
+  describe "active/0 routing" do
+    setup do
+      prev_runtime_mode = Application.get_env(:controlkeel, :runtime_mode)
+      prev_cloud_repo = Application.get_env(:controlkeel, ControlKeel.CloudRepo)
+      prev_mode_env = System.get_env("CONTROLKEEL_RUNTIME_MODE")
+
+      on_exit(fn ->
+        if prev_runtime_mode do
+          Application.put_env(:controlkeel, :runtime_mode, prev_runtime_mode)
+        else
+          Application.delete_env(:controlkeel, :runtime_mode)
+        end
+
+        if prev_cloud_repo do
+          Application.put_env(:controlkeel, ControlKeel.CloudRepo, prev_cloud_repo)
+        else
+          Application.delete_env(:controlkeel, ControlKeel.CloudRepo)
+        end
+
+        if prev_mode_env,
+          do: System.put_env("CONTROLKEEL_RUNTIME_MODE", prev_mode_env),
+          else: System.delete_env("CONTROLKEEL_RUNTIME_MODE")
+      end)
+
+      :ok
+    end
+
+    test "resolves to the local SQLite repo in :local mode" do
+      Application.put_env(:controlkeel, :runtime_mode, :local)
+      System.delete_env("CONTROLKEEL_RUNTIME_MODE")
+      Application.delete_env(:controlkeel, ControlKeel.CloudRepo)
+
+      assert Runtime.mode() == :local
+      assert Repo.active() == ControlKeel.Repo.Local
+    end
+
+    test "resolves to CloudRepo when cloud mode is enabled and configured" do
+      System.delete_env("CONTROLKEEL_RUNTIME_MODE")
+      Application.put_env(:controlkeel, :runtime_mode, :cloud)
+      Application.put_env(:controlkeel, ControlKeel.CloudRepo, url: "postgresql://placeholder")
+
+      assert Runtime.mode() == :cloud
+      assert Runtime.cloud_repo_enabled?()
+      assert Repo.active() == ControlKeel.CloudRepo
+    end
+
+    test "fails closed to SQLite when cloud mode is set but CloudRepo is unconfigured" do
+      # Mirrors Runtime.cloud_repo_enabled?/0: a cloud deploy missing the
+      # DATABASE_URL config must NOT route to a half-initialized CloudRepo.
+      # Tests assert the primitive; the deploy-time failure mode is covered by
+      # `cloud doctor` and the runtime.exs raise.
+      System.delete_env("CONTROLKEEL_RUNTIME_MODE")
+      Application.put_env(:controlkeel, :runtime_mode, :cloud)
+      Application.delete_env(:controlkeel, ControlKeel.CloudRepo)
+
+      assert Runtime.mode() == :cloud
+      refute Runtime.cloud_repo_enabled?()
+      assert Repo.active() == ControlKeel.Repo.Local
+    end
+
+    test "resolves to CloudRepo for :self_hosted mode when CloudRepo is configured" do
+      System.delete_env("CONTROLKEEL_RUNTIME_MODE")
+      Application.put_env(:controlkeel, :runtime_mode, :self_hosted)
+      Application.put_env(:controlkeel, ControlKeel.CloudRepo, url: "postgresql://placeholder")
+
+      assert Runtime.mode() == :self_hosted
+      assert Runtime.cloud_repo_enabled?()
+      assert Repo.active() == ControlKeel.CloudRepo
+    end
+  end
+
+  describe "forwarded queries (local mode)" do
+    # Confirms the dispatcher actually hands off to the underlying repo for the
+    # common query path, not just resolves the module.
+    test "Repo.all/1 reaches Repo.Local" do
+      Application.put_env(:controlkeel, :runtime_mode, :local)
+      System.delete_env("CONTROLKEEL_RUNTIME_MODE")
+
+      assert Repo.active() == ControlKeel.Repo.Local
+
+      # Sanity: a call through the dispatcher does not raise and matches the
+      # underlying repo's result for an empty table.
+      assert Repo.all(ControlKeel.Mission.Session) ==
+               ControlKeel.Repo.Local.all(ControlKeel.Mission.Session)
+    end
+  end
+end

--- a/test/controlkeel/repo_test.exs
+++ b/test/controlkeel/repo_test.exs
@@ -75,6 +75,53 @@ defmodule ControlKeel.RepoTest do
       assert Runtime.cloud_repo_enabled?()
       assert Repo.active() == ControlKeel.CloudRepo
     end
+
+    test "resolves to SQLite for :self_hosted when CloudRepo has no :url (issue #44)" do
+      # config/config.exs always sets CloudRepo priv: "priv/repo", so a bare
+      # non-empty CloudRepo env must NOT count as "enabled". A self-hosted box
+      # without DATABASE_URL must keep using the SQLite database runtime.exs
+      # configured, rather than routing queries to an unconfigured Postgres repo.
+      System.delete_env("CONTROLKEEL_RUNTIME_MODE")
+      Application.put_env(:controlkeel, :runtime_mode, :self_hosted)
+      Application.put_env(:controlkeel, ControlKeel.CloudRepo, priv: "priv/repo")
+
+      assert Runtime.mode() == :self_hosted
+      refute Runtime.cloud_repo_enabled?()
+      assert Repo.active() == ControlKeel.Repo.Local
+    end
+  end
+
+  describe "Runtime.local_repo_configured?/0" do
+    # Gates whether Repo.Local is supervised. A prod cloud release leaves
+    # Repo.Local without :database/:url, so the predicate must report false to
+    # avoid booting an unconfigured SQLite repo (issue #44).
+    setup do
+      prev = Application.get_env(:controlkeel, ControlKeel.Repo.Local)
+
+      on_exit(fn ->
+        case prev do
+          nil -> Application.delete_env(:controlkeel, ControlKeel.Repo.Local)
+          config -> Application.put_env(:controlkeel, ControlKeel.Repo.Local, config, persistent: true)
+        end
+      end)
+
+      :ok
+    end
+
+    test "true when a :database is present" do
+      Application.put_env(:controlkeel, ControlKeel.Repo.Local, database: "/tmp/x.db")
+      assert Runtime.local_repo_configured?()
+    end
+
+    test "true when a :url is present" do
+      Application.put_env(:controlkeel, ControlKeel.Repo.Local, url: "postgresql://x")
+      assert Runtime.local_repo_configured?()
+    end
+
+    test "false with only non-connection config (mirrors prod cloud)" do
+      Application.put_env(:controlkeel, ControlKeel.Repo.Local, priv: "priv/repo")
+      refute Runtime.local_repo_configured?()
+    end
   end
 
   describe "forwarded queries (local mode)" do

--- a/test/controlkeel/runtime/defaults_test.exs
+++ b/test/controlkeel/runtime/defaults_test.exs
@@ -273,10 +273,10 @@ defmodule ControlKeel.Runtime.DefaultsTest do
 
   describe "bind_inspection_database/0" do
     setup do
-      prev_repo = Application.get_env(:controlkeel, ControlKeel.Repo, [])
+      prev_repo = Application.get_env(:controlkeel, ControlKeel.Repo.Local, [])
 
       on_exit(fn ->
-        Application.put_env(:controlkeel, ControlKeel.Repo, prev_repo)
+        Application.put_env(:controlkeel, ControlKeel.Repo.Local, prev_repo)
       end)
     end
 
@@ -296,7 +296,7 @@ defmodule ControlKeel.Runtime.DefaultsTest do
       File.write!(db_path, "stub")
 
       # Point DATABASE_PATH at our temp DB so database_path/0 resolves to it.
-      Application.put_env(:controlkeel, ControlKeel.Repo, database: "/dev/null/original.db")
+      Application.put_env(:controlkeel, ControlKeel.Repo.Local, database: "/dev/null/original.db")
 
       with_envs(%{"DATABASE_PATH" => db_path}, fn ->
         result = Defaults.bind_inspection_database()
@@ -312,25 +312,28 @@ defmodule ControlKeel.Runtime.DefaultsTest do
 
         assert redirected_path == db_path
 
-        redirected = Application.get_env(:controlkeel, ControlKeel.Repo, [])
+        redirected = Application.get_env(:controlkeel, ControlKeel.Repo.Local, [])
         assert Keyword.get(redirected, :database) == db_path
       end)
     end
 
     test "is a no-op when the resolved database does not exist yet" do
-      Application.put_env(:controlkeel, ControlKeel.Repo, database: "/dev/null/original.db")
+      Application.put_env(:controlkeel, ControlKeel.Repo.Local, database: "/dev/null/original.db")
 
       with_envs(%{"DATABASE_PATH" => "/nonexistent/path/controlkeel.db"}, fn ->
         assert :noop = Defaults.bind_inspection_database()
 
-        assert Keyword.get(Application.get_env(:controlkeel, ControlKeel.Repo, []), :database) ==
+        assert Keyword.get(
+                 Application.get_env(:controlkeel, ControlKeel.Repo.Local, []),
+                 :database
+               ) ==
                  "/dev/null/original.db"
       end)
     end
 
     test "is a no-op when the resolved path already matches the configured one" do
       db = "/dev/null/already-bound.db"
-      Application.put_env(:controlkeel, ControlKeel.Repo, database: db)
+      Application.put_env(:controlkeel, ControlKeel.Repo.Local, database: db)
 
       with_envs(%{"DATABASE_PATH" => db}, fn ->
         assert :noop = Defaults.bind_inspection_database()

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -34,16 +34,33 @@ defmodule ControlKeel.DataCase do
 
   @doc """
   Sets up the sandbox based on the test tags.
+
+  Targets `ControlKeel.Repo.Local` because the sandbox API needs a real
+  Ecto.Repo (the dispatcher at `ControlKeel.Repo` is not one). Tests run in
+  `:local` runtime mode, so the dispatcher routes every query to `.Local`
+  anyway — the sandbox owns the same pool that production code uses.
+
+  Also cleans up any leaked `ControlKeel.CloudRepo` config after each test
+  so no test accidentally routes queries to an unstarted Postgres repo
+  (issue #44). Tests that deliberately exercise cloud-mode behavior should
+  set CloudRepo config AND a sandbox for it within their own setup; they
+  will restore the original state via their own `on_exit` handlers.
   """
   def setup_sandbox(tags) do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(ControlKeel.Repo, shared: not tags[:async])
+    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(ControlKeel.Repo.Local, shared: not tags[:async])
 
     on_exit(fn ->
       # Check in the connection gracefully before stopping the owner.
       # This prevents "client exited" error logs when LiveView processes
       # that shared the sandbox are still alive during cleanup.
-      Ecto.Adapters.SQL.Sandbox.checkin(ControlKeel.Repo, sandbox: pid)
+      Ecto.Adapters.SQL.Sandbox.checkin(ControlKeel.Repo.Local, sandbox: pid)
       Ecto.Adapters.SQL.Sandbox.stop_owner(pid)
+
+      # Prevent leaked CloudRepo config from routing subsequent tests'
+      # queries to an unstarted Postgres repo. This runs before the test's
+      # own `on_exit` (LIFO), so tests that explicitly save/restore
+      # CloudRepo config will have their original restored properly.
+      Application.delete_env(:controlkeel, ControlKeel.CloudRepo)
     end)
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -40,14 +40,19 @@ defmodule ControlKeel.DataCase do
   `:local` runtime mode, so the dispatcher routes every query to `.Local`
   anyway — the sandbox owns the same pool that production code uses.
 
-  Also cleans up any leaked `ControlKeel.CloudRepo` config after each test
-  so no test accidentally routes queries to an unstarted Postgres repo
-  (issue #44). Tests that deliberately exercise cloud-mode behavior should
-  set CloudRepo config AND a sandbox for it within their own setup; they
-  will restore the original state via their own `on_exit` handlers.
+  Also restores any `ControlKeel.CloudRepo` config captured at setup start so a
+  test that deliberately exercises cloud-mode behavior can save/restore its own
+  state without this case clobbering it (issue #44). Tests that opt into cloud
+  mode must start a CloudRepo sandbox in their own setup; the dispatcher routes
+  accordingly.
   """
   def setup_sandbox(tags) do
     pid = Ecto.Adapters.SQL.Sandbox.start_owner!(ControlKeel.Repo.Local, shared: not tags[:async])
+    # Capture the CloudRepo config as of setup start. on_exit handlers run LIFO
+    # and this case registers before a test's own setup, so this on_exit runs
+    # AFTER the test's. Restoring (rather than unconditionally deleting) preserves
+    # the test's intended state instead of wiping a restore it just performed.
+    prior_cloud_repo_config = Application.get_env(:controlkeel, ControlKeel.CloudRepo)
 
     on_exit(fn ->
       # Check in the connection gracefully before stopping the owner.
@@ -56,11 +61,13 @@ defmodule ControlKeel.DataCase do
       Ecto.Adapters.SQL.Sandbox.checkin(ControlKeel.Repo.Local, sandbox: pid)
       Ecto.Adapters.SQL.Sandbox.stop_owner(pid)
 
-      # Prevent leaked CloudRepo config from routing subsequent tests'
-      # queries to an unstarted Postgres repo. This runs before the test's
-      # own `on_exit` (LIFO), so tests that explicitly save/restore
-      # CloudRepo config will have their original restored properly.
-      Application.delete_env(:controlkeel, ControlKeel.CloudRepo)
+      case prior_cloud_repo_config do
+        nil ->
+          Application.delete_env(:controlkeel, ControlKeel.CloudRepo)
+
+        config ->
+          Application.put_env(:controlkeel, ControlKeel.CloudRepo, config, persistent: true)
+      end
     end)
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,4 +7,4 @@ excludes =
 
 ExUnit.start(max_cases: 1, exclude: excludes)
 ControlKeel.Benchmark.list_suites()
-Ecto.Adapters.SQL.Sandbox.mode(ControlKeel.Repo, :manual)
+Ecto.Adapters.SQL.Sandbox.mode(ControlKeel.Repo.Local, :manual)


### PR DESCRIPTION
Closes #44 — cloud mode silently routed all queries to local SQLite despite having Postgres configured.

Made ControlKeel.Repo a runtime dispatcher facade. Resolves at runtime:
- :local → Repo.Local (SQLite)
- :cloud/:self_hosted → CloudRepo (Postgres)

Zero changes to 63 context-module call sites. Also tightened migrations, runtime config, doctor checks, and test isolation. Full details in commit: 47495b8.