### PR TITLE
⚡ Bolt: [performance improvement] Optimize Elixir list counting in observability

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-08-13 - Elixir List Allocation Overhead
+**Learning:** Using `length(Enum.filter/2)` and `Enum.map/2 |> Enum.uniq/1 |> length/1` causes unnecessary intermediate list allocations in Elixir, adding performance overhead compared to more direct counting methods.
+**Action:** Always prefer `Enum.count/2` over `length(Enum.filter/2)` and use `MapSet.new/2 |> MapSet.size()` instead of `Enum.map/2 |> Enum.uniq/1 |> length/1` when counting unique items to avoid creating intermediate list allocations.

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -524,7 +524,7 @@ defmodule ControlKeel.Observability do
       benchmark_drafts: drafts.count,
       approved_drafts: approved_drafts,
       materialized_scenarios: length(scenario_ids),
-      covered_scenarios: length(Enum.filter(scenario_ids, &(&1 in covered_ids))),
+      covered_scenarios: Enum.count(scenario_ids, &(&1 in covered_ids)),
       benchmark_runs: length(runs)
     }
 
@@ -1698,7 +1698,7 @@ defmodule ControlKeel.Observability do
       input_tokens: sum_invocation_field(invocations, :input_tokens),
       cached_input_tokens: sum_invocation_field(invocations, :cached_input_tokens),
       output_tokens: sum_invocation_field(invocations, :output_tokens),
-      sessions: invocations |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+      sessions: invocations |> Enum.map(& &1.session_id) |> MapSet.new() |> MapSet.size()
     }
   end
 
@@ -1713,7 +1713,7 @@ defmodule ControlKeel.Observability do
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
         output_tokens: sum_invocation_field(group, :output_tokens),
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+        sessions: group |> Enum.map(& &1.session_id) |> MapSet.new() |> MapSet.size()
       }
     end)
     |> Enum.sort_by(&{&1.estimated_cost_cents, &1.invocations}, :desc)
@@ -1730,7 +1730,7 @@ defmodule ControlKeel.Observability do
       %{
         name: name,
         invocations: invocation_count,
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length(),
+        sessions: group |> Enum.map(& &1.session_id) |> MapSet.new() |> MapSet.size(),
         estimated_cost_cents: total_cost,
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
@@ -2194,7 +2194,7 @@ defmodule ControlKeel.Observability do
       suite: benchmark_run_suite_slug(run),
       subjects: run.subjects || [],
       total_scenarios: run.total_scenarios,
-      observed_scenarios: run.results |> Enum.map(& &1.scenario_id) |> Enum.uniq() |> length(),
+      observed_scenarios: run.results |> Enum.map(& &1.scenario_id) |> MapSet.new() |> MapSet.size(),
       caught_count: run.caught_count,
       blocked_count: run.blocked_count,
       catch_rate: run.catch_rate || 0.0,


### PR DESCRIPTION
💡 **What:** Optimized several counting operations in `lib/controlkeel/observability.ex`. Replaced `length(Enum.filter(...))` with `Enum.count(...)` and `Enum.map(...) |> Enum.uniq() |> length()` with `MapSet.new(...) |> MapSet.size()`.
🎯 **Why:** `Enum.filter` followed by `length` creates an intermediate list in memory just to determine the count. `Enum.count` with a function increments a counter without allocating a new list. Similarly, `Enum.uniq` creates an intermediate list of unique items, whereas converting to a `MapSet` and checking its size does the same without allocating intermediate lists for each step in the pipeline. This reduces garbage collection pressure and memory allocations.
📊 **Impact:** Reduces intermediate list allocations and garbage collection overhead during observability metric computations, which are frequently run operations.
🔬 **Measurement:** While testing in this environment is constrained, memory allocations per function call for these operations will be reduced. You can measure memory reductions via `:erts_debug.size/1` in a live shell, or notice lower latencies on these report endpoints in telemetry.

---
*PR created automatically by Jules for task [795195978215280618](https://jules.google.com/task/795195978215280618) started by @aryaminus*