### PR TITLE
🎨 Palette: Add ARIA label to command copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Missing ARIA attributes on standalone icon action buttons
+**Learning:** Icon-only action buttons (like the copy-to-clipboard button in `CommandPill`) often lack `aria-label` attributes and tooltips, which makes them inaccessible to screen readers and difficult for mouse users to understand.
+**Action:** When adding or reviewing component-level action buttons with standalone icons, strictly verify that an appropriate `aria-label` and `title` (or tooltip) property is present so that all users receive adequate context.

--- a/lib/controlkeel_web/components/command_pill.ex
+++ b/lib/controlkeel_web/components/command_pill.ex
@@ -14,6 +14,8 @@ defmodule ControlKeelWeb.CommandPill do
         phx-click="copy_command"
         phx-value-command={@command}
         class="cursor-pointer hover:text-primary transition-colors"
+        aria-label="Copy command"
+        title="Copy command"
       >
         <.icon name="hero-clipboard" class="w-4 h-4" />
       </button>


### PR DESCRIPTION
💡 What: Added `aria-label="Copy command"` and `title="Copy command"` to the copy-to-clipboard button in `CommandPill` component.
🎯 Why: Icon-only buttons are inaccessible to screen readers and difficult for mouse users to understand without context.
♿ Accessibility: Improved screen reader support and added native tooltip for mouse hover.

---
*PR created automatically by Jules for task [16157431774292388102](https://jules.google.com/task/16157431774292388102) started by @aryaminus*