### PR TITLE
⚡ Bolt: [performance improvement] Optimize intermediate list allocations

### DIFF
--- a/lib/controlkeel/cloud/baseline_analyzer.ex
+++ b/lib/controlkeel/cloud/baseline_analyzer.ex
@@ -94,7 +94,8 @@ defmodule ControlKeel.Cloud.BaselineAnalyzer do
       )
       |> Repo.all()
 
-    sample_sessions = rows |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+    # Performance: MapSet avoids intermediate list allocations
+    sample_sessions = rows |> MapSet.new(& &1.session_id) |> MapSet.size()
 
     baseline =
       rows

--- a/lib/controlkeel/governance.ex
+++ b/lib/controlkeel/governance.ex
@@ -555,7 +555,8 @@ defmodule ControlKeel.Governance do
   end
 
   defp review_summary(decision, findings, fragments) do
-    files_reviewed = fragments |> Enum.map(& &1.path) |> Enum.uniq() |> length()
+    # Performance: MapSet avoids intermediate list allocations
+    files_reviewed = fragments |> MapSet.new(& &1.path) |> MapSet.size()
     chunks_reviewed = length(fragments)
     added_lines_reviewed = Enum.reduce(fragments, 0, &(&1.added_line_count + &2))
 

--- a/lib/controlkeel/mcp/tool_group_tracker.ex
+++ b/lib/controlkeel/mcp/tool_group_tracker.ex
@@ -163,7 +163,8 @@ defmodule ControlKeel.MCP.ToolGroupTracker do
       total_calls = entries |> Enum.map(fn {_key, _ts, count} -> count end) |> Enum.sum()
 
       unique_tools =
-        entries |> Enum.map(fn {key, _ts, _count} -> key end) |> Enum.uniq() |> length()
+        # Performance: MapSet avoids intermediate list allocations
+        entries |> MapSet.new(fn {key, _ts, _count} -> key end) |> MapSet.size()
 
       %{total_calls: total_calls, unique_tools: unique_tools}
     end

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -524,7 +524,8 @@ defmodule ControlKeel.Observability do
       benchmark_drafts: drafts.count,
       approved_drafts: approved_drafts,
       materialized_scenarios: length(scenario_ids),
-      covered_scenarios: length(Enum.filter(scenario_ids, &(&1 in covered_ids))),
+      # Performance: Enum.count avoids intermediate list allocation
+      covered_scenarios: Enum.count(scenario_ids, &(&1 in covered_ids)),
       benchmark_runs: length(runs)
     }
 
@@ -1698,7 +1699,8 @@ defmodule ControlKeel.Observability do
       input_tokens: sum_invocation_field(invocations, :input_tokens),
       cached_input_tokens: sum_invocation_field(invocations, :cached_input_tokens),
       output_tokens: sum_invocation_field(invocations, :output_tokens),
-      sessions: invocations |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+      # Performance: MapSet avoids intermediate list allocations
+      sessions: invocations |> MapSet.new(& &1.session_id) |> MapSet.size()
     }
   end
 
@@ -1713,7 +1715,8 @@ defmodule ControlKeel.Observability do
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
         output_tokens: sum_invocation_field(group, :output_tokens),
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+        # Performance: MapSet avoids intermediate list allocations
+        sessions: group |> MapSet.new(& &1.session_id) |> MapSet.size()
       }
     end)
     |> Enum.sort_by(&{&1.estimated_cost_cents, &1.invocations}, :desc)
@@ -1730,7 +1733,8 @@ defmodule ControlKeel.Observability do
       %{
         name: name,
         invocations: invocation_count,
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length(),
+        # Performance: MapSet avoids intermediate list allocations
+        sessions: group |> MapSet.new(& &1.session_id) |> MapSet.size(),
         estimated_cost_cents: total_cost,
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
@@ -2194,7 +2198,8 @@ defmodule ControlKeel.Observability do
       suite: benchmark_run_suite_slug(run),
       subjects: run.subjects || [],
       total_scenarios: run.total_scenarios,
-      observed_scenarios: run.results |> Enum.map(& &1.scenario_id) |> Enum.uniq() |> length(),
+      # Performance: MapSet avoids intermediate list allocations
+      observed_scenarios: run.results |> MapSet.new(& &1.scenario_id) |> MapSet.size(),
       caught_count: run.caught_count,
       blocked_count: run.blocked_count,
       catch_rate: run.catch_rate || 0.0,


### PR DESCRIPTION
### 💡 What:
Replaced inefficient list counting operations:
- `Enum.map/2 |> Enum.uniq/1 |> length/1` was replaced with `MapSet.new/2 |> MapSet.size/1`
- `Enum.filter/2 |> length/1` was replaced with `Enum.count/2`

### 🎯 Why:
The original pipelines create intermediate lists during `Enum.map`, `Enum.uniq`, and `Enum.filter` before simply returning an integer count. This increases garbage collection pressure and memory usage overhead. By switching to `MapSet` and `Enum.count`, these allocations are bypassed.

### 📊 Impact:
Saves multiple O(N) list allocations per invocation. This translates directly to less memory churn and lower garbage collection pauses.

### 🔬 Measurement:
This relies on fundamental Elixir core behaviors. The functional outputs remain exactly the same as prior logic.

---
*PR created automatically by Jules for task [11241694642683274397](https://jules.google.com/task/11241694642683274397) started by @aryaminus*