### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-08-08 - Enum.map |> Enum.uniq() |> length() replaced by Enum.uniq_by |> length()
+**Learning:** Found an inefficiency in calculating lengths of unique elements from mapped structs/maps. The idiom `Enum.map(& &1.field) |> Enum.uniq() |> length()` forces the creation of an intermediate list before deduplication and counting.
+**Action:** Use `Enum.uniq_by` to do this without the intermediate map step: `Enum.uniq_by(& &1.field) |> length()`.

--- a/lib/controlkeel/cloud/baseline_analyzer.ex
+++ b/lib/controlkeel/cloud/baseline_analyzer.ex
@@ -94,7 +94,7 @@ defmodule ControlKeel.Cloud.BaselineAnalyzer do
       )
       |> Repo.all()
 
-    sample_sessions = rows |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+    sample_sessions = rows |> Enum.uniq_by(& &1.session_id) |> length()
 
     baseline =
       rows

--- a/lib/controlkeel/governance.ex
+++ b/lib/controlkeel/governance.ex
@@ -559,7 +559,7 @@ defmodule ControlKeel.Governance do
   end
 
   defp review_summary(decision, findings, fragments) do
-    files_reviewed = fragments |> Enum.map(& &1.path) |> Enum.uniq() |> length()
+    files_reviewed = fragments |> Enum.uniq_by(& &1.path) |> length()
     chunks_reviewed = length(fragments)
     added_lines_reviewed = Enum.reduce(fragments, 0, &(&1.added_line_count + &2))
 

--- a/lib/controlkeel/mcp/tool_group_tracker.ex
+++ b/lib/controlkeel/mcp/tool_group_tracker.ex
@@ -163,7 +163,7 @@ defmodule ControlKeel.MCP.ToolGroupTracker do
       total_calls = entries |> Enum.map(fn {_key, _ts, count} -> count end) |> Enum.sum()
 
       unique_tools =
-        entries |> Enum.map(fn {key, _ts, _count} -> key end) |> Enum.uniq() |> length()
+        entries |> Enum.uniq_by(fn {key, _ts, _count} -> key end) |> length()
 
       %{total_calls: total_calls, unique_tools: unique_tools}
     end

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -1698,7 +1698,7 @@ defmodule ControlKeel.Observability do
       input_tokens: sum_invocation_field(invocations, :input_tokens),
       cached_input_tokens: sum_invocation_field(invocations, :cached_input_tokens),
       output_tokens: sum_invocation_field(invocations, :output_tokens),
-      sessions: invocations |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+      sessions: invocations |> Enum.uniq_by(& &1.session_id) |> length()
     }
   end
 
@@ -1713,7 +1713,7 @@ defmodule ControlKeel.Observability do
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
         output_tokens: sum_invocation_field(group, :output_tokens),
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+        sessions: group |> Enum.uniq_by(& &1.session_id) |> length()
       }
     end)
     |> Enum.sort_by(&{&1.estimated_cost_cents, &1.invocations}, :desc)
@@ -1730,7 +1730,7 @@ defmodule ControlKeel.Observability do
       %{
         name: name,
         invocations: invocation_count,
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length(),
+        sessions: group |> Enum.uniq_by(& &1.session_id) |> length(),
         estimated_cost_cents: total_cost,
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
@@ -2194,7 +2194,7 @@ defmodule ControlKeel.Observability do
       suite: benchmark_run_suite_slug(run),
       subjects: run.subjects || [],
       total_scenarios: run.total_scenarios,
-      observed_scenarios: run.results |> Enum.map(& &1.scenario_id) |> Enum.uniq() |> length(),
+      observed_scenarios: run.results |> Enum.uniq_by(& &1.scenario_id) |> length(),
       caught_count: run.caught_count,
       blocked_count: run.blocked_count,
       catch_rate: run.catch_rate || 0.0,


### PR DESCRIPTION
💡 **What:** 
Replaced occurrences of the pattern `Enum.map(& &1.field) |> Enum.uniq() |> length()` with `Enum.uniq_by(& &1.field) |> length()` across backend modules (BaselineAnalyzer, Governance, ToolGroupTracker, and Observability). Also recorded this finding in `.jules/bolt.md`.

🎯 **Why:** 
The original pattern creates an intermediate list containing mapped elements, then deduplicates that list before counting. The updated logic delegates the extraction of the unique identity to `Enum.uniq_by/2`, sidestepping the intermediate mapping operation.

📊 **Impact:** 
Avoids unnecessary O(n) memory allocation overhead for intermediary lists on relatively hot paths containing analytics and governance routines. Reduces memory churn.

🔬 **Measurement:** 
Review backend memory allocations for the associated jobs/controllers; code remains functionally identical but avoids allocating the intermediary list.

---
*PR created automatically by Jules for task [11713799393355614966](https://jules.google.com/task/11713799393355614966) started by @aryaminus*