### PR TITLE
🎨 Palette: Add accessibility to CommandPill copy button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-12 - Added aria-label and focus state to CommandPill copy button
+**Learning:** Icon-only buttons often lack accessibility. Using `aria-label` and Tailwind `focus-visible` utility classes enhances accessibility greatly without disrupting the existing UX.
+**Action:** Add `aria-label` and focus ring utility classes to all icon-only buttons as a standard procedure to improve accessibility.

--- a/lib/controlkeel_web/components/command_pill.ex
+++ b/lib/controlkeel_web/components/command_pill.ex
@@ -13,7 +13,8 @@ defmodule ControlKeelWeb.CommandPill do
         type="button"
         phx-click="copy_command"
         phx-value-command={@command}
-        class="cursor-pointer hover:text-primary transition-colors"
+        class="cursor-pointer hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
+        aria-label="Copy command"
       >
         <.icon name="hero-clipboard" class="w-4 h-4" />
       </button>


### PR DESCRIPTION
### 💡 What
Added an `aria-label` and `focus-visible` states to the icon-only "Copy" button within the `CommandPill` component.

### 🎯 Why
Icon-only buttons are inaccessible to screen readers without an explicit `aria-label`. Additionally, they need clear keyboard focus styles to be usable for those navigating via keyboard.

### 📸 Before/After
*(Visual change only visible via screen reader or keyboard navigation)*

### ♿ Accessibility
- Added `aria-label="Copy command"` to the button so screen readers announce it properly.
- Applied `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded` to provide a clear, visible focus indicator for keyboard users.

---
*PR created automatically by Jules for task [15944085069745461632](https://jules.google.com/task/15944085069745461632) started by @aryaminus*