### PR TITLE
🎨 Palette: Add accessible labels and focus states to command pill and flash

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-09 - Accessible Icon Buttons
+**Learning:** Icon-only buttons (like command copy or flash close) frequently lack `aria-label` attributes and explicit focus visible states (`focus-visible:ring-2`) in this repository.
+**Action:** Always ensure icon-only buttons have an `aria-label` and `focus-visible` styles (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded`) applied when creating or modifying them.

--- a/lib/controlkeel_web/components/command_pill.ex
+++ b/lib/controlkeel_web/components/command_pill.ex
@@ -13,7 +13,9 @@ defmodule ControlKeelWeb.CommandPill do
         type="button"
         phx-click="copy_command"
         phx-value-command={@command}
-        class="cursor-pointer hover:text-primary transition-colors"
+        class="cursor-pointer hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
+        aria-label="Copy command"
+        title="Copy command"
       >
         <.icon name="hero-clipboard" class="w-4 h-4" />
       </button>

--- a/lib/controlkeel_web/components/core_components.ex
+++ b/lib/controlkeel_web/components/core_components.ex
@@ -67,7 +67,7 @@ defmodule ControlKeelWeb.CoreComponents do
           <p>{msg}</p>
         </div>
         <div class="flex-1" />
-        <button type="button" class="group self-start cursor-pointer" aria-label={gettext("close")}>
+        <button type="button" class="group self-start cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded" aria-label={gettext("close")}>
           <.icon name="hero-x-mark" class="size-5 opacity-40 group-hover:opacity-70" />
         </button>
       </div>


### PR DESCRIPTION
💡 What: Added aria labels and clear focus states (using Tailwind `focus-visible`) to icon-only buttons like the command pill copy button and the flash close button.
🎯 Why: Without these attributes, screen reader users do not know what the icon-only buttons do. Sighted keyboard users could not easily see which button was currently focused.
📸 Before/After: Visual focus rings will now appear around these buttons when they receive keyboard focus. A native tooltip will now appear when hovering over the copy button.
♿ Accessibility:
  - Added `aria-label="Copy command"` and `title="Copy command"` to the `CommandPill` copy button.
  - Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded` to ensure strong keyboard focus visibility for both the `CommandPill` copy button and the `CoreComponents` flash close button.

---
*PR created automatically by Jules for task [13378001590201852820](https://jules.google.com/task/13378001590201852820) started by @aryaminus*