### PR TITLE
🎨 Palette: Add aria-label and focus-visible to CommandPill

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-04 - Icon-only buttons lacking ARIA labels and focus states in utility components
+**Learning:** Utility components like `CommandPill` frequently have icon-only buttons for copy-to-clipboard actions. These often lack `aria-label` attributes for screen readers and visible focus states (`focus-visible:ring-*`) for keyboard users.
+**Action:** Always check icon-only buttons across all small utility/helper components to ensure they have an `aria-label` and `focus-visible` classes with an appropriate `rounded` style to make the focus ring look good.

--- a/lib/controlkeel_web/components/command_pill.ex
+++ b/lib/controlkeel_web/components/command_pill.ex
@@ -13,7 +13,8 @@ defmodule ControlKeelWeb.CommandPill do
         type="button"
         phx-click="copy_command"
         phx-value-command={@command}
-        class="cursor-pointer hover:text-primary transition-colors"
+        aria-label="Copy command"
+        class="cursor-pointer rounded hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary transition-colors"
       >
         <.icon name="hero-clipboard" class="w-4 h-4" />
       </button>


### PR DESCRIPTION
💡 What: Added `aria-label` and `focus-visible` styles to the `CommandPill` component's copy button.
🎯 Why: The copy button was an icon-only button without an accessible label, making it difficult for screen readers to understand. It also lacked a clear focus state for keyboard navigation.
📸 Before/After: N/A (Internal styling change)
♿ Accessibility: Improved keyboard navigation with `focus-visible:ring-2` and screen reader compatibility with `aria-label`.

---
*PR created automatically by Jules for task [15023296671263205520](https://jules.google.com/task/15023296671263205520) started by @aryaminus*