### PR TITLE
refactor/web-mission-to-session: rename mission to session across web

### DIFF
--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -82,7 +82,7 @@ defmodule ControlKeelWeb.Layouts do
   defp nav_items do
     [
       {~p"/dashboard", "hero-squares-2x2", "Dashboard"},
-      {~p"/missions", "hero-rocket-launch", "Missions"},
+      {~p"/sessions", "hero-rocket-launch", "Sessions"},
       {~p"/organizations", "hero-building-office-2", "Organizations"},
       {~p"/skills", "hero-puzzle-piece", "Skills"},
       {~p"/proofs", "hero-shield-check", "Proofs"},
@@ -245,7 +245,7 @@ defmodule ControlKeelWeb.Layouts do
       <.dashboard_header
         current_path={@current_path}
         page_action={[
-          %{to: "/dashboard/missions/new", label: "New mission", icon: "hero-plus"}
+          %{to: "/sessions/start", label: "New session", icon: "hero-plus"}
         ]}
       />
   """
@@ -326,7 +326,7 @@ defmodule ControlKeelWeb.Layouts do
 
   @label_map %{
     "dashboard" => "Dashboard",
-    "missions" => "Missions",
+    "sessions" => "Sessions",
     "findings" => "Findings",
     "benchmarks" => "Benchmarks",
     "proofs" => "Proofs",
@@ -342,7 +342,7 @@ defmodule ControlKeelWeb.Layouts do
     "service-accounts" => "Service Accounts",
     "webhooks" => "Webhooks",
     "tool-policy" => "Tool Policy",
-    "start" => "New Mission",
+    "start" => "New Session",
     "runs" => "Runs",
     "telemetry" => "Telemetry",
     "projects" => "Projects"

--- a/lib/controlkeel_web/components/typography.ex
+++ b/lib/controlkeel_web/components/typography.ex
@@ -12,7 +12,7 @@ defmodule ControlKeelWeb.Typography do
   @doc """
   Page title block: an `<h1>` with an optional one-line subtitle.
 
-      <.page_title title="Agent Control Plane" subtitle="Live mission state." />
+      <.page_title title="Agent Control Plane" subtitle="Live session state." />
 
   Pass `class` to adjust the wrapper spacing (e.g. `class="mb-12"`).
   """

--- a/lib/controlkeel_web/controllers/page_html/getting_started.html.heex
+++ b/lib/controlkeel_web/controllers/page_html/getting_started.html.heex
@@ -73,7 +73,7 @@
           4. Run <code class="rounded bg-muted px-1.5 py-0.5 text-foreground">controlkeel attach doctor</code>, <code class="rounded bg-muted px-1.5 py-0.5 text-foreground">controlkeel provider doctor</code>, and <code class="rounded bg-muted px-1.5 py-0.5 text-foreground">controlkeel status</code>.
         </li>
         <li class="text-sm text-muted-foreground">
-          5. Trigger a controlled validation, then open Mission Control or run
+          5. Trigger a controlled validation, then open Session Control or run
           <code class="rounded bg-muted px-1.5 py-0.5 text-foreground">
             controlkeel findings
           </code>
@@ -130,7 +130,7 @@
       <ul class="grid gap-4 m-0 p-0 list-none mt-3">
         <li class="text-sm text-muted-foreground">
           Intent intake and execution briefs at
-          <code class="rounded bg-muted px-1.5 py-0.5 text-foreground">/missions/start</code>
+          <code class="rounded bg-muted px-1.5 py-0.5 text-foreground">/sessions/start</code>
         </li>
         <li class="text-sm text-muted-foreground">
           Task graph, validation, and findings during execution
@@ -147,7 +147,7 @@
       </p>
       <ul class="grid gap-4 m-0 p-0 list-none mt-3">
         <li class="text-sm text-muted-foreground">
-          Mission Control for active task state, risk, and approvals
+          Session Control for active task state, risk, and approvals
         </li>
         <li class="text-sm text-muted-foreground">
           Findings turn policy violations into reviewable work

--- a/lib/controlkeel_web/live/dashboard_live.ex
+++ b/lib/controlkeel_web/live/dashboard_live.ex
@@ -37,7 +37,7 @@ defmodule ControlKeelWeb.DashboardLive do
     <div class="w-full space-y-8">
       <.page_title
         title="Agent Control Plane"
-        subtitle="Live mission state, findings, proof coverage, benchmark signal, and ship readiness in one operator view."
+        subtitle="Live session state, findings, proof coverage, benchmark signal, and ship readiness in one operator view."
       />
 
       <%!-- Key metrics --%>
@@ -111,7 +111,7 @@ defmodule ControlKeelWeb.DashboardLive do
           <p class="mt-2 text-xl font-semibold text-foreground/90">
             {format_number(avg_findings)}
           </p>
-          <p class="mt-4 text-xs text-muted-foreground">Average findings per recent mission</p>
+          <p class="mt-4 text-xs text-muted-foreground">Average findings per recent session</p>
         </article>
       </div>
 
@@ -389,12 +389,12 @@ defmodule ControlKeelWeb.DashboardLive do
         </div>
       </section>
 
-      <%!-- Recent Missions --%>
+      <%!-- Recent Sessions --%>
       <section class="space-y-3">
         <div class="flex items-center justify-between gap-3">
-          <.section_title>Recent Missions</.section_title>
+          <.section_title>Recent Sessions</.section_title>
           <a
-            href={~p"/missions"}
+            href={~p"/sessions"}
             class="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition hover:text-primary"
           >
             View all <.icon name="hero-arrow-up-right" class="size-3" />
@@ -405,7 +405,7 @@ defmodule ControlKeelWeb.DashboardLive do
           <table class="min-w-full divide-y divide-border text-left text-sm">
             <thead class="bg-muted text-xs uppercase tracking-[0.14em] text-muted-foreground">
               <tr>
-                <th class="px-5 py-3 font-semibold">Mission</th>
+                <th class="px-5 py-3 font-semibold">Session</th>
                 <th class="px-5 py-3 font-semibold">Risk</th>
                 <th class="px-5 py-3 font-semibold">Workload</th>
                 <th class="px-5 py-3 font-semibold">Findings</th>
@@ -417,9 +417,9 @@ defmodule ControlKeelWeb.DashboardLive do
               <%= if @recent_sessions == [] do %>
                 <tr>
                   <td colspan="6" class="px-5 py-12 text-center">
-                    <p class="text-base font-medium text-foreground">No missions yet.</p>
+                    <p class="text-base font-medium text-foreground">No sessions yet.</p>
                     <p class="mt-1 text-sm text-muted-foreground">
-                      Start a mission to populate live governance telemetry.
+                      Start a session to populate live governance telemetry.
                     </p>
                   </td>
                 </tr>
@@ -428,7 +428,7 @@ defmodule ControlKeelWeb.DashboardLive do
                   <tr class="transition hover:bg-muted/30">
                     <td class="max-w-sm px-5 py-4">
                       <a
-                        href={~p"/missions/#{session.id}"}
+                        href={~p"/sessions/#{session.id}"}
                         class="font-medium text-foreground transition hover:text-primary"
                       >
                         {session.title}
@@ -475,7 +475,7 @@ defmodule ControlKeelWeb.DashboardLive do
                     </td>
                     <td class="px-5 py-4 text-right">
                       <a
-                        href={~p"/missions/#{session.id}"}
+                        href={~p"/sessions/#{session.id}"}
                         aria-label={"Inspect #{session.title}"}
                         class="inline-flex items-center justify-center rounded-full border p-2 text-muted-foreground transition hover:border-primary/40 hover:bg-primary/10 hover:text-foreground"
                       >
@@ -581,7 +581,7 @@ defmodule ControlKeelWeb.DashboardLive do
   defp always_available_capabilities do
     [
       "Governance and policy validation on agent actions",
-      "Findings, proof bundles, and mission audit trail",
+      "Findings, proof bundles, and session audit trail",
       "MCP tools, skills, and agent attachments",
       "Benchmark runs and policy artifact management"
     ]

--- a/lib/controlkeel_web/live/findings_live.ex
+++ b/lib/controlkeel_web/live/findings_live.ex
@@ -255,14 +255,14 @@ defmodule ControlKeelWeb.FindingsLive do
               </div>
               <div class="space-y-2">
                 <label for="filters-session_id" class="text-xs uppercase tracking-[0.28em]">
-                  Mission
+                  Session
                 </label>
                 <select
                   id="filters-session_id"
                   name="filters[session_id]"
                   class="w-full rounded-md border border-input bg-background px-4 py-3 text-sm text-foreground focus:border-primary focus:ring-2 focus:ring-primary/15 focus:outline-none"
                 >
-                  <option value="">All missions</option>
+                  <option value="">All sessions</option>
                   <%= for {label, id} <- session_filter_options(@session_options) do %>
                     <option
                       value={id}
@@ -299,7 +299,7 @@ defmodule ControlKeelWeb.FindingsLive do
                     Finding
                   </th>
                   <th class="px-8 py-6 text-left text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-                    Mission
+                    Session
                   </th>
                   <th class="px-8 py-6 text-left text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
                     Severity
@@ -335,7 +335,7 @@ defmodule ControlKeelWeb.FindingsLive do
                   </td>
                   <td class="px-8 py-6 align-top">
                     <.link
-                      navigate={~p"/missions/#{finding.session_id}"}
+                      navigate={~p"/sessions/#{finding.session_id}"}
                       class="text-xs font-semibold tracking-[0.14em] text-primary hover:underline"
                     >
                       {finding.session.title}

--- a/lib/controlkeel_web/live/mission_control_live.ex
+++ b/lib/controlkeel_web/live/mission_control_live.ex
@@ -20,7 +20,7 @@ defmodule ControlKeelWeb.MissionControlLive do
       nil ->
         {:ok,
          socket
-         |> put_flash(:error, "Mission not found.")
+         |> put_flash(:error, "Session not found.")
          |> push_navigate(to: ~p"/")}
 
       session when not is_nil(org_id) and not is_nil(session) ->
@@ -39,7 +39,7 @@ defmodule ControlKeelWeb.MissionControlLive do
         else
           {:ok,
            socket
-           |> put_flash(:error, "Mission not found.")
+           |> put_flash(:error, "Session not found.")
            |> push_navigate(to: ~p"/")}
         end
 

--- a/lib/controlkeel_web/live/missions_live.ex
+++ b/lib/controlkeel_web/live/missions_live.ex
@@ -7,10 +7,10 @@ defmodule ControlKeelWeb.MissionsLive do
   def mount(_params, _session, socket) do
     {:ok,
      socket
-     |> assign(:page_title, "Missions")
+|> assign(:page_title, "Sessions")
      |> assign(
        :page_action,
-       %{label: "New Mission", to: ~p"/missions/start", icon: "hero-plus"}
+       %{label: "New Session", to: ~p"/sessions/start", icon: "hero-plus"}
      )
      |> assign(:recent_sessions, Mission.list_all_sessions())}
   end
@@ -23,7 +23,7 @@ defmodule ControlKeelWeb.MissionsLive do
         <table class="min-w-full divide-y divide-border text-left text-sm">
           <thead class="bg-muted text-xs uppercase tracking-[0.14em] text-muted-foreground sticky top-0 z-10">
             <tr>
-              <th class="px-5 py-3 font-semibold">Mission</th>
+              <th class="px-5 py-3 font-semibold">Session</th>
               <th class="px-5 py-3 font-semibold">Risk</th>
               <th class="px-5 py-3 font-semibold">Workload</th>
               <th class="px-5 py-3 font-semibold">Findings</th>
@@ -35,9 +35,9 @@ defmodule ControlKeelWeb.MissionsLive do
             <%= if @recent_sessions == [] do %>
               <tr>
                 <td colspan="6" class="px-5 py-12 text-center">
-                  <p class="text-base font-medium text-foreground">No missions yet.</p>
+                  <p class="text-base font-medium text-foreground">No sessions yet.</p>
                   <p class="mt-1 text-sm text-muted-foreground">
-                    Start a mission to populate live governance telemetry.
+                    Start a session to populate live governance telemetry.
                   </p>
                 </td>
               </tr>
@@ -85,7 +85,7 @@ defmodule ControlKeelWeb.MissionsLive do
                   </td>
                   <td class="px-4 text-right whitespace-nowrap w-px">
                     <.link
-                      navigate={~p"/missions/#{session.id}"}
+                      navigate={~p"/sessions/#{session.id}"}
                       class="inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-xs font-semibold text-muted-foreground transition hover:border-primary/40 hover:bg-primary/10 hover:text-foreground"
                     >
                       Inspect <.icon name="hero-arrow-right" class="size-3" />

--- a/lib/controlkeel_web/live/onboarding_live.ex
+++ b/lib/controlkeel_web/live/onboarding_live.ex
@@ -16,7 +16,7 @@ defmodule ControlKeelWeb.OnboardingLive do
 
     {:ok,
      socket
-     |> assign(:page_title, "Start a mission")
+     |> assign(:page_title, "Start a session")
      |> assign(:project_root, project_root)
      |> assign(:mode, mode)
      |> assign(:cloud_mode, cloud_mode)
@@ -162,7 +162,7 @@ defmodule ControlKeelWeb.OnboardingLive do
       {:ok, session} ->
         {:noreply,
          socket
-         |> push_navigate(to: ~p"/missions/#{session.id}?launched=1")}
+         |> push_navigate(to: ~p"/sessions/#{session.id}?launched=1")}
 
       {:error, :workspace_not_found} ->
         {:noreply,
@@ -176,7 +176,7 @@ defmodule ControlKeelWeb.OnboardingLive do
       {:error, _scope, _changeset} ->
         {:noreply,
          socket
-         |> put_flash(:error, "ControlKeel could not create the mission from this brief.")
+         |> put_flash(:error, "ControlKeel could not create the session from this brief.")
          |> assign(:step, 4)}
     end
   end
@@ -197,7 +197,7 @@ defmodule ControlKeelWeb.OnboardingLive do
           nil ->
             {:noreply,
              socket
-             |> put_flash(:error, "Selected mission not found.")}
+             |> put_flash(:error, "Selected session not found.")}
 
           session ->
             brief = session.execution_brief || %{}
@@ -227,7 +227,7 @@ defmodule ControlKeelWeb.OnboardingLive do
     <section class="max-w-7xl mx-auto px-4 py-6">
       <div class="mb-8">
         <p class="text-xs font-semibold tracking-wider text-primary uppercase font-mono">
-          Mission onboarding
+          Session onboarding
         </p>
       </div>
 
@@ -240,7 +240,7 @@ defmodule ControlKeelWeb.OnboardingLive do
                   Organization and workspace
                 </p>
                 <p class="text-sm text-muted-foreground mt-1">
-                  Choose where this mission's session will be created.
+                  Choose where this session will be created.
                 </p>
               </div>
 
@@ -420,7 +420,7 @@ defmodule ControlKeelWeb.OnboardingLive do
                     <div class="border-t pt-6">
                       <div class="space-y-1.5">
                         <label class="text-xs font-semibold text-muted-foreground uppercase tracking-wider font-mono">
-                          Or continue from an existing mission
+                          Or continue from an existing session
                         </label>
                         <select
                           name="recent_mission_id"
@@ -642,7 +642,7 @@ defmodule ControlKeelWeb.OnboardingLive do
                   type="button"
                   phx-click="accept"
                 >
-                  Create mission
+                  Create session
                 </button>
               </div>
             </div>
@@ -852,7 +852,7 @@ defmodule ControlKeelWeb.OnboardingLive do
   defp onboarding_block_message(%{assigns: assigns}) do
     case workspace_notice(assigns) do
       %{text: text} -> text
-      nil -> "Choose an organization and workspace before starting this mission."
+      nil -> "Choose an organization and workspace before starting this session."
     end
   end
 
@@ -861,7 +861,7 @@ defmodule ControlKeelWeb.OnboardingLive do
       assigns.org_options == [] ->
         %{
           text:
-            "You need to be an admin or owner of at least one organization to start a mission here. Organizations where you are only a member or viewer are not shown for onboarding.",
+            "You need to be an admin or owner of at least one organization to start a session here. Organizations where you are only a member or viewer are not shown for onboarding.",
           link: ~p"/organizations",
           link_text: "View organizations"
         }
@@ -869,13 +869,13 @@ defmodule ControlKeelWeb.OnboardingLive do
       assigns.workspace_options == [] ->
         %{
           text:
-            "This organization has no workspaces yet. Create a workspace before starting a mission.",
+            "This organization has no workspaces yet. Create a workspace before starting a session.",
           link: ~p"/organizations/#{selected_org_slug(assigns)}",
           link_text: "Manage workspaces"
         }
 
       not is_integer(assigns.selected_workspace_id) ->
-        %{text: "Choose a workspace before starting this mission.", link: nil, link_text: nil}
+        %{text: "Choose a workspace before starting this session.", link: nil, link_text: nil}
 
       true ->
         nil
@@ -904,7 +904,7 @@ defmodule ControlKeelWeb.OnboardingLive do
       |> maybe_error(
         "occupation",
         blank?(attrs["occupation"]),
-        "Choose the occupation that best fits this mission."
+        "Choose the occupation that best fits this session."
       )
       |> maybe_error("agent", blank?(attrs["agent"]), "Choose the primary coding agent.")
 
@@ -922,7 +922,7 @@ defmodule ControlKeelWeb.OnboardingLive do
       |> maybe_error(
         "project_name",
         duplicate_project_name?(attrs["project_name"]),
-        "This project name is already used by an existing mission."
+        "This project name is already used by an existing session."
       )
       |> maybe_error(
         "idea",

--- a/lib/controlkeel_web/live/proof_browser_live.ex
+++ b/lib/controlkeel_web/live/proof_browser_live.ex
@@ -109,10 +109,10 @@ defmodule ControlKeelWeb.ProofBrowserLive do
           </div>
 
           <.link
-            navigate={~p"/missions/#{@proof.session_id}"}
+            navigate={~p"/sessions/#{@proof.session_id}"}
             class="text-xs font-semibold uppercase tracking-[0.14em] text-primary border-muted-foreground border rounded-md px-3 py-2 hover:bg-primary/10"
           >
-            Open mission
+            Open session
           </.link>
         </div>
       </div>
@@ -172,7 +172,7 @@ defmodule ControlKeelWeb.ProofBrowserLive do
           </p>
           <div class="grid grid-cols-2 gap-4 max-[900px]:grid-cols-1">
             <div>
-              <h3>Mission</h3>
+              <h3>Session</h3>
               <p class="text-muted-foreground">{@proof.session.title}</p>
             </div>
             <div>
@@ -532,7 +532,7 @@ defmodule ControlKeelWeb.ProofBrowserLive do
           Proof browser
         </h2>
         <p class="text-muted-foreground">
-          Review immutable task evidence, filter by readiness and risk, and jump back to the mission that generated each bundle.
+          Review immutable task evidence, filter by readiness and risk, and jump back to the session that generated each bundle.
         </p>
       </div>
 
@@ -551,7 +551,7 @@ defmodule ControlKeelWeb.ProofBrowserLive do
                 name="filters[q]"
                 type="text"
                 value={@form[:q].value}
-                placeholder="Mission or task..."
+                placeholder="Session or task..."
                 phx-debounce="300"
                 class="w-full rounded-md border border-input bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/15 focus:outline-none"
               />
@@ -562,14 +562,14 @@ defmodule ControlKeelWeb.ProofBrowserLive do
                 for="filters-session_id"
                 class="text-xs uppercase tracking-[0.28em]"
               >
-                Mission
+                Session
               </label>
               <select
                 id="filters-session_id"
                 name="filters[session_id]"
                 class="w-full rounded-md border border-input bg-background px-4 py-3 text-sm text-foreground focus:border-primary focus:ring-2 focus:ring-primary/15 focus:outline-none"
               >
-                <option value="">All missions</option>
+                <option value="">All sessions</option>
                 <%= for session_option <- @session_options do %>
                   <option
                     value={session_option.id}
@@ -794,10 +794,10 @@ defmodule ControlKeelWeb.ProofBrowserLive do
                     <td class="px-2 py-6 text-right align-top">
                       <div class="flex justify-end gap-2 font-semibold text-sm">
                         <.link
-                          navigate={~p"/missions/#{proof.session_id}"}
+                          navigate={~p"/sessions/#{proof.session_id}"}
                           class="text-muted-foreground transition hover:text-foreground border px-2 py-1 rounded-md"
                         >
-                          Mission
+                          Session
                         </.link>
 
                         <.link

--- a/lib/controlkeel_web/live/review_live.ex
+++ b/lib/controlkeel_web/live/review_live.ex
@@ -88,9 +88,9 @@ defmodule ControlKeelWeb.ReviewLive do
           </div>
           <a
             class="uppercase tracking-[0.14em] text-xs text-primary font-semibold"
-            href={~p"/missions/#{@review.session_id}"}
+            href={~p"/sessions/#{@review.session_id}"}
           >
-            Open mission
+            Open session
           </a>
         </div>
 

--- a/lib/controlkeel_web/live/workspace_detail_live.ex
+++ b/lib/controlkeel_web/live/workspace_detail_live.ex
@@ -119,7 +119,7 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
           <.section_title>Sessions</.section_title>
 
           <.link
-            navigate={~p"/missions/start"}
+            navigate={~p"/sessions/start"}
             class="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
           >
             <.icon name="hero-plus" class="size-4" /> New Session
@@ -189,7 +189,7 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
                     </td>
                     <td class="px-4 text-right whitespace-nowrap w-px">
                       <.link
-                        navigate={~p"/missions/#{session.id}"}
+                        navigate={~p"/sessions/#{session.id}"}
                         class="inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-xs font-semibold text-muted-foreground transition hover:border-primary/40 hover:bg-primary/10 hover:text-foreground"
                       >
                         Inspect <.icon name="hero-arrow-right" class="size-3" />

--- a/lib/controlkeel_web/live/workspace_repos_live.ex
+++ b/lib/controlkeel_web/live/workspace_repos_live.ex
@@ -101,7 +101,7 @@ defmodule ControlKeelWeb.WorkspaceReposLive do
           </p>
           <h1 class="text-[clamp(2rem,4vw,3.4rem)] leading-[1.02]">GitHub repositories</h1>
           <p class="text-muted-foreground text-[1.05rem] leading-[1.7] max-w-[48rem]">
-            Bind GitHub repos so missions, findings, and proofs can reference them.
+            Bind GitHub repos so sessions, findings, and proofs can reference them.
             For governance via the GitHub App, set <code>installation_id</code>.
           </p>
         </div>

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -80,9 +80,9 @@ defmodule ControlKeelWeb.Router do
         ControlKeelWeb.LayoutDefaults
       ] do
       live "/dashboard", DashboardLive, :index
-      live "/missions", MissionsLive, :index
-      live "/missions/start", OnboardingLive, :new
-      live "/missions/:id", MissionControlLive, :show
+      live "/sessions", MissionsLive, :index
+      live "/sessions/start", OnboardingLive, :new
+      live "/sessions/:id", MissionControlLive, :show
       live "/findings", FindingsLive, :index
       live "/benchmarks", BenchmarksLive, :index
       live "/benchmarks/runs/:id", BenchmarksLive, :show

--- a/test/controlkeel_web/live/dashboard_live_test.exs
+++ b/test/controlkeel_web/live/dashboard_live_test.exs
@@ -11,7 +11,7 @@ defmodule ControlKeelWeb.DashboardLiveTest do
     assert html =~ "Proof Coverage"
     assert html =~ "Deploy Ready Rate"
     assert html =~ "Delivery Funnel"
-    assert html =~ "Recent Missions"
+    assert html =~ "Recent Sessions"
     assert html =~ "Provider and Autonomy"
     assert html =~ "Provider and bootstrap status"
     assert html =~ "ACP registry cache"

--- a/test/controlkeel_web/live/findings_live_test.exs
+++ b/test/controlkeel_web/live/findings_live_test.exs
@@ -42,7 +42,7 @@ defmodule ControlKeelWeb.FindingsLiveTest do
     assert html =~ "Findings browser"
     assert html =~ "Alpha SQL finding"
     refute html =~ "Bravo XSS finding"
-    assert has_element?(view, "a[href=\"/missions/#{alpha.id}\"]", alpha.title)
+    assert has_element?(view, "a[href=\"/sessions/#{alpha.id}\"]", alpha.title)
 
     patched =
       render_change(

--- a/test/controlkeel_web/live/mission_control_live_test.exs
+++ b/test/controlkeel_web/live/mission_control_live_test.exs
@@ -41,7 +41,7 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
         title: "Release verify"
       })
 
-    {:ok, _view, html} = live(conn, ~p"/missions/#{session.id}")
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}")
 
     assert html =~ "Task dependencies"
     assert html =~ "Architecture lock"
@@ -70,7 +70,7 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
                }
              })
 
-    {:ok, _view, html} = live(conn, ~p"/missions/#{session.id}")
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}")
 
     assert html =~ "Inversion:"
     assert html =~ "Evidence check:"
@@ -89,7 +89,7 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
                "session_id" => session.id
              })
 
-    {:ok, _view, html} = live(conn, ~p"/missions/#{session.id}")
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}")
 
     assert html =~ "Build the first governed workflow"
     assert html =~ "Sql injection"
@@ -117,7 +117,7 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
 
     task_fixture(%{session: session})
 
-    {:ok, _view, html} = live(conn, ~p"/missions/#{session.id}")
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}")
 
     assert html =~ "Production boundary"
     assert html =~ "Local-first deploy"
@@ -136,7 +136,7 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
       status: "open"
     })
 
-    {:ok, _view, html} = live(conn, ~p"/missions/#{session.id}")
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}")
 
     assert html =~ "mission-observability-panel"
     assert html =~ "Session run observability"
@@ -150,7 +150,7 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
     session = session_fixture(%{spent_cents: 600, budget_cents: 5_000})
     task_fixture(%{session: session})
 
-    {:ok, view, html} = live(conn, ~p"/missions/#{session.id}")
+    {:ok, view, html} = live(conn, ~p"/sessions/#{session.id}")
     assert html =~ "6.0 / 50.0"
 
     assert {:ok, _} =
@@ -197,7 +197,7 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
         metadata: %{"path" => "assets/js/app.js", "matched_text_redacted" => "inner...HTML"}
       })
 
-    {:ok, view, _html} = live(conn, ~p"/missions/#{session.id}")
+    {:ok, view, _html} = live(conn, ~p"/sessions/#{session.id}")
 
     detail_html =
       render_click(
@@ -218,7 +218,7 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
     session = session_fixture()
     task = task_fixture(%{session: session, status: "in_progress"})
 
-    {:ok, view, html} = live(conn, ~p"/missions/#{session.id}")
+    {:ok, view, html} = live(conn, ~p"/sessions/#{session.id}")
 
     assert html =~ "Workspace context"
     assert html =~ "Recent transcript"
@@ -255,7 +255,7 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
         title: "Done task"
       })
 
-    {:ok, _view, html} = live(conn, ~p"/missions/#{session.id}")
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}")
 
     assert html =~ "Verified task"
     assert html =~ "verified"
@@ -270,7 +270,7 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
     finding_fixture(%{session: session, status: "blocked", title: "Blocked ship finding"})
     {:ok, _proof} = Mission.generate_proof_bundle(task.id)
 
-    {:ok, _view, html} = live(conn, ~p"/missions/#{session.id}")
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}")
 
     assert html =~ "Ship readiness"
     # Blocked finding forces a Blocked verdict.

--- a/test/controlkeel_web/live/missions_live_test.exs
+++ b/test/controlkeel_web/live/missions_live_test.exs
@@ -11,7 +11,7 @@ defmodule ControlKeelWeb.MissionsLiveTest do
       session_fixture(%{workspace: workspace, title: "Session #{n}"})
     end
 
-    {:ok, _view, html} = live(conn, ~p"/missions")
+    {:ok, _view, html} = live(conn, ~p"/sessions")
 
     assert html =~ "Session 7"
     assert html =~ "Session 1"

--- a/test/controlkeel_web/live/observability_live_test.exs
+++ b/test/controlkeel_web/live/observability_live_test.exs
@@ -80,7 +80,7 @@ defmodule ControlKeelWeb.ObservabilityLiveTest do
     session = session_fixture()
     task_fixture(%{session: session})
 
-    {:ok, _view, html} = live(conn, ~p"/missions/#{session.id}")
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}")
 
     assert html =~ "mission-observability-open"
     assert html =~ "Open run observability"

--- a/test/controlkeel_web/live/onboarding_live_test.exs
+++ b/test/controlkeel_web/live/onboarding_live_test.exs
@@ -13,7 +13,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
     # assert against the delta, not an absolute empty list.
     initial_session_count = length(Mission.list_sessions())
 
-    {:ok, view, html} = live(conn, ~p"/missions/start")
+    {:ok, view, html} = live(conn, ~p"/sessions/start")
 
     assert html =~ "Choose the domain and primary agent"
     assert html =~ "Founder / Product Builder"
@@ -62,7 +62,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
     render_click(element(view, "button[phx-click=\"accept\"]"))
     {path, _flash} = assert_redirect(view)
 
-    assert path =~ "/missions/"
+    assert path =~ "/sessions/"
 
     redirected_html =
       conn
@@ -78,7 +78,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
   test "onboarding UI prevents duplicate project names", %{conn: conn} do
     _session = session_fixture(%{title: "Existing Project"})
 
-    {:ok, view, _html} = live(conn, ~p"/missions/start")
+    {:ok, view, _html} = live(conn, ~p"/sessions/start")
 
     render_submit(form(view, "form", launch: %{"occupation" => "founder", "agent" => "claude"}))
 
@@ -92,7 +92,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
         )
       )
 
-    assert error_html =~ "This project name is already used by an existing mission."
+    assert error_html =~ "This project name is already used by an existing session."
   end
 
   test "validation errors render and provider keys are not exposed in the browser", %{conn: conn} do
@@ -116,7 +116,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
       }
     )
 
-    {:ok, view, html} = live(conn, ~p"/missions/start")
+    {:ok, view, html} = live(conn, ~p"/sessions/start")
     refute html =~ "sk-secret-test"
 
     render_submit(form(view, "form", launch: %{"occupation" => "founder", "agent" => "claude"}))
@@ -133,7 +133,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
   test "review step explains heuristic mode and provider status without leaking secrets", %{
     conn: conn
   } do
-    {:ok, view, _html} = live(conn, ~p"/missions/start")
+    {:ok, view, _html} = live(conn, ~p"/sessions/start")
 
     render_submit(form(view, "form", launch: %{"occupation" => "founder", "agent" => "claude"}))
 
@@ -170,7 +170,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
   end
 
   test "expanded domain occupations render and advance through onboarding", %{conn: conn} do
-    {:ok, view, _html} = live(conn, ~p"/missions/start")
+    {:ok, view, _html} = live(conn, ~p"/sessions/start")
 
     assert has_element?(view, "option[value=\"hr\"]")
     assert has_element?(view, "option[value=\"legal\"]")
@@ -194,7 +194,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
   end
 
   test "onboarding creates the session in the default workspace", %{conn: conn} do
-    {:ok, view, _html} = live(conn, ~p"/missions/start")
+    {:ok, view, _html} = live(conn, ~p"/sessions/start")
 
     assert render_submit(
              form(view, "form", launch: %{"occupation" => "founder", "agent" => "claude"})
@@ -225,11 +225,11 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
 
     render_click(element(view, "button[phx-click=\"accept\"]"))
     {path, _flash} = assert_redirect(view)
-    assert path =~ "/missions/"
+    assert path =~ "/sessions/"
 
     session_id =
       path
-      |> String.split("/missions/")
+      |> String.split("/sessions/")
       |> List.last()
       |> String.split("?")
       |> List.first()
@@ -238,7 +238,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
     assert session.workspace.slug == "default-workspace"
   end
 
-  test "user can continue from an existing mission in onboarding", %{conn: conn} do
+  test "user can continue from an existing session in onboarding", %{conn: conn} do
     session =
       session_fixture(%{
         title: "Saved Project",
@@ -254,12 +254,12 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
         }
       })
 
-    {:ok, view, _html} = live(conn, ~p"/missions/start")
+    {:ok, view, _html} = live(conn, ~p"/sessions/start")
 
     # Step 1
     render_submit(form(view, "form", launch: %{"occupation" => "founder", "agent" => "claude"}))
 
-    # Step 2: Select the existing mission from dropdown
+    # Step 2: Select the existing session from dropdown
     render_change(view, :select_mission, %{recent_mission_id: to_string(session.id)})
 
     # Verify project name is populated
@@ -267,7 +267,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
     assert render(view) =~ "Original project objective"
   end
 
-  describe "cloud mode /missions/start" do
+  describe "cloud mode /sessions/start" do
     setup do
       original = Application.get_env(:controlkeel, :runtime_mode)
       Application.put_env(:controlkeel, :runtime_mode, :cloud)
@@ -294,7 +294,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
     test "blocks onboarding when the user has no organizations", %{} do
       user = user_fixture()
 
-      {:ok, view, html} = live(cloud_conn(user, nil), ~p"/missions/start")
+      {:ok, view, html} = live(cloud_conn(user, nil), ~p"/sessions/start")
 
       assert html =~ "Organization and workspace"
       assert html =~ "admin or owner of at least one organization"
@@ -327,7 +327,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
         })
         |> ControlKeel.Repo.insert()
 
-      {:ok, view, html} = live(cloud_conn(member, org.id), ~p"/missions/start")
+      {:ok, view, html} = live(cloud_conn(member, org.id), ~p"/sessions/start")
 
       assert html =~ "Organization and workspace"
       assert html =~ "admin or owner of at least one organization"
@@ -352,7 +352,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
       user = user_fixture()
       {:ok, org} = Accounts.create_org_with_owner(user.id, %{name: "No WS", slug: "no-ws"})
 
-      {:ok, view, html} = live(cloud_conn(user, org.id), ~p"/missions/start")
+      {:ok, view, html} = live(cloud_conn(user, org.id), ~p"/sessions/start")
 
       assert html =~ "Organization and workspace"
       assert html =~ "has no workspaces yet"
@@ -372,7 +372,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
       {:ok, org} = Accounts.create_org_with_owner(user.id, %{name: "Acme", slug: "acme"})
       ws = workspace_fixture(%{org_id: org.id, name: "Backend", slug: "backend"})
 
-      {:ok, view, html} = live(cloud_conn(user, org.id), ~p"/missions/start")
+      {:ok, view, html} = live(cloud_conn(user, org.id), ~p"/sessions/start")
 
       assert html =~ "Organization and workspace"
       assert has_element?(view, "#onboarding-org-select option[value=\"#{org.id}\"]")
@@ -406,11 +406,11 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
 
       render_click(element(view, "button[phx-click=\"accept\"]"))
       {path, _flash} = assert_redirect(view)
-      assert path =~ "/missions/"
+      assert path =~ "/sessions/"
 
       session_id =
         path
-        |> String.split("/missions/")
+        |> String.split("/sessions/")
         |> List.last()
         |> String.split("?")
         |> List.first()
@@ -427,7 +427,7 @@ defmodule ControlKeelWeb.OnboardingLiveTest do
       ws_a = workspace_fixture(%{org_id: org_a.id, name: "Alpha WS", slug: "alpha-ws"})
       ws_b = workspace_fixture(%{org_id: org_b.id, name: "Beta WS", slug: "beta-ws"})
 
-      {:ok, view, _html} = live(cloud_conn(user, org_a.id), ~p"/missions/start")
+      {:ok, view, _html} = live(cloud_conn(user, org_a.id), ~p"/sessions/start")
 
       assert has_element?(view, "#onboarding-workspace-select option[value=\"#{ws_a.id}\"]")
       refute has_element?(view, "#onboarding-workspace-select option[value=\"#{ws_b.id}\"]")

--- a/test/controlkeel_web/live/workspace_detail_live_test.exs
+++ b/test/controlkeel_web/live/workspace_detail_live_test.exs
@@ -61,7 +61,7 @@ defmodule ControlKeelWeb.WorkspaceDetailLiveTest do
       assert html =~ "Slug"
       assert html =~ "Sessions"
       assert html =~ "Monthly budget"
-      # Session rows render in the missions-style table.
+      # Session rows render in the sessions-style table.
       assert html =~ "First session"
       assert html =~ "Second session"
       assert html =~ "$100"


### PR DESCRIPTION
## Summary

Full-text terminology sweep replacing **mission → session** on the **user-facing surface**: web routes, navigation, and rendered UI strings. The run surface already uses `session`; the module/schema/UI layer still said `mission`. This PR fixes the visible drift — what a user reads and navigates.

This is **Part 1** of the two-part split in #64 . It is purely cosmetic and non-breaking.

## What changed

### Routes (`lib/controlkeel_web/router.ex`)

| Before                                            | After                                             |
| ------------------------------------------------- | ------------------------------------------------- |
| `live "/missions", MissionsLive, :index`          | `live "/sessions", MissionsLive, :index`          |
| `live "/missions/start", OnboardingLive, :new`    | `live "/sessions/start", OnboardingLive, :new`    |
| `live "/missions/:id", MissionControlLive, :show` | `live "/sessions/:id", MissionControlLive, :show` |

> Nominality note: old `/missions/*` **redirects are intentionally deferred** to avoid scope creep in this cosmetic step. Decide before/at merge whether old bookmarks need a redirect (plan says redirect or note as deprecated).

### Links & navigation pointing at the routes

Updated every `href` / `navigate` / `push_navigate` / breadcrumb / nav-item target from `/missions...` to `/sessions...` across the LiveViews and layouts.

### User-facing strings

All visible "mission"/"missions" → "session"/"sessions" in page titles, headings, table columns, empty states, stats, flash errors, form labels, buttons, placeholders, sidebar nav, and breadcrumbs (see `layouts.ex`, `typography.ex`, and the getting-started doc).

### Tests

Route and rendered-string assertions updated to match the new paths and copy. **No behavior changed.**

## Scope / intentionally out of scope (→ Part 2, next PR)

This PR deliberately does **not** touch:

- **Module tree**: `ControlKeel.Mission` → `ControlKeel.Session`, `lib/controlkeel/mission.ex` → `session.ex`, the `mission/` directory, `Mission*` aliases (207 refs) and fully-qualified refs (253).
- **Collision resolution (the indivisible risk)**: `ControlKeel.Mission.Session` → `ControlKeel.Session`, and dedup `SessionDigest`/`SessionEvent`/`SessionTranscript` into `Digest`/`Event`/`Transcript`.
- **DB**: `missions` table → `sessions`, `mission_id` → `session_id`, `mission_workspace_id` → `session_workspace_id` (additive migration; applied migrations stay locked).
- **Atoms/structs**: `:mission` → `:session` keys and field names.
- **Code identifiers still referencing "mission"**: `MissionsLive`/`MissionControlLive` module names, `Mission.` alias calls, `mission-*` DOM ids, `select_mission` event, `mission_id`/`mission_workspace_id` fields.
- **CLI help strings** (`lib/controlkeel/cli/help.ex`, 9 occurrences) and `dispatch/*` error strings.
- **Docs** beyond the getting-started UI copy touched here.

Part 2 requires the module rename, an additive migration, atom/struct sweep, and a full `lib/`+`test/`+`config/`+`priv/` grep gate. The collision handling in Part 2 is the reason the sweep is split.

## Verification

- `mix compile` — green (only pre-existing `cli.ex` soft warning).
- `mix test` — **2151 passed** (1 performance-tagged excluded).
- Grep gate scoped to `lib/controlkeel_web/**`: zero visible `mission` (case-insensitive) — only module names, aliases, DB fields, DOM ids, and event names remain (all Part-2 scope).

Close this as **Part 1 complete**; the follow-up should be the module/schema/atom sweep.
