### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label and focus styles to CommandPill copy button

### DIFF
--- a/lib/controlkeel_web/components/command_pill.ex
+++ b/lib/controlkeel_web/components/command_pill.ex
@@ -13,7 +13,8 @@ defmodule ControlKeelWeb.CommandPill do
         type="button"
         phx-click="copy_command"
         phx-value-command={@command}
-        class="cursor-pointer hover:text-primary transition-colors"
+        aria-label="Copy command"
+        class="cursor-pointer hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
       >
         <.icon name="hero-clipboard" class="w-4 h-4" />
       </button>


### PR DESCRIPTION
## 💡 What
Added an `aria-label` ("Copy command") and explicit keyboard focus styles (`focus-visible:ring-2 focus-visible:ring-primary`, etc) to the icon-only copy button in the `CommandPill` component (`lib/controlkeel_web/components/command_pill.ex`).

## 🎯 Why
Icon-only buttons are inaccessible to screen readers without an explicit text alternative. Additionally, when navigating via keyboard, it's crucial to have clear visual feedback on which element is currently focused.

## 📸 Before/After
*(Visual change only applies to focus states)*
Before: Keyboard tabbing onto the copy button produced no distinct visible ring, and screen readers read nothing meaningful.
After: The button has a clear primary-colored focus ring when tabbed into, and screen readers announce "Copy command".

## ♿ Accessibility
- Added `aria-label="Copy command"`
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded` classes to ensure visible focus states without impacting mouse users.

---
*PR created automatically by Jules for task [8975146739194734373](https://jules.google.com/task/8975146739194734373) started by @aryaminus*