### PR TITLE
🎨 Palette: [UX improvement] Add a11y attributes to finding fix modal close button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-13 - Added missing ARIA label to Findings fix modal close button
+**Learning:** The Guided fix modal's close button lacked an `aria-label` and explicit keyboard focus visibility.
+**Action:** When adding close buttons to modals, ensure `aria-label="Close modal"` and Tailwind classes like `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded` are included for accessibility.

--- a/lib/controlkeel_web/live/findings_live.ex
+++ b/lib/controlkeel_web/live/findings_live.ex
@@ -518,8 +518,9 @@ defmodule ControlKeelWeb.FindingsLive do
         <div class="relative rounded-lg border bg-card shadow-2xl p-8 w-full max-w-2xl mx-4 space-y-4">
           <button
             type="button"
-            class="absolute top-2 right-2 text-muted-foreground hover:text-foreground transition"
+            class="absolute top-2 right-2 text-muted-foreground hover:text-foreground transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
             phx-click="close_fix"
+            aria-label="Close modal"
           >
             <.icon name="hero-x-mark" class="w-5 h-5" />
           </button>


### PR DESCRIPTION
💡 **What:** Added an `aria-label` and explicit keyboard focus styles to the close button in the Guided fix modal within `lib/controlkeel_web/live/findings_live.ex`.

🎯 **Why:** The close button was an icon-only button lacking an accessible name, meaning screen readers would announce it incorrectly or not at all. Additionally, it lacked clear visual feedback when navigating via keyboard, making it difficult for keyboard users to know when it was focused.

📸 **Before/After:**
*(No visual change for mouse users. For keyboard users, the button now displays a primary-colored focus ring when tabbed to.)*

♿ **Accessibility:**
- Added `aria-label="Close modal"` for screen reader support.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded` to ensure keyboard navigation highlights the button clearly.

---
*PR created automatically by Jules for task [6514507775289173190](https://jules.google.com/task/6514507775289173190) started by @aryaminus*