### PR TITLE
🎨 Palette: [UX improvement] Add focus states and labels to icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing Focus States and Labels on Icon-Only Buttons
+**Learning:** Icon-only interactive elements, such as the copy button in `CommandPill` and the close button in flash messages (`core_components.ex`), are commonly missing structural focus states and labels which degrades keyboard accessibility. Without default outline/ring focus states, keyboard users are unaware when these elements receive focus, and without an ARIA label, screen readers will announce an empty button.
+**Action:** When implementing new custom interactive elements or icon-only buttons, always apply explicit keyboard focus styles (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded`) and an appropriate `aria-label`.

--- a/lib/controlkeel_web/components/command_pill.ex
+++ b/lib/controlkeel_web/components/command_pill.ex
@@ -13,7 +13,8 @@ defmodule ControlKeelWeb.CommandPill do
         type="button"
         phx-click="copy_command"
         phx-value-command={@command}
-        class="cursor-pointer hover:text-primary transition-colors"
+        class="cursor-pointer hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
+        aria-label="Copy command"
       >
         <.icon name="hero-clipboard" class="w-4 h-4" />
       </button>

--- a/lib/controlkeel_web/components/core_components.ex
+++ b/lib/controlkeel_web/components/core_components.ex
@@ -67,7 +67,7 @@ defmodule ControlKeelWeb.CoreComponents do
           <p>{msg}</p>
         </div>
         <div class="flex-1" />
-        <button type="button" class="group self-start cursor-pointer" aria-label={gettext("close")}>
+        <button type="button" class="group self-start cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded" aria-label={gettext("close")}>
           <.icon name="hero-x-mark" class="size-5 opacity-40 group-hover:opacity-70" />
         </button>
       </div>


### PR DESCRIPTION
💡 **What**: Added `aria-label` to the copy command button in `CommandPill` and applied visible focus states (`focus-visible:ring-2`) to both the copy button and the flash message close button.
🎯 **Why**: Icon-only buttons often lack visual focus indicators and accessible names, which breaks keyboard navigation and screen reader support.
📸 **Before/After**: 
- Before: Copy button had no accessible name; close button and copy button showed no visual change when focused via keyboard.
- After: Screen readers announce "Copy command", and keyboard navigation highlights the buttons with a primary color ring.
♿ **Accessibility**: Enhanced keyboard navigation and screen reader clarity.

---
*PR created automatically by Jules for task [902978530916076320](https://jules.google.com/task/902978530916076320) started by @aryaminus*