### PR TITLE
⚡ Bolt: Optimize Elixir list operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-08-12 - Optimize Elixir intermediate list allocations
+**Learning:** Operations like length(Enum.filter(...)) and length(Enum.uniq(...)) create intermediate list allocations which add memory overhead. Using Enum.count/2 and MapSet is more efficient.
+**Action:** Always prefer Enum.count/2 over length(Enum.filter/2), and MapSet over length(Enum.uniq/1) when dealing with lists to avoid unnecessary memory allocation.

--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -270,7 +270,7 @@ defmodule ControlKeel.Benchmark do
   # itself), so we skip the recompute and keep the export payload lean. The
   # explicit `benchmark compare <id>` command always computes a comparison.
   defp maybe_comparison(%Run{subjects: subjects} = run) when is_list(subjects) do
-    if length(Enum.uniq(subjects)) >= 2, do: compare_run(run), else: nil
+    if MapSet.size(MapSet.new(subjects)) >= 2, do: compare_run(run), else: nil
   end
 
   defp maybe_comparison(_run), do: nil

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -524,7 +524,7 @@ defmodule ControlKeel.Observability do
       benchmark_drafts: drafts.count,
       approved_drafts: approved_drafts,
       materialized_scenarios: length(scenario_ids),
-      covered_scenarios: length(Enum.filter(scenario_ids, &(&1 in covered_ids))),
+      covered_scenarios: Enum.count(scenario_ids, &(&1 in covered_ids)),
       benchmark_runs: length(runs)
     }
 


### PR DESCRIPTION
* 💡 What: Replaced `length(Enum.filter)` with `Enum.count` and `length(Enum.uniq)` with `MapSet.new |> MapSet.size`.
* 🎯 Why: To avoid intermediate list allocations, reducing memory overhead and improving performance.
* 📊 Impact: Reduces memory allocation and garbage collection overhead when processing collections.
* 🔬 Measurement: Observe memory profiling and benchmarking on list operations.

---
*PR created automatically by Jules for task [4670076504191451692](https://jules.google.com/task/4670076504191451692) started by @aryaminus*