### PR TITLE
⚡ Bolt: Optimize map creation in Utils

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-08-05 - Elixir Map Creation Optimization
+**Learning:** Replaced `Enum.into(..., %{}, fn)` with `Map.new(..., fn)`. `Map.new/2` is generally faster and more idiomatic for creating maps from enumerables in Elixir.
+**Action:** Default to `Map.new/2` when building maps from enumerables with transformations.

--- a/lib/controlkeel/utils.ex
+++ b/lib/controlkeel/utils.ex
@@ -5,7 +5,7 @@ defmodule ControlKeel.Utils do
   Shallow key stringification: converts top-level keys to strings, leaves values untouched.
   """
   def stringify_keys(map) when is_map(map) do
-    Enum.into(map, %{}, fn {key, value} -> {to_string(key), value} end)
+    Map.new(map, fn {key, value} -> {to_string(key), value} end)
   end
 
   @doc """
@@ -13,7 +13,7 @@ defmodule ControlKeel.Utils do
   nested maps and lists. Non-map/non-list values pass through unchanged.
   """
   def stringify_keys_deep(map) when is_map(map) do
-    Enum.into(map, %{}, fn
+    Map.new(map, fn
       {key, value} when is_map(value) -> {to_string(key), stringify_keys_deep(value)}
       {key, value} -> {to_string(key), value}
     end)
@@ -27,7 +27,7 @@ defmodule ControlKeel.Utils do
   through unchanged. Returns `%{}` for non-map inputs.
   """
   def stringify_keys_deep_list(map) when is_map(map) do
-    Enum.into(map, %{}, fn {key, value} ->
+    Map.new(map, fn {key, value} ->
       {to_string(key), stringify_keys_deep_list_value(value)}
     end)
   end


### PR DESCRIPTION
💡 What: Replaced `Enum.into(map, %{}, fn...)` with `Map.new(map, fn...)` in `lib/controlkeel/utils.ex`.
🎯 Why: `Map.new/2` is optimized for creating maps from enumerables and is more performant than the generic `Enum.into/3`.
📊 Impact: Minor speedup on key stringification tasks.
🔬 Measurement: Elixir benchmarking of `Map.new` vs `Enum.into` shows `Map.new` is generally faster.

---
*PR created automatically by Jules for task [1191719563161771042](https://jules.google.com/task/1191719563161771042) started by @aryaminus*