### PR TITLE
⚡ Bolt: [performance improvement] optimize intermediate list allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-08-11 - Optimize List Allocations in Elixir
+**Learning:** Using `length(Enum.filter(...))` or `enumerable |> Enum.map(...) |> Enum.uniq() |> length()` in Elixir creates unnecessary intermediate list allocations and traverses the list multiple times, which adds performance overhead.
+**Action:** When counting filtered items, prefer `Enum.count/2` over `length(Enum.filter/2)`. When counting unique items after mapping, prefer `enumerable |> MapSet.new(fun) |> MapSet.size()` to avoid intermediate lists and improve performance.

--- a/lib/controlkeel/cloud/baseline_analyzer.ex
+++ b/lib/controlkeel/cloud/baseline_analyzer.ex
@@ -94,7 +94,7 @@ defmodule ControlKeel.Cloud.BaselineAnalyzer do
       )
       |> Repo.all()
 
-    sample_sessions = rows |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+    sample_sessions = rows |> MapSet.new(& &1.session_id) |> MapSet.size()
 
     baseline =
       rows

--- a/lib/controlkeel/governance.ex
+++ b/lib/controlkeel/governance.ex
@@ -555,7 +555,7 @@ defmodule ControlKeel.Governance do
   end
 
   defp review_summary(decision, findings, fragments) do
-    files_reviewed = fragments |> Enum.map(& &1.path) |> Enum.uniq() |> length()
+    files_reviewed = fragments |> MapSet.new(& &1.path) |> MapSet.size()
     chunks_reviewed = length(fragments)
     added_lines_reviewed = Enum.reduce(fragments, 0, &(&1.added_line_count + &2))
 

--- a/lib/controlkeel/mcp/tool_group_tracker.ex
+++ b/lib/controlkeel/mcp/tool_group_tracker.ex
@@ -163,7 +163,7 @@ defmodule ControlKeel.MCP.ToolGroupTracker do
       total_calls = entries |> Enum.map(fn {_key, _ts, count} -> count end) |> Enum.sum()
 
       unique_tools =
-        entries |> Enum.map(fn {key, _ts, _count} -> key end) |> Enum.uniq() |> length()
+        entries |> MapSet.new(fn {key, _ts, _count} -> key end) |> MapSet.size()
 
       %{total_calls: total_calls, unique_tools: unique_tools}
     end

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -524,7 +524,7 @@ defmodule ControlKeel.Observability do
       benchmark_drafts: drafts.count,
       approved_drafts: approved_drafts,
       materialized_scenarios: length(scenario_ids),
-      covered_scenarios: length(Enum.filter(scenario_ids, &(&1 in covered_ids))),
+      covered_scenarios: Enum.count(scenario_ids, &(&1 in covered_ids)),
       benchmark_runs: length(runs)
     }
 
@@ -1698,7 +1698,7 @@ defmodule ControlKeel.Observability do
       input_tokens: sum_invocation_field(invocations, :input_tokens),
       cached_input_tokens: sum_invocation_field(invocations, :cached_input_tokens),
       output_tokens: sum_invocation_field(invocations, :output_tokens),
-      sessions: invocations |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+      sessions: invocations |> MapSet.new(& &1.session_id) |> MapSet.size()
     }
   end
 
@@ -1713,7 +1713,7 @@ defmodule ControlKeel.Observability do
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
         output_tokens: sum_invocation_field(group, :output_tokens),
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+        sessions: group |> MapSet.new(& &1.session_id) |> MapSet.size()
       }
     end)
     |> Enum.sort_by(&{&1.estimated_cost_cents, &1.invocations}, :desc)
@@ -1730,7 +1730,7 @@ defmodule ControlKeel.Observability do
       %{
         name: name,
         invocations: invocation_count,
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length(),
+        sessions: group |> MapSet.new(& &1.session_id) |> MapSet.size(),
         estimated_cost_cents: total_cost,
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
@@ -2194,7 +2194,7 @@ defmodule ControlKeel.Observability do
       suite: benchmark_run_suite_slug(run),
       subjects: run.subjects || [],
       total_scenarios: run.total_scenarios,
-      observed_scenarios: run.results |> Enum.map(& &1.scenario_id) |> Enum.uniq() |> length(),
+      observed_scenarios: run.results |> MapSet.new(& &1.scenario_id) |> MapSet.size(),
       caught_count: run.caught_count,
       blocked_count: run.blocked_count,
       catch_rate: run.catch_rate || 0.0,


### PR DESCRIPTION
### 💡 What
Replaced Elixir list pipelines that create unnecessary intermediate lists with more direct, memory-efficient operations:
- `enumerable |> Enum.map(fun) |> Enum.uniq() |> length()` was replaced with `enumerable |> MapSet.new(fun) |> MapSet.size()`.
- `length(Enum.filter(enumerable, fun))` was replaced with `Enum.count(enumerable, fun)`.

These changes were applied across `ControlKeel.Observability`, `ControlKeel.Cloud.BaselineAnalyzer`, `ControlKeel.MCP.ToolGroupTracker`, and `ControlKeel.Governance`.

### 🎯 Why
The original code allocated intermediate linked lists just to calculate their length, adding unnecessary memory overhead and GC pressure. Using `MapSet.new/2` builds a unique set in a single pass without the intermediate list, and `MapSet.size/1` is an O(1) operation. Using `Enum.count/2` calculates the count directly without building an intermediate list. 

### 📊 Impact
Reduces intermediate list allocations and garbage collection overhead during frequent data processing tasks like computing baseline analysis, governance tracking, and observability coverage. Improves processing time, particularly on larger datasets where multiple iterations add up.

### 🔬 Measurement
These backend changes can be verified by running the test suite to ensure results remain identical (`mix test`). The memory and speed improvements can be observed via profiling data ingestion or observability calculations in large workloads (e.g. reduced BEAM memory spikes).

---
*PR created automatically by Jules for task [1309358885414277010](https://jules.google.com/task/1309358885414277010) started by @aryaminus*