### PR TITLE
🎨 Palette: Add ARIA label and tooltip to copy command button

### DIFF
--- a/lib/controlkeel_web/components/command_pill.ex
+++ b/lib/controlkeel_web/components/command_pill.ex
@@ -13,7 +13,9 @@ defmodule ControlKeelWeb.CommandPill do
         type="button"
         phx-click="copy_command"
         phx-value-command={@command}
-        class="cursor-pointer hover:text-primary transition-colors"
+        class="cursor-pointer hover:text-primary transition-colors rounded-md focus:outline-none focus:ring-1 focus:ring-primary"
+        aria-label="Copy command"
+        title="Copy command"
       >
         <.icon name="hero-clipboard" class="w-4 h-4" />
       </button>


### PR DESCRIPTION
💡 What: Added `aria-label`, `title`, and explicit `focus` classes to the icon-only "Copy command" button in `lib/controlkeel_web/components/command_pill.ex`.
🎯 Why: Icon-only utility buttons lack context for screen readers and can be difficult to discern for sighted users without a tooltip. Additionally, they require a clear focus ring for keyboard navigation.
♿ Accessibility:
- Added `aria-label="Copy command"` for screen readers.
- Added `title="Copy command"` for sighted users hovering with a mouse.
- Added `focus:outline-none focus:ring-1 focus:ring-primary` along with `rounded-md` to provide a clear, visible focus indicator when navigating via keyboard.

---
*PR created automatically by Jules for task [9528139232433465173](https://jules.google.com/task/9528139232433465173) started by @aryaminus*