### PR TITLE
🎨 Palette: Add accessibility attributes to copy command button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-08 - Icon-Only Buttons Missing Accessibility Attributes
+**Learning:** Found an icon-only "copy" button lacking `aria-label`, `title`, and keyboard focus styling, which is an accessibility issue for screen readers and keyboard navigation.
+**Action:** Applied standard `aria-label`, `title`, and `focus-visible` styling ring. Will look for similar icon-only buttons across the application.

--- a/lib/controlkeel_web/components/command_pill.ex
+++ b/lib/controlkeel_web/components/command_pill.ex
@@ -13,7 +13,9 @@ defmodule ControlKeelWeb.CommandPill do
         type="button"
         phx-click="copy_command"
         phx-value-command={@command}
-        class="cursor-pointer hover:text-primary transition-colors"
+        class="cursor-pointer hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
+        aria-label="Copy command"
+        title="Copy command"
       >
         <.icon name="hero-clipboard" class="w-4 h-4" />
       </button>


### PR DESCRIPTION
💡 **What:** Added `aria-label`, `title`, and keyboard focus styling (`focus-visible` classes) to the icon-only "copy" button in the `CommandPill` component.
🎯 **Why:** Icon-only buttons lacking accessible labels provide zero context to screen reader users, and without a visible focus ring, keyboard users cannot determine when the button is active.
📸 **Before/After:**
- Before: `<button class="..."> <.icon /> </button>`
- After: `<button aria-label="Copy command" title="Copy command" class="... focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"> <.icon /> </button>`
♿ **Accessibility:**
- Added standard `aria-label` for assistive technologies.
- Added `title` for visual tooltip support on hover.
- Added keyboard-visible focus state using native Tailwind `focus-visible` ring.

---
*PR created automatically by Jules for task [1220219768083483146](https://jules.google.com/task/1220219768083483146) started by @aryaminus*