### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Add ARIA Labels to Icon-Only Buttons
+**Learning:** Icon-only buttons (like copy or close buttons) without ARIA labels are completely unreadable for screen readers, as they just announce them as "button". Adding `aria-label` provides the necessary context and improves accessibility for visually impaired users.
+**Action:** Always verify if a button containing only an icon has an `aria-label`. Consider making `aria-label` mandatory in custom UI button components if they don't have text children.

--- a/lib/controlkeel_web/components/command_pill.ex
+++ b/lib/controlkeel_web/components/command_pill.ex
@@ -14,6 +14,7 @@ defmodule ControlKeelWeb.CommandPill do
         phx-click="copy_command"
         phx-value-command={@command}
         class="cursor-pointer hover:text-primary transition-colors"
+        aria-label="Copy command"
       >
         <.icon name="hero-clipboard" class="w-4 h-4" />
       </button>

--- a/lib/controlkeel_web/live/findings_live.ex
+++ b/lib/controlkeel_web/live/findings_live.ex
@@ -520,6 +520,7 @@ defmodule ControlKeelWeb.FindingsLive do
             type="button"
             class="absolute top-2 right-2 text-muted-foreground hover:text-foreground transition"
             phx-click="close_fix"
+            aria-label="Close"
           >
             <.icon name="hero-x-mark" class="w-5 h-5" />
           </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to icon-only buttons that were missing them (e.g., the copy command pill button and the findings fix close button).

🎯 **Why:** To ensure that these buttons are properly announced by screen readers, improving the overall accessibility of the application.

📸 **Before/After:** No visual changes. This is purely an accessibility improvement.

♿ **Accessibility:** Screen readers will now announce "Copy command" or "Close" instead of just "button" for these controls.

---
*PR created automatically by Jules for task [6748712001887380866](https://jules.google.com/task/6748712001887380866) started by @aryaminus*