### PR TITLE
a11y(web): add focus-visible ring to flash dismiss button

### DIFF
--- a/lib/controlkeel_web/components/core_components.ex
+++ b/lib/controlkeel_web/components/core_components.ex
@@ -67,7 +67,7 @@ defmodule ControlKeelWeb.CoreComponents do
           <p>{msg}</p>
         </div>
         <div class="flex-1" />
-        <button type="button" class="group self-start cursor-pointer" aria-label={gettext("close")}>
+        <button type="button" class="group self-start cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded" aria-label={gettext("close")}>
           <.icon name="hero-x-mark" class="size-5 opacity-40 group-hover:opacity-70" />
         </button>
       </div>


### PR DESCRIPTION
## Summary

The flash dismiss button (`<.flash>` close button in `core_components.ex`) already has `aria-label={gettext("close")}` but no visible keyboard-focus indicator. This adds the same `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded` treatment approved in #68 (command_pill) so keyboard users can see focus on the icon-only button.

## Why

Spun out of the closed bot drafts #71 / #73 — those bundled this genuine a11y fix with a now-redundant `command_pill` change (covered by merged #68) and a `.Jules/palette.md` marker file. This keeps just the one new, correct improvement.

## Changes

- `lib/controlkeel_web/components/core_components.ex` — one line: add focus-visible ring classes to the flash dismiss `<button>`.

## Verify

- `mix compile` — clean (no warnings).
- `mix format --check-formatted` — clean.

The class set matches the convention already approved in #68, so it should sit cleanly within the design system from #53. @saragam-git — quick confirm that the focus-ring style matches your tokens, please.