### PR TITLE
Refactor session review routes, UI, and centralized URL generation

### DIFF
--- a/lib/controlkeel/cli.ex
+++ b/lib/controlkeel/cli.ex
@@ -29,7 +29,6 @@ defmodule ControlKeel.CLI do
   alias ControlKeel.Skills
   alias ControlKeel.Project.WorkspaceContext
   alias ControlKeel.Utils.Yaml, as: UtilsYaml
-  alias ControlKeelWeb.Endpoint
 
   def standalone_argv do
     cond do
@@ -1885,7 +1884,8 @@ defmodule ControlKeel.CLI do
 
   def format_cli_error(reason), do: inspect(reason)
 
-  def review_url(review_id), do: Endpoint.url() <> "/reviews/#{review_id}"
+  def review_url(%{session_id: session_id, id: review_id}),
+    do: ReviewBridge.browser_url(session_id, review_id)
 
   def manual_approval_lines(review, %{server_serving: false}) do
     [

--- a/lib/controlkeel/cli/dispatch/review.ex
+++ b/lib/controlkeel/cli/dispatch/review.ex
@@ -56,7 +56,7 @@ defmodule ControlKeel.CLI.Dispatch.Review do
       payload =
         review_cli_payload(review, %{
           "message" => "submitted",
-          "browser_url" => review_url(review.id)
+          "browser_url" => review_url(review)
         })
 
       if options[:json] do
@@ -66,7 +66,7 @@ defmodule ControlKeel.CLI.Dispatch.Review do
          [
            "Submitted plan review ##{review.id}.",
            "Status: #{review.status}",
-           "Browser URL: #{review_url(review.id)}",
+           "Browser URL: #{review_url(review)}",
            "Execution gate: task remains blocked until the plan review is approved."
          ]}
       end
@@ -133,7 +133,7 @@ defmodule ControlKeel.CLI.Dispatch.Review do
       payload =
         review_cli_payload(review, %{
           "message" => "wait",
-          "browser_url" => review_url(review.id)
+          "browser_url" => review_url(review)
         })
 
       case review.status do
@@ -145,7 +145,7 @@ defmodule ControlKeel.CLI.Dispatch.Review do
              [
                "Plan review ##{review.id} approved.",
                "Status: #{review.status}",
-               "Browser URL: #{review_url(review.id)}"
+               "Browser URL: #{review_url(review)}"
              ] ++ review_feedback_lines(review)}
           end
 
@@ -172,7 +172,7 @@ defmodule ControlKeel.CLI.Dispatch.Review do
             "message" => "timeout",
             "timed_out" => true,
             "status" => review.status,
-            "browser_url" => review_url(review.id)
+            "browser_url" => review_url(review)
           })
 
         if review.status in ["pending", "superseded"] do
@@ -183,7 +183,7 @@ defmodule ControlKeel.CLI.Dispatch.Review do
              [
                "Timed out waiting for plan review ##{review.id}.",
                "Status: #{review.status}",
-               "Browser URL: #{review_url(review.id)}",
+               "Browser URL: #{review_url(review)}",
                "Review is still open; keep waiting or respond in browser."
              ]}
           end
@@ -212,7 +212,7 @@ defmodule ControlKeel.CLI.Dispatch.Review do
       payload =
         review_cli_payload(review, %{
           "message" => "responded",
-          "browser_url" => review_url(review.id)
+          "browser_url" => review_url(review)
         })
 
       if options[:json] do
@@ -222,7 +222,7 @@ defmodule ControlKeel.CLI.Dispatch.Review do
          [
            "Updated plan review ##{review.id}.",
            "Status: #{review.status}",
-           "Browser URL: #{review_url(review.id)}"
+           "Browser URL: #{review_url(review)}"
          ]}
       end
     else

--- a/lib/controlkeel/mcp/tools/ck_review_submit.ex
+++ b/lib/controlkeel/mcp/tools/ck_review_submit.ex
@@ -27,7 +27,7 @@ defmodule ControlKeel.MCP.Tools.CkReviewSubmit do
 
         browser_url =
           try do
-            ControlKeelWeb.Endpoint.url() <> "/reviews/#{review.id}"
+            ControlKeel.Mission.ReviewBridge.browser_url(review)
           rescue
             _ -> nil
           end

--- a/lib/controlkeel/mcp/tools/review_helpers.ex
+++ b/lib/controlkeel/mcp/tools/review_helpers.ex
@@ -181,23 +181,13 @@ defmodule ControlKeel.MCP.Tools.ReviewHelpers do
 
   defp safe_review_url(%{session_id: session_id, id: review_id})
        when is_integer(session_id) and is_integer(review_id),
-       do: build_review_url(session_id, review_id)
+       do: ReviewBridge.browser_url(session_id, review_id)
 
   defp safe_review_url(%{"session_id" => session_id, "id" => review_id})
        when is_integer(session_id) and is_integer(review_id),
-       do: build_review_url(session_id, review_id)
+       do: ReviewBridge.browser_url(session_id, review_id)
 
   defp safe_review_url(_review), do: nil
-
-  defp build_review_url(session_id, review_id) do
-    try do
-      ControlKeelWeb.Endpoint.url() <> "/sessions/#{session_id}/reviews/#{review_id}"
-    rescue
-      _ -> nil
-    catch
-      _, _ -> nil
-    end
-  end
 
   defp take_balanced_json_object("{" <> _ = input) do
     bytes = :binary.bin_to_list(input)

--- a/lib/controlkeel/mcp/tools/review_helpers.ex
+++ b/lib/controlkeel/mcp/tools/review_helpers.ex
@@ -52,10 +52,10 @@ defmodule ControlKeel.MCP.Tools.ReviewHelpers do
   Extracts the browser URL from a review record.
   """
   def review_browser_url(%{fallback_payload: payload}) do
-    Map.get(payload, "browser_url") || safe_review_url(Map.get(payload, "review", %{})["id"])
+    Map.get(payload, "browser_url") || safe_review_url(Map.get(payload, "review"))
   end
 
-  def review_browser_url(review), do: safe_review_url(review.id)
+  def review_browser_url(review), do: safe_review_url(review)
 
   @doc """
   Builds approval instructions for a review.
@@ -179,9 +179,19 @@ defmodule ControlKeel.MCP.Tools.ReviewHelpers do
 
   defp safe_review_url(nil), do: nil
 
-  defp safe_review_url(review_id) do
+  defp safe_review_url(%{session_id: session_id, id: review_id})
+       when is_integer(session_id) and is_integer(review_id),
+       do: build_review_url(session_id, review_id)
+
+  defp safe_review_url(%{"session_id" => session_id, "id" => review_id})
+       when is_integer(session_id) and is_integer(review_id),
+       do: build_review_url(session_id, review_id)
+
+  defp safe_review_url(_review), do: nil
+
+  defp build_review_url(session_id, review_id) do
     try do
-      ControlKeelWeb.Endpoint.url() <> "/reviews/#{review_id}"
+      ControlKeelWeb.Endpoint.url() <> "/sessions/#{session_id}/reviews/#{review_id}"
     rescue
       _ -> nil
     catch

--- a/lib/controlkeel/mission/review_bridge.ex
+++ b/lib/controlkeel/mission/review_bridge.ex
@@ -5,10 +5,12 @@ defmodule ControlKeel.Mission.ReviewBridge do
   alias ControlKeel.Mission.Review
   alias ControlKeelWeb.Endpoint
 
-  def browser_url(%Review{id: id}), do: browser_url(id)
+  def browser_url(%Review{id: review_id, session_id: session_id}),
+    do: browser_url(session_id, review_id)
 
-  def browser_url(review_id) when is_integer(review_id),
-    do: Endpoint.url() <> "/reviews/#{review_id}"
+  def browser_url(session_id, review_id)
+      when is_integer(session_id) and is_integer(review_id),
+      do: Endpoint.url() <> "/sessions/#{session_id}/reviews/#{review_id}"
 
   def open_review(review_or_id, opts \\ []) do
     with {:ok, review} <- fetch_review(review_or_id) do

--- a/lib/controlkeel/mission/review_bridge.ex
+++ b/lib/controlkeel/mission/review_bridge.ex
@@ -8,9 +8,25 @@ defmodule ControlKeel.Mission.ReviewBridge do
   def browser_url(%Review{id: review_id, session_id: session_id}),
     do: browser_url(session_id, review_id)
 
+  def browser_url(_review), do: nil
+
   def browser_url(session_id, review_id)
-      when is_integer(session_id) and is_integer(review_id),
-      do: Endpoint.url() <> "/sessions/#{session_id}/reviews/#{review_id}"
+      when is_integer(session_id) and is_integer(review_id) do
+    case safe_endpoint_url() do
+      nil -> nil
+      base -> base <> "/sessions/#{session_id}/reviews/#{review_id}"
+    end
+  end
+
+  def browser_url(_session_id, _review_id), do: nil
+
+  defp safe_endpoint_url do
+    Endpoint.url()
+  rescue
+    _ -> nil
+  catch
+    _, _ -> nil
+  end
 
   def open_review(review_or_id, opts \\ []) do
     with {:ok, review} <- fetch_review(review_or_id) do

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -3350,6 +3350,7 @@ defmodule ControlKeel.Observability do
         |> Enum.map(fn review ->
           %{
             id: review.id,
+            session_id: review.session_id,
             status: review.status,
             review_type: review.review_type,
             title: review.title || "Review #{review.id}"

--- a/lib/controlkeel_web/components/core_components.ex
+++ b/lib/controlkeel_web/components/core_components.ex
@@ -76,6 +76,65 @@ defmodule ControlKeelWeb.CoreComponents do
   end
 
   @doc """
+  Renders a button with a selectable variant.
+
+  Variants:
+
+    * `default` - solid primary fill, the default accent
+    * `secondary` - muted soft fill for less prominent actions
+    * `outline` - bordered transparent for neutral actions
+    * `destructive` - soft destructive fill for high-risk actions
+
+  Any additional attributes (such as `id`, `name`, `value`, `disabled`,
+  `phx-click`) are passed through to the button element.
+
+  ## Examples
+
+      <.button>Submit</.button>
+      <.button variant="outline" phx-click="cancel">Cancel</.button>
+      <.button variant="destructive" type="submit" name="decision" value="denied">Deny</.button>
+  """
+  attr :variant, :string,
+    default: "default",
+    values: ~w(default secondary outline destructive)
+
+  attr :type, :string, default: "button", values: ~w(button submit reset)
+  attr :class, :any, default: nil, doc: "additional classes appended to the base styling"
+
+  attr :rest, :global,
+    include: ~w(id disabled name value form autofocus formaction formnovalidate)
+
+  slot :inner_block, required: true
+
+  def button(assigns) do
+    ~H"""
+    <button
+      type={@type}
+      class={[
+        "inline-flex items-center justify-center gap-1.5 rounded-lg px-4 py-1.5 text-xs font-semibold transition cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:pointer-events-none disabled:opacity-50",
+        button_variant_class(@variant),
+        @class
+      ]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </button>
+    """
+  end
+
+  defp button_variant_class("default"),
+    do: "bg-primary text-primary-foreground hover:bg-primary/90"
+
+  defp button_variant_class("secondary"),
+    do: "bg-secondary/30 hover:bg-secondary/40 border border-border/40 text-muted-foreground"
+
+  defp button_variant_class("outline"),
+    do: "border border-border bg-transparent text-foreground hover:bg-muted"
+
+  defp button_variant_class("destructive"),
+    do: "bg-destructive/20 hover:bg-destructive/30 border border-destructive/40 text-destructive"
+
+  @doc """
   Renders an input with label and error messages.
 
   A `Phoenix.HTML.FormField` may be passed as argument,
@@ -261,72 +320,115 @@ defmodule ControlKeelWeb.CoreComponents do
   end
 
   @doc """
-  Renders a labeled input or textarea with the alternate soft-surface styling.
+  Renders a labeled input with the alternate soft-surface styling.
+
+  `input_component` exists because a legacy `input` component is already
+  used throughout the repo. Changing `input` now would ripple across many
+  call sites, so new form fields are written against `input_component`
+  (or `<.textarea>` for multi-line input) instead. Usages migrate slowly,
+  and once the legacy `input` is fully replaced, `input_component` will
+  be renamed to `input`.
 
   Accepts a `Phoenix.HTML.FormField` for the bound field, an optional icon
-  and hint, and dispatches on `:type` (defaults to `"textarea"`).
+  and hint.
 
   ## Examples
 
-      <.input_component field={@form[:feedback_notes]} label="Feedback notes" placeholder="Add notes..." rows={3} />
       <.input_component field={@form[:title]} type="text" label="Title" icon="hero-bars-3" />
   """
   attr :id, :any, default: nil
   attr :name, :any
   attr :label, :string, required: true
   attr :value, :any
-  attr :type, :string, default: "textarea"
+  attr :type, :string, default: "text"
   attr :field, Phoenix.HTML.FormField
-  attr :rows, :integer, default: 3
   attr :hint, :string, default: nil
   attr :icon, :string, default: nil
+  attr :class, :any, default: nil, doc: "additional classes appended to the default styling"
 
   attr :rest, :global,
     include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
                 multiple pattern placeholder readonly required size step)
-
-  def input_component(%{type: "textarea"} = assigns) do
-    assigns = assign_component_field(assigns)
-
-    ~H"""
-    <div>
-      <div class="mb-1.5 flex items-center gap-1.5">
-        <.icon :if={@icon} name={@icon} class="size-3.5 text-muted-foreground" />
-        <label for={@id} class="text-sm font-medium text-foreground/90">{@label}</label>
-      </div>
-      <div :if={@hint} class="sr-only">{@hint}</div>
-      <textarea
-        id={@id}
-        name={@name}
-        rows={@rows}
-        class={input_component_class(@rest[:disabled] || false)}
-        {@rest}
-      >{Phoenix.HTML.Form.normalize_value("textarea", @value)}</textarea>
-      <p :if={@hint} class="mt-1.5 text-xs text-muted-foreground">{@hint}</p>
-    </div>
-    """
-  end
 
   def input_component(assigns) do
     assigns = assign_component_field(assigns)
 
     ~H"""
     <div>
-      <div class="mb-1.5 flex items-center gap-1.5">
-        <.icon :if={@icon} name={@icon} class="size-3.5 text-muted-foreground" />
-        <label for={@id} class="text-sm font-medium text-foreground/90">{@label}</label>
-      </div>
-      <div :if={@hint} class="sr-only">{@hint}</div>
+      <.component_field_header icon={@icon} label={@label} hint={@hint} id={@id} />
       <input
         type={@type}
         id={@id}
         name={@name}
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
-        class={input_component_class(@rest[:disabled] || false)}
+        class={[input_component_field_class(), @class]}
         {@rest}
       />
-      <p :if={@hint} class="mt-1.5 text-xs text-muted-foreground">{@hint}</p>
+      <.component_field_hint :if={@hint} hint={@hint} />
     </div>
+    """
+  end
+
+  defp input_component_field_class(),
+    do:
+      "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm"
+
+  @doc """
+  Renders a labeled textarea with the alternate soft-surface styling.
+
+  See the migration note in `input_component/1`.
+
+  ## Examples
+
+      <.textarea field={@form[:feedback_notes]} label="Feedback notes" placeholder="Add notes..." />
+  """
+  attr :id, :any, default: nil
+  attr :name, :any
+  attr :label, :string, required: true
+  attr :value, :any
+  attr :field, Phoenix.HTML.FormField
+  attr :hint, :string, default: nil
+  attr :icon, :string, default: nil
+  attr :class, :any, default: nil, doc: "additional classes appended to the default styling"
+
+  attr :rest, :global,
+    include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+                multiple pattern placeholder readonly required size step)
+
+  def textarea(assigns) do
+    assigns = assign_component_field(assigns)
+
+    ~H"""
+    <div>
+      <.component_field_header icon={@icon} label={@label} hint={@hint} id={@id} />
+      <textarea
+        id={@id}
+        name={@name}
+        class={[textarea_component_field_class(), @class]}
+        {@rest}
+      >{Phoenix.HTML.Form.normalize_value("textarea", @value)}</textarea>
+      <.component_field_hint :if={@hint} hint={@hint} />
+    </div>
+    """
+  end
+
+  defp textarea_component_field_class(),
+    do:
+      "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm"
+
+  defp component_field_header(assigns) do
+    ~H"""
+    <div class="mb-1.5 flex items-center gap-1.5">
+      <.icon :if={@icon} name={@icon} class="size-3.5 text-muted-foreground" />
+      <label for={@id} class="text-sm font-medium text-foreground/90">{@label}</label>
+    </div>
+    <div :if={@hint} class="sr-only">{@hint}</div>
+    """
+  end
+
+  defp component_field_hint(assigns) do
+    ~H"""
+    <p class="mt-1.5 text-xs text-muted-foreground">{@hint}</p>
     """
   end
 
@@ -338,14 +440,6 @@ defmodule ControlKeelWeb.CoreComponents do
   end
 
   defp assign_component_field(assigns), do: assigns
-
-  defp input_component_class(false),
-    do:
-      "w-full resize-none rounded-xl border border-border bg-muted/30 px-3.5 py-2.5 text-sm leading-6 text-foreground placeholder:text-muted-foreground/50 transition focus:border-primary focus:bg-card focus:outline-none focus:ring-2 focus:ring-primary/30"
-
-  defp input_component_class(true),
-    do:
-      "w-full resize-none rounded-xl border border-border/60 bg-muted/30 px-3.5 py-2.5 text-sm leading-6 text-muted-foreground transition cursor-not-allowed"
 
   # Helper used by inputs to generate form errors
   defp error(assigns) do

--- a/lib/controlkeel_web/components/core_components.ex
+++ b/lib/controlkeel_web/components/core_components.ex
@@ -260,6 +260,93 @@ defmodule ControlKeelWeb.CoreComponents do
     """
   end
 
+  @doc """
+  Renders a labeled input or textarea with the alternate soft-surface styling.
+
+  Accepts a `Phoenix.HTML.FormField` for the bound field, an optional icon
+  and hint, and dispatches on `:type` (defaults to `"textarea"`).
+
+  ## Examples
+
+      <.input_component field={@form[:feedback_notes]} label="Feedback notes" placeholder="Add notes..." rows={3} />
+      <.input_component field={@form[:title]} type="text" label="Title" icon="hero-bars-3" />
+  """
+  attr :id, :any, default: nil
+  attr :name, :any
+  attr :label, :string, required: true
+  attr :value, :any
+  attr :type, :string, default: "textarea"
+  attr :field, Phoenix.HTML.FormField
+  attr :rows, :integer, default: 3
+  attr :hint, :string, default: nil
+  attr :icon, :string, default: nil
+
+  attr :rest, :global,
+    include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+                multiple pattern placeholder readonly required size step)
+
+  def input_component(%{type: "textarea"} = assigns) do
+    assigns = assign_component_field(assigns)
+
+    ~H"""
+    <div>
+      <div class="mb-1.5 flex items-center gap-1.5">
+        <.icon :if={@icon} name={@icon} class="size-3.5 text-muted-foreground" />
+        <label for={@id} class="text-sm font-medium text-foreground/90">{@label}</label>
+      </div>
+      <div :if={@hint} class="sr-only">{@hint}</div>
+      <textarea
+        id={@id}
+        name={@name}
+        rows={@rows}
+        class={input_component_class(@rest[:disabled] || false)}
+        {@rest}
+      >{Phoenix.HTML.Form.normalize_value("textarea", @value)}</textarea>
+      <p :if={@hint} class="mt-1.5 text-xs text-muted-foreground">{@hint}</p>
+    </div>
+    """
+  end
+
+  def input_component(assigns) do
+    assigns = assign_component_field(assigns)
+
+    ~H"""
+    <div>
+      <div class="mb-1.5 flex items-center gap-1.5">
+        <.icon :if={@icon} name={@icon} class="size-3.5 text-muted-foreground" />
+        <label for={@id} class="text-sm font-medium text-foreground/90">{@label}</label>
+      </div>
+      <div :if={@hint} class="sr-only">{@hint}</div>
+      <input
+        type={@type}
+        id={@id}
+        name={@name}
+        value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+        class={input_component_class(@rest[:disabled] || false)}
+        {@rest}
+      />
+      <p :if={@hint} class="mt-1.5 text-xs text-muted-foreground">{@hint}</p>
+    </div>
+    """
+  end
+
+  defp assign_component_field(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
+    assigns
+    |> assign(field: nil, id: assigns.id || field.id)
+    |> assign_new(:name, fn -> field.name end)
+    |> assign_new(:value, fn -> field.value end)
+  end
+
+  defp assign_component_field(assigns), do: assigns
+
+  defp input_component_class(false),
+    do:
+      "w-full resize-none rounded-xl border border-border bg-muted/30 px-3.5 py-2.5 text-sm leading-6 text-foreground placeholder:text-muted-foreground/50 transition focus:border-primary focus:bg-card focus:outline-none focus:ring-2 focus:ring-primary/30"
+
+  defp input_component_class(true),
+    do:
+      "w-full resize-none rounded-xl border border-border/60 bg-muted/30 px-3.5 py-2.5 text-sm leading-6 text-muted-foreground transition cursor-not-allowed"
+
   # Helper used by inputs to generate form errors
   defp error(assigns) do
     ~H"""

--- a/lib/controlkeel_web/components/core_components.ex
+++ b/lib/controlkeel_web/components/core_components.ex
@@ -355,7 +355,7 @@ defmodule ControlKeelWeb.CoreComponents do
 
     ~H"""
     <div>
-      <.component_field_header icon={@icon} label={@label} hint={@hint} id={@id} />
+      <.component_field_header icon={@icon} label={@label} id={@id} />
       <input
         type={@type}
         id={@id}
@@ -374,9 +374,10 @@ defmodule ControlKeelWeb.CoreComponents do
       "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm"
 
   @doc """
-  Renders a labeled textarea with the alternate soft-surface styling.
+  Renders a labeled textarea with the soft-surface styling.
 
-  See the migration note in `input_component/1`.
+  Accepts a `Phoenix.HTML.FormField` for the bound field, an optional icon
+  and hint.
 
   ## Examples
 
@@ -400,7 +401,7 @@ defmodule ControlKeelWeb.CoreComponents do
 
     ~H"""
     <div>
-      <.component_field_header icon={@icon} label={@label} hint={@hint} id={@id} />
+      <.component_field_header icon={@icon} label={@label} id={@id} />
       <textarea
         id={@id}
         name={@name}
@@ -422,7 +423,6 @@ defmodule ControlKeelWeb.CoreComponents do
       <.icon :if={@icon} name={@icon} class="size-3.5 text-muted-foreground" />
       <label for={@id} class="text-sm font-medium text-foreground/90">{@label}</label>
     </div>
-    <div :if={@hint} class="sr-only">{@hint}</div>
     """
   end
 

--- a/lib/controlkeel_web/controllers/api_controller.ex
+++ b/lib/controlkeel_web/controllers/api_controller.ex
@@ -1655,7 +1655,7 @@ defmodule ControlKeelWeb.ApiController do
       previous_review_id: review.previous_review_id,
       responded_at: review.responded_at,
       inserted_at: review.inserted_at,
-      browser_url: ControlKeelWeb.Endpoint.url() <> "/reviews/#{review.id}",
+      browser_url: ControlKeel.Mission.ReviewBridge.browser_url(review),
       task_title: review.task && review.task.title,
       previous_status: review.previous_review && review.previous_review.status
     }

--- a/lib/controlkeel_web/live/mission_control_live.ex
+++ b/lib/controlkeel_web/live/mission_control_live.ex
@@ -346,6 +346,12 @@ defmodule ControlKeelWeb.MissionControlLive do
             <p class="text-xs text-muted-foreground mt-1">
               {@observability.gates.total_reviews} total review gates
             </p>
+            <.link
+              navigate={~p"/sessions/#{@session.id}/reviews"}
+              class="inline-flex items-center gap-1 mt-2 text-xs font-semibold uppercase tracking-[0.14em] text-primary hover:text-primary transition cursor-pointer"
+            >
+              View all <.icon name="hero-arrow-right" class="size-3" />
+            </.link>
           </div>
           <div
             id="mission-observability-timeline"

--- a/lib/controlkeel_web/live/observability_live.ex
+++ b/lib/controlkeel_web/live/observability_live.ex
@@ -335,7 +335,7 @@ defmodule ControlKeelWeb.ObservabilityLive do
               <%= for review <- @run.gates.latest do %>
                 <div class="rounded-lg px-3 py-2 border bg-[rgba(255,255,255,0.02)]">
                   <.link
-                    navigate={~p"/reviews/#{review.id}"}
+                    navigate={~p"/sessions/#{review.session_id}/reviews/#{review.id}"}
                     class="text-sm font-medium text-primary hover:opacity-80 transition-opacity"
                   >
                     {review.title}

--- a/lib/controlkeel_web/live/review_live.ex
+++ b/lib/controlkeel_web/live/review_live.ex
@@ -10,8 +10,7 @@ defmodule ControlKeelWeb.ReviewLive do
      |> assign(:page_title, "Review")
      |> assign(:review, nil)
      |> assign(:diff_chunks, [])
-     |> assign(:response_form, response_form())
-     |> assign(:review_url, nil)}
+     |> assign(:response_form, response_form())}
   end
 
   @impl true
@@ -24,8 +23,7 @@ defmodule ControlKeelWeb.ReviewLive do
            socket
            |> put_flash(:error, "Review not found.")
            |> assign(:review, nil)
-           |> assign(:diff_chunks, [])
-           |> assign(:review_url, nil)}
+           |> assign(:diff_chunks, [])}
 
         %{session_id: ^session_id} = review ->
           {:noreply, assign_review(socket, review)}
@@ -35,8 +33,7 @@ defmodule ControlKeelWeb.ReviewLive do
            socket
            |> put_flash(:error, "Review not found.")
            |> assign(:review, nil)
-           |> assign(:diff_chunks, [])
-           |> assign(:review_url, nil)}
+           |> assign(:diff_chunks, [])}
       end
     else
       :error ->
@@ -80,74 +77,41 @@ defmodule ControlKeelWeb.ReviewLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <section class="mx-auto w-[min(1180px,calc(100%-2rem))] pt-8 pb-16 max-[900px]:w-[min(100%-1.25rem,1180px)] max-[900px]:pt-6">
+    <div class="space-y-8">
       <%= if @review do %>
-        <div class="flex items-center justify-between gap-4 mt-6 mb-4 max-[900px]:flex-col max-[900px]:items-start">
-          <div>
-            <h1 class="text-[clamp(2rem,4vw,3.4rem)] leading-[1.02]">{@review.title}</h1>
-            <div class="mt-4 space-y-1">
-              <p class="text-muted-foreground text-[1.05rem] leading-[1.7]">
-                Review type:
-                <span class="text-foreground">{String.capitalize(@review.review_type)}</span>
-              </p>
-              <p class="text-muted-foreground text-[1.05rem] leading-[1.7]">
-                Task:
-                <span class="text-foreground">
-                  {if @review.task, do: @review.task.title, else: "session-level submission"}
-                </span>
-              </p>
-            </div>
-          </div>
+        <.page_title title={@review.title} />
+
+        <%!-- Stat row --%>
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+          <article class="rounded-2xl border bg-card p-5 shadow-card">
+            <p class="text-sm font-medium text-muted-foreground">Review type</p>
+            <p class="mt-2 text-xl font-semibold capitalize text-foreground/90">
+              {@review.review_type}
+            </p>
+          </article>
+          <article class="rounded-2xl border bg-card p-5 shadow-card">
+            <p class="text-sm font-medium text-muted-foreground">Task</p>
+            <p class="mt-2 text-xl font-semibold text-foreground/90">
+              {if @review.task, do: @review.task.title, else: "session-level"}
+            </p>
+          </article>
+          <article class="rounded-2xl border bg-card p-5 shadow-card">
+            <p class="text-sm font-medium text-muted-foreground">Phase</p>
+            <p class="mt-2 text-xl font-semibold text-foreground/90">{review_phase(@review)}</p>
+          </article>
+          <article class="rounded-2xl border bg-card p-5 shadow-card">
+            <p class="text-sm font-medium text-muted-foreground">Submitted by</p>
+            <p class="mt-2 text-xl font-semibold text-foreground/90">
+              {@review.submitted_by || "agent"}
+            </p>
+          </article>
         </div>
 
-        <div class="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-4 mt-5">
-          <div
-            class="border bg-card rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6"
-            id="review-status-card"
-          >
-            <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-              Status
-            </p>
-            <strong>{String.capitalize(@review.status)}</strong>
-          </div>
-          <div class="border bg-card rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-              Phase
-            </p>
-            <strong>{review_phase(@review)}</strong>
-          </div>
-          <div class="border bg-card rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-              Submitted by
-            </p>
-            <strong>{@review.submitted_by || "agent"}</strong>
-          </div>
-          <div class="border bg-card rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-              Shareable URL
-            </p>
-            <a
-              class="uppercase tracking-[0.14em] text-xs text-primary font-semibold"
-              href={@review_url}
-            >
-              {@review_url}
-            </a>
-          </div>
-        </div>
-
-        <div
-          class="grid grid-cols-[minmax(0,1.35fr)_minmax(280px,0.75fr)] gap-6 max-[900px]:grid-cols-1 mt-6"
-          style="margin-top: 1rem;"
-        >
-          <div class="space-y-4">
-            <article
-              class="border bg-card rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6"
-              id="review-submission-body"
-            >
-              <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-                Submission
-              </p>
-              <pre class="m-0 p-4 border rounded-xl bg-muted/[0.03] whitespace-pre-wrap break-words font-mono text-[0.9rem] leading-[1.6]">{@review.submission_body}</pre>
+        <div class="grid gap-6 lg:grid-cols-3">
+          <div class="space-y-6 lg:col-span-2">
+            <article class="rounded-2xl border bg-card p-5 shadow-card" id="review-submission-body">
+              <.card_title>Submission</.card_title>
+              <pre class="mt-4 rounded-lg bg-muted p-4 whitespace-pre-wrap break-words font-mono text-sm leading-6">{@review.submission_body}</pre>
             </article>
 
             <article
@@ -155,34 +119,30 @@ defmodule ControlKeelWeb.ReviewLive do
                 present_plan_context?(@review, "alignment_context") or
                   present_plan_context?(@review, "consulted_roles")
               }
-              class="border bg-card rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6"
+              class="rounded-2xl border bg-card p-5 shadow-card"
               id="review-alignment-card"
             >
-              <div class="flex items-center justify-between gap-4">
-                <div>
-                  <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-                    Alignment context
-                  </p>
-                  <h2>Human context gathered before execution</h2>
-                </div>
-              </div>
+              <.card_title>Alignment context</.card_title>
+              <p class="mt-1 text-sm text-muted-foreground">
+                Human context gathered before execution
+              </p>
               <div class="mt-4 space-y-4">
                 <div :if={present_plan_context?(@review, "alignment_context")}>
-                  <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
+                  <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                     Context that shaped the plan
                   </p>
-                  <ul class="list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+                  <ul class="mt-2 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
                     <li :for={entry <- plan_context(@review, "alignment_context")}>{entry}</li>
                   </ul>
                 </div>
                 <div :if={present_plan_context?(@review, "consulted_roles")}>
-                  <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
+                  <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                     Roles consulted
                   </p>
-                  <div class="flex flex-wrap gap-2">
+                  <div class="mt-2 flex flex-wrap gap-2">
                     <span
                       :for={role <- plan_context(@review, "consulted_roles")}
-                      class="border bg-muted rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]"
+                      class="inline-flex rounded-full bg-success/10 px-2.5 py-1 text-xs font-medium text-success"
                     >
                       {role}
                     </span>
@@ -193,23 +153,17 @@ defmodule ControlKeelWeb.ReviewLive do
 
             <article
               :if={present_semantic_boundaries?(@review)}
-              class="border bg-card rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6"
+              class="rounded-2xl border bg-card p-5 shadow-card"
               id="review-semantic-boundaries-card"
             >
-              <div class="flex items-center justify-between gap-4">
-                <div>
-                  <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-                    Semantic boundaries
-                  </p>
-                  <h2>Agent execution guardrails</h2>
-                </div>
-              </div>
+              <.card_title>Semantic boundaries</.card_title>
+              <p class="mt-1 text-sm text-muted-foreground">Agent execution guardrails</p>
               <div class="mt-4 space-y-4">
                 <div :for={boundary <- semantic_boundary_sections(@review)}>
-                  <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
+                  <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                     {boundary.label}
                   </p>
-                  <ul class="list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+                  <ul class="mt-2 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
                     <li :for={entry <- boundary.entries}>{entry}</li>
                   </ul>
                 </div>
@@ -218,133 +172,140 @@ defmodule ControlKeelWeb.ReviewLive do
 
             <article
               :if={@review.previous_review}
-              class="border bg-card rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6"
+              class="rounded-2xl border bg-card p-5 shadow-card"
               id="review-diff-card"
             >
-              <div class="flex items-center justify-between gap-4">
+              <div class="flex items-center justify-between gap-3">
                 <div>
-                  <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-                    Revision diff
+                  <.card_title>Revision diff</.card_title>
+                  <p class="mt-1 text-sm text-muted-foreground">
+                    Compared with review #{@review.previous_review_id}
                   </p>
-                  <h2>Compared with review #{@review.previous_review_id}</h2>
                 </div>
-                <span class="border bg-muted rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]">
+                <span class="inline-flex rounded-full border px-2.5 py-1 text-xs text-muted-foreground">
                   Previous: {String.capitalize(@review.previous_review.status)}
                 </span>
               </div>
               <div class="mt-4 space-y-3">
                 <%= for chunk <- @diff_chunks do %>
                   <div class={diff_chunk_class(chunk.kind)}>
-                    <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
+                    <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                       {diff_chunk_label(chunk.kind)}
                     </p>
-                    <pre class="m-0 p-4 border rounded-xl bg-muted/[0.03] whitespace-pre-wrap break-words font-mono text-[0.9rem] leading-[1.6]">{chunk.text}</pre>
+                    <pre class="mt-2 whitespace-pre-wrap break-words font-mono text-sm leading-6">{chunk.text}</pre>
                   </div>
                 <% end %>
               </div>
             </article>
           </div>
 
-          <div class="space-y-4">
-            <article
-              class="border bg-card rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6"
-              id="review-response-card"
-            >
-              <div class="flex items-center justify-between gap-4">
-                <div>
-                  <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-                    Respond
-                  </p>
-                  <h2>Approve, deny, or annotate</h2>
-                </div>
-                <span class={review_status_pill_class(@review.status)}>
-                  {String.capitalize(@review.status)}
-                </span>
-              </div>
+          <div
+            class="rounded-2xl h-fit border bg-card p-5 shadow-card space-y-6"
+            id="review-response-card"
+          >
+            <div class="space-y-3">
+              <.card_title>Respond</.card_title>
 
               <.form for={@response_form} id="review-response-form" phx-submit="respond">
-                <div class="space-y-4">
-                  <.input
-                    field={@response_form[:decision]}
-                    type="select"
-                    label="Decision"
-                    options={[{"Approve", "approved"}, {"Deny", "denied"}]}
-                  />
+                <div class="flex items-center justify-between gap-3">
+                  <span class={status_text_class(@review.status)}>
+                    {String.capitalize(@review.status)}
+                  </span>
 
-                  <.input
+                  <div class="flex items-center gap-2">
+                    <button
+                      id="review-response-approve"
+                      type="submit"
+                      name="review_response[decision]"
+                      value="approved"
+                      disabled={@review.status != "pending"}
+                      class="rounded-lg bg-secondary/30 hover:bg-secondary/40 border border-border/40 px-4 py-1.5 text-xs font-semibold text-muted-foreground cursor-pointer"
+                    >
+                      Approve
+                    </button>
+                    <button
+                      id="review-response-deny"
+                      type="submit"
+                      name="review_response[decision]"
+                      value="denied"
+                      disabled={@review.status != "pending"}
+                      class="rounded-lg bg-destructive/20 hover:bg-destructive/30 border border-destructive/40 px-4 py-1.5 text-xs font-semibold text-destructive cursor-pointer"
+                    >
+                      Deny
+                    </button>
+                  </div>
+                </div>
+
+                <div class="mt-5 space-y-4">
+                  <.input_component
                     field={@response_form[:feedback_notes]}
-                    type="textarea"
                     label="Feedback notes"
-                    rows="6"
+                    placeholder="Add notes..."
+                    rows={3}
                   />
 
-                  <.input
+                  <.input_component
                     field={@response_form[:annotation_text]}
-                    type="textarea"
                     label="Annotations"
-                    rows="5"
+                    placeholder="Add notes..."
+                    rows={3}
                   />
-
-                  <button
-                    class="inline-flex items-center justify-center gap-[0.4rem] px-[1.25rem] py-[0.95rem] rounded-full bg-primary text-[#11170d] font-bold transition-[transform,box-shadow] duration-[160ms] ease-out hover:-translate-y-px hover:shadow-[0_12px_24px_rgba(196,240,66,0.24)]"
-                    id="review-response-submit"
-                    type="submit"
-                  >
-                    Save response
-                  </button>
                 </div>
               </.form>
-            </article>
+            </div>
 
-            <article
-              class="border bg-card rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6"
-              id="review-audit-card"
-            >
-              <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-                Audit trail
-              </p>
-              <div class="grid gap-4 m-0 p-0 list-none">
-                <article class="grid gap-[0.55rem] border/[0.07] rounded-[1.1rem] p-4 bg-muted/[0.03]">
-                  <div class="flex items-center justify-between gap-4">
-                    <h3>Submitted</h3>
-                    <span class="border bg-muted rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]">
-                      {format_dt(@review.inserted_at)}
-                    </span>
-                  </div>
-                  <p class="text-muted-foreground">By {@review.submitted_by || "agent"}</p>
-                </article>
-                <article
-                  :if={@review.responded_at}
-                  class="grid gap-[0.55rem] border/[0.07] rounded-[1.1rem] p-4 bg-muted/[0.03]"
-                >
-                  <div class="flex items-center justify-between gap-4">
-                    <h3>Responded</h3>
-                    <span class={review_status_pill_class(@review.status)}>
-                      {String.capitalize(@review.status)}
-                    </span>
-                  </div>
-                  <p class="text-muted-foreground">At {format_dt(@review.responded_at)}</p>
-                  <p class="text-muted-foreground">By {@review.reviewed_by || "human"}</p>
-                  <p :if={present?(@review.feedback_notes)} class="text-muted-foreground">
-                    {@review.feedback_notes}
+            <div class="space-y-3">
+              <.card_title>Audit trail</.card_title>
+
+              <div class="flex items-start gap-3">
+                <div class="flex h-6 w-6 items-center justify-center rounded-full border border-border/80 bg-muted text-muted-foreground shadow-sm">
+                  <.icon name="hero-clock" class="size-3.5" />
+                </div>
+                <div>
+                  <p class="text-sm font-semibold text-foreground">Submitted</p>
+                  <p class="mt-0.5 text-xs text-muted-foreground">
+                    {format_dt(@review.inserted_at)}
                   </p>
-                </article>
+                  <p class="mt-0.5 text-xs text-muted-foreground">
+                    By {@review.submitted_by || "agent"}
+                  </p>
+                </div>
               </div>
-            </article>
+
+              <div
+                :if={@review.responded_at || @review.status != "pending"}
+                class="flex items-start gap-3"
+              >
+                <div class={[
+                  "flex h-6 w-6 items-center justify-center rounded-full border shadow-sm",
+                  audit_timeline_icon_class(@review.status)
+                ]}>
+                  <.icon name={audit_timeline_icon_name(@review.status)} class="size-3.5" />
+                </div>
+                <div>
+                  <p class="text-sm font-semibold text-foreground">
+                    {String.capitalize(@review.status)}
+                  </p>
+                  <p class="mt-0.5 text-xs text-muted-foreground">
+                    {format_dt(@review.responded_at || @review.updated_at)}
+                  </p>
+                  <p :if={@review.reviewed_by} class="mt-0.5 text-xs text-muted-foreground">
+                    By {@review.reviewed_by}
+                  </p>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       <% else %>
-        <div
-          class="border bg-card rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6"
-          id="review-missing"
-        >
-          <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-            Browser Review
+        <section class="rounded-2xl border bg-card p-5 shadow-card" id="review-missing">
+          <.card_title>Review not found</.card_title>
+          <p class="mt-2 text-sm text-muted-foreground">
+            This review may have been removed or does not belong to this session.
           </p>
-          <h1 class="text-[clamp(2rem,4vw,3.4rem)] leading-[1.02]">Review not found</h1>
-        </div>
+        </section>
       <% end %>
-    </section>
+    </div>
     """
   end
 
@@ -352,7 +313,6 @@ defmodule ControlKeelWeb.ReviewLive do
     socket
     |> assign(:review, review)
     |> assign(:page_title, review.title)
-    |> assign(:review_url, ControlKeel.Mission.ReviewBridge.browser_url(review))
     |> assign(:diff_chunks, diff_chunks(review))
     |> assign(:response_form, response_form(review))
   end
@@ -360,17 +320,12 @@ defmodule ControlKeelWeb.ReviewLive do
   defp response_form(review \\ nil) do
     to_form(
       %{
-        "decision" => default_decision(review),
         "feedback_notes" => (review && review.feedback_notes) || "",
         "annotation_text" => annotation_text(review)
       },
       as: :review_response
     )
   end
-
-  defp default_decision(nil), do: "approved"
-  defp default_decision(review) when review.status in ["approved", "denied"], do: review.status
-  defp default_decision(_review), do: "approved"
 
   defp annotation_text(nil), do: ""
 
@@ -400,33 +355,39 @@ defmodule ControlKeelWeb.ReviewLive do
   end
 
   defp diff_chunk_class(:added),
-    do: "rounded-2xl border border-[var(--ck-success)] bg-[var(--ck-success)]/80 p-4"
+    do: "rounded-lg border border-success/20 bg-success/10 p-4"
 
   defp diff_chunk_class(:removed),
-    do: "rounded-2xl border border-destructive bg-destructive/80 p-4"
+    do: "rounded-lg border border-destructive/20 bg-destructive/10 p-4"
 
   defp diff_chunk_class(:unchanged),
-    do: "rounded-2xl border bg-muted/80 p-4"
+    do: "rounded-lg border bg-muted p-4"
 
   defp diff_chunk_label(:added), do: "Added"
   defp diff_chunk_label(:removed), do: "Removed"
   defp diff_chunk_label(:unchanged), do: "Unchanged"
 
-  defp review_status_pill_class("approved"),
-    do:
-      "border bg-muted rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]"
+  defp status_text_class("approved"), do: "text-success font-semibold text-sm"
+  defp status_text_class("denied"), do: "text-destructive font-semibold text-sm"
+  defp status_text_class("superseded"), do: "text-warning font-semibold text-sm"
+  defp status_text_class(_status), do: "text-info font-semibold text-sm"
 
-  defp review_status_pill_class("denied"),
-    do:
-      "border bg-muted rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(255,143,107,0.12)] text-[#ffd6cb]"
+  defp audit_timeline_icon_class("approved"),
+    do: "bg-success/20 border-success/40 text-success"
 
-  defp review_status_pill_class("superseded"),
-    do:
-      "border bg-muted rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(255,207,107,0.12)] text-[#fff0bf]"
+  defp audit_timeline_icon_class("denied"),
+    do: "bg-destructive/20 border-destructive/40 text-destructive"
 
-  defp review_status_pill_class(_status),
-    do:
-      "border bg-muted rounded-full px-[0.8rem] py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]"
+  defp audit_timeline_icon_class("superseded"),
+    do: "bg-warning/20 border-warning/40 text-warning"
+
+  defp audit_timeline_icon_class(_status),
+    do: "bg-muted border-border text-muted-foreground"
+
+  defp audit_timeline_icon_name("approved"), do: "hero-check"
+  defp audit_timeline_icon_name("denied"), do: "hero-x-mark"
+  defp audit_timeline_icon_name("superseded"), do: "hero-clock"
+  defp audit_timeline_icon_name(_status), do: "hero-clock"
 
   defp review_phase(review) do
     review
@@ -439,9 +400,6 @@ defmodule ControlKeelWeb.ReviewLive do
 
   defp format_dt(nil), do: "pending"
   defp format_dt(value), do: Calendar.strftime(value, "%Y-%m-%d %H:%M UTC")
-
-  defp present?(value) when is_binary(value), do: String.trim(value) != ""
-  defp present?(_value), do: false
 
   defp plan_context(review, key) do
     get_in(review.metadata || %{}, ["plan_refinement", key]) || []

--- a/lib/controlkeel_web/live/review_live.ex
+++ b/lib/controlkeel_web/live/review_live.ex
@@ -215,6 +215,44 @@ defmodule ControlKeelWeb.ReviewLive do
                 <% end %>
               </div>
             </article>
+
+            <article
+              class="rounded-2xl border bg-card p-5 shadow-card"
+              id="review-revisions-card"
+            >
+              <div class="flex items-center justify-between gap-3">
+                <.card_title>Revisions</.card_title>
+                <span class="inline-flex rounded-full border px-2.5 py-1 text-xs text-muted-foreground">
+                  {length(@review.revisions)}
+                </span>
+              </div>
+              <p class="mt-1 text-sm text-muted-foreground">
+                Later resubmissions of this review
+              </p>
+              <ul class="mt-4 space-y-3">
+                <li
+                  :for={revision <- @review.revisions}
+                  class="flex items-center justify-between gap-3"
+                >
+                  <div>
+                    <.link
+                      navigate={
+                        ~p"/sessions/#{revision.session_id || @review.session_id}/reviews/#{revision.id}"
+                      }
+                      class="font-medium text-sm hover:text-primary"
+                    >
+                      {revision.title}
+                    </.link>
+                    <p class="mt-0.5 text-xs text-muted-foreground">
+                      {String.capitalize(revision.review_type)} · {format_dt(revision.inserted_at)}
+                    </p>
+                  </div>
+                  <span class={status_text_class(revision.status)}>
+                    {String.capitalize(revision.status)}
+                  </span>
+                </li>
+              </ul>
+            </article>
           </div>
 
           <div

--- a/lib/controlkeel_web/live/review_live.ex
+++ b/lib/controlkeel_web/live/review_live.ex
@@ -15,22 +15,30 @@ defmodule ControlKeelWeb.ReviewLive do
   end
 
   @impl true
-  def handle_params(%{"id" => id}, _uri, socket) do
-    case parse_integer(id) do
-      {:ok, review_id} ->
-        case Mission.get_review_with_context(review_id) do
-          nil ->
-            {:noreply,
-             socket
-             |> put_flash(:error, "Review not found.")
-             |> assign(:review, nil)
-             |> assign(:diff_chunks, [])
-             |> assign(:review_url, nil)}
+  def handle_params(%{"rid" => rid, "sid" => sid}, _uri, socket) do
+    with {:ok, review_id} <- parse_integer(rid),
+         {:ok, session_id} <- parse_integer(sid) do
+      case Mission.get_review_with_context(review_id) do
+        nil ->
+          {:noreply,
+           socket
+           |> put_flash(:error, "Review not found.")
+           |> assign(:review, nil)
+           |> assign(:diff_chunks, [])
+           |> assign(:review_url, nil)}
 
-          review ->
-            {:noreply, assign_review(socket, review)}
-        end
+        %{session_id: ^session_id} = review ->
+          {:noreply, assign_review(socket, review)}
 
+        _review ->
+          {:noreply,
+           socket
+           |> put_flash(:error, "Review not found.")
+           |> assign(:review, nil)
+           |> assign(:diff_chunks, [])
+           |> assign(:review_url, nil)}
+      end
+    else
       :error ->
         {:noreply, put_flash(socket, :error, "Invalid review id.")}
     end
@@ -76,22 +84,20 @@ defmodule ControlKeelWeb.ReviewLive do
       <%= if @review do %>
         <div class="flex items-center justify-between gap-4 mt-6 mb-4 max-[900px]:flex-col max-[900px]:items-start">
           <div>
-            <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-              Browser Review
-            </p>
             <h1 class="text-[clamp(2rem,4vw,3.4rem)] leading-[1.02]">{@review.title}</h1>
-            <p class="text-muted-foreground text-[1.05rem] leading-[1.7] max-w-[48rem]">
-              Review type: {String.capitalize(@review.review_type)}. Task: {if @review.task,
-                do: @review.task.title,
-                else: "session-level submission"}.
-            </p>
+            <div class="mt-4 space-y-1">
+              <p class="text-muted-foreground text-[1.05rem] leading-[1.7]">
+                Review type:
+                <span class="text-foreground">{String.capitalize(@review.review_type)}</span>
+              </p>
+              <p class="text-muted-foreground text-[1.05rem] leading-[1.7]">
+                Task:
+                <span class="text-foreground">
+                  {if @review.task, do: @review.task.title, else: "session-level submission"}
+                </span>
+              </p>
+            </div>
           </div>
-          <a
-            class="uppercase tracking-[0.14em] text-xs text-primary font-semibold"
-            href={~p"/sessions/#{@review.session_id}"}
-          >
-            Open session
-          </a>
         </div>
 
         <div class="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-4 mt-5">
@@ -346,7 +352,7 @@ defmodule ControlKeelWeb.ReviewLive do
     socket
     |> assign(:review, review)
     |> assign(:page_title, review.title)
-    |> assign(:review_url, ControlKeelWeb.Endpoint.url() <> "/reviews/#{review.id}")
+    |> assign(:review_url, ControlKeel.Mission.ReviewBridge.browser_url(review))
     |> assign(:diff_chunks, diff_chunks(review))
     |> assign(:response_form, response_form(review))
   end

--- a/lib/controlkeel_web/live/review_live.ex
+++ b/lib/controlkeel_web/live/review_live.ex
@@ -45,34 +45,39 @@ defmodule ControlKeelWeb.ReviewLive do
 
   @impl true
   def handle_event("respond", %{"review_response" => params}, socket) do
-    review = socket.assigns.review
-
-    annotations =
-      case String.trim(params["annotation_text"] || "") do
-        "" -> %{}
-        text -> %{"browser_notes" => text}
-      end
-
-    case Mission.respond_review(review, %{
-           "decision" => params["decision"],
-           "feedback_notes" => params["feedback_notes"],
-           "annotations" => annotations,
-           "reviewed_by" => "browser"
-         }) do
-      {:ok, updated_review} ->
-        {:noreply,
-         socket
-         |> assign_review(updated_review)
-         |> put_flash(:info, "Review response saved.")}
-
-      {:error, {:invalid_arguments, message}} ->
-        {:noreply, put_flash(socket, :error, message)}
-
-      {:error, :not_found} ->
+    case socket.assigns.review do
+      nil ->
         {:noreply, put_flash(socket, :error, "Review not found.")}
 
-      {:error, reason} ->
-        {:noreply, put_flash(socket, :error, "Failed to respond to review: #{inspect(reason)}")}
+      review ->
+        annotations =
+          case String.trim(params["annotation_text"] || "") do
+            "" -> %{}
+            text -> %{"browser_notes" => text}
+          end
+
+        case Mission.respond_review(review, %{
+               "decision" => params["decision"],
+               "feedback_notes" => params["feedback_notes"],
+               "annotations" => annotations,
+               "reviewed_by" => "browser"
+             }) do
+          {:ok, updated_review} ->
+            {:noreply,
+             socket
+             |> assign_review(updated_review)
+             |> put_flash(:info, "Review response saved.")}
+
+          {:error, {:invalid_arguments, message}} ->
+            {:noreply, put_flash(socket, :error, message)}
+
+          {:error, :not_found} ->
+            {:noreply, put_flash(socket, :error, "Review not found.")}
+
+          {:error, reason} ->
+            {:noreply,
+             put_flash(socket, :error, "Failed to respond to review: #{inspect(reason)}")}
+        end
     end
   end
 

--- a/lib/controlkeel_web/live/review_live.ex
+++ b/lib/controlkeel_web/live/review_live.ex
@@ -13,6 +13,8 @@ defmodule ControlKeelWeb.ReviewLive do
      |> assign(:response_form, response_form())}
   end
 
+  # TODO(security): backend endpoints/contexts lack per-user auth/token checks.
+  # See https://github.com/aryaminus/controlkeel/issues/83
   @impl true
   def handle_params(%{"rid" => rid, "sid" => sid}, _uri, socket) do
     with {:ok, review_id} <- parse_integer(rid),

--- a/lib/controlkeel_web/live/review_live.ex
+++ b/lib/controlkeel_web/live/review_live.ex
@@ -213,42 +213,41 @@ defmodule ControlKeelWeb.ReviewLive do
                   </span>
 
                   <div class="flex items-center gap-2">
-                    <button
+                    <.button
                       id="review-response-approve"
                       type="submit"
                       name="review_response[decision]"
                       value="approved"
                       disabled={@review.status != "pending"}
-                      class="rounded-lg bg-secondary/30 hover:bg-secondary/40 border border-border/40 px-4 py-1.5 text-xs font-semibold text-muted-foreground cursor-pointer"
                     >
                       Approve
-                    </button>
-                    <button
+                    </.button>
+                    <.button
                       id="review-response-deny"
                       type="submit"
+                      variant="destructive"
                       name="review_response[decision]"
                       value="denied"
                       disabled={@review.status != "pending"}
-                      class="rounded-lg bg-destructive/20 hover:bg-destructive/30 border border-destructive/40 px-4 py-1.5 text-xs font-semibold text-destructive cursor-pointer"
                     >
                       Deny
-                    </button>
+                    </.button>
                   </div>
                 </div>
 
                 <div class="mt-5 space-y-4">
-                  <.input_component
+                  <.textarea
                     field={@response_form[:feedback_notes]}
                     label="Feedback notes"
                     placeholder="Add notes..."
-                    rows={3}
+                    class="resize-none h-24"
                   />
 
-                  <.input_component
+                  <.textarea
                     field={@response_form[:annotation_text]}
                     label="Annotations"
                     placeholder="Add notes..."
-                    rows={3}
+                    class="resize-none h-24"
                   />
                 </div>
               </.form>

--- a/lib/controlkeel_web/live/review_live.ex
+++ b/lib/controlkeel_web/live/review_live.ex
@@ -110,8 +110,19 @@ defmodule ControlKeelWeb.ReviewLive do
         <div class="grid gap-6 lg:grid-cols-3">
           <div class="space-y-6 lg:col-span-2">
             <article class="rounded-2xl border bg-card p-5 shadow-card" id="review-submission-body">
-              <.card_title>Submission</.card_title>
-              <pre class="mt-4 rounded-lg bg-muted p-4 whitespace-pre-wrap break-words font-mono text-sm leading-6">{@review.submission_body}</pre>
+              <div class="flex items-center justify-between gap-3">
+                <.card_title>Submission</.card_title>
+                <.button
+                  type="button"
+                  variant="outline"
+                  phx-click={
+                    JS.dispatch("phx:copy-to-clipboard", detail: %{text: @review.submission_body})
+                  }
+                >
+                  <.icon name="hero-clipboard" class="size-3.5" /> Copy
+                </.button>
+              </div>
+              <pre class="mt-4 rounded-lg bg-muted p-4 whitespace-pre-wrap break-words font-mono text-xs leading-6 overflow-y-auto max-h-96">{@review.submission_body}</pre>
             </article>
 
             <article
@@ -186,13 +197,13 @@ defmodule ControlKeelWeb.ReviewLive do
                   Previous: {String.capitalize(@review.previous_review.status)}
                 </span>
               </div>
-              <div class="mt-4 space-y-3">
+              <div class="mt-4 space-y-3 overflow-y-auto max-h-96">
                 <%= for chunk <- @diff_chunks do %>
                   <div class={diff_chunk_class(chunk.kind)}>
                     <p class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                       {diff_chunk_label(chunk.kind)}
                     </p>
-                    <pre class="mt-2 whitespace-pre-wrap break-words font-mono text-sm leading-6">{chunk.text}</pre>
+                    <pre class="mt-2 whitespace-pre-wrap break-words font-mono text-xs leading-6">{chunk.text}</pre>
                   </div>
                 <% end %>
               </div>

--- a/lib/controlkeel_web/live/session_reviews_live.ex
+++ b/lib/controlkeel_web/live/session_reviews_live.ex
@@ -1,0 +1,180 @@
+defmodule ControlKeelWeb.SessionReviewsLive do
+  use ControlKeelWeb, :live_view
+
+  alias ControlKeel.Mission
+
+  @refresh_interval_ms 2_000
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    org_id = socket.assigns[:current_org_id]
+
+    case Mission.get_session_context(id) do
+      nil ->
+        {:ok,
+         socket
+         |> put_flash(:error, "Session not found.")
+         |> push_navigate(to: ~p"/")}
+
+      session when not is_nil(org_id) and not is_nil(session) ->
+        if session_accessible?(session, org_id) do
+          {:ok, mount_session(socket, session)}
+        else
+          {:ok,
+           socket
+           |> put_flash(:error, "Session not found.")
+           |> push_navigate(to: ~p"/")}
+        end
+
+      session ->
+        {:ok, mount_session(socket, session)}
+    end
+  end
+
+  @impl true
+  def handle_info(:refresh, socket) do
+    if connected?(socket), do: schedule_refresh()
+    {:noreply, assign_reviews(socket)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <section class="mx-auto max-w-[1180px] w-full px-4 pt-8 pb-16">
+      <div class="mb-8">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div class="space-y-1">
+            <h2 class="text-2xl font-semibold text-primary leading-6 tracking-wide uppercase">
+              Review queue
+            </h2>
+            <p class="text-muted-foreground">
+              Plan, diff, and completion submissions for {@session.title}.
+            </p>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-5 max-w-lg">
+          <div class="p-5 rounded-3xl border bg-card/70 backdrop-blur-xl shadow-lg">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-primary mb-1">
+              Total
+            </p>
+            <strong>{@review_counts.total} total</strong>
+          </div>
+          <div class="p-5 rounded-3xl border bg-card/70 backdrop-blur-xl shadow-lg">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-primary mb-1">
+              Pending
+            </p>
+            <strong>{@review_counts.pending} pending</strong>
+          </div>
+          <div class="p-5 rounded-3xl border bg-card/70 backdrop-blur-xl shadow-lg">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-primary mb-1">
+              Resolved
+            </p>
+            <strong>{resolved_count(@reviews)} resolved</strong>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-card border rounded-2xl shadow-card overflow-clip">
+        <table class="min-w-full divide-y divide-border text-left text-sm">
+          <thead class="bg-muted text-xs uppercase tracking-[0.14em] text-muted-foreground">
+            <tr>
+              <th class="px-5 py-3 font-semibold">Review</th>
+              <th class="px-5 py-3 font-semibold">Task</th>
+              <th class="px-5 py-3 font-semibold">Type</th>
+              <th class="px-5 py-3 font-semibold">Submitted by</th>
+              <th class="px-5 py-3 font-semibold">Date</th>
+              <th class="px-5 py-3 font-semibold text-right">Status</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-border">
+            <%= for review <- @reviews do %>
+              <tr class="transition hover:bg-muted/30">
+                <td class="px-5 py-4">
+                  <.link
+                    navigate={~p"/sessions/#{@session.id}/reviews/#{review.id}"}
+                    class="font-medium text-foreground hover:text-primary"
+                  >
+                    {review.title}
+                  </.link>
+                </td>
+                <td class="px-5 py-4 text-muted-foreground">
+                  {if review.task, do: review.task.title, else: "Session-level"}
+                </td>
+                <td class="px-5 py-4 text-muted-foreground capitalize">{review.review_type}</td>
+                <td class="px-5 py-4 text-muted-foreground">{review.submitted_by || "agent"}</td>
+                <td class="px-5 py-4 text-muted-foreground whitespace-nowrap font-mono tabular-nums tracking-tight">
+                  {event_timestamp(review.inserted_at)}
+                </td>
+                <td class="px-5 py-4 text-right">
+                  <span class={review_status_pill_class(review.status)}>{review.status}</span>
+                </td>
+              </tr>
+            <% end %>
+            <%= if @reviews == [] do %>
+              <tr>
+                <td colspan="6" class="px-5 py-12 text-center">
+                  <p class="text-base font-medium text-foreground">No reviews yet.</p>
+                  <p class="mt-1 text-sm text-muted-foreground">
+                    Agent plan, diff, or completion submissions for this session appear here.
+                  </p>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </section>
+    """
+  end
+
+  defp mount_session(socket, session) do
+    if connected?(socket), do: schedule_refresh()
+
+    socket
+    |> assign(:page_title, "#{session.title} — Reviews")
+    |> assign(:session, session)
+    |> assign_reviews()
+  end
+
+  defp assign_reviews(socket) do
+    session_id = socket.assigns.session.id
+
+    socket
+    |> assign(:reviews, Mission.list_reviews_for_session(session_id))
+    |> assign(:review_counts, Mission.session_review_counts(session_id))
+  end
+
+  defp schedule_refresh, do: Process.send_after(self(), :refresh, @refresh_interval_ms)
+
+  defp resolved_count(reviews) do
+    Enum.count(reviews, &(&1.status in ["approved", "denied", "superseded"]))
+  end
+
+  defp event_timestamp(nil), do: "unknown"
+
+  defp event_timestamp(%DateTime{} = timestamp),
+    do: Calendar.strftime(timestamp, "%Y-%m-%d %H:%M:%S UTC")
+
+  defp review_status_pill_class("approved"),
+    do:
+      "inline-flex rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1 bg-success/10 text-success ring-success/20"
+
+  defp review_status_pill_class("denied"),
+    do:
+      "inline-flex rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1 bg-destructive/10 text-destructive ring-destructive/20"
+
+  defp review_status_pill_class("superseded"),
+    do:
+      "inline-flex rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1 bg-warning/10 text-warning ring-warning/20"
+
+  defp review_status_pill_class(_status),
+    do:
+      "inline-flex rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1 bg-info/10 text-info ring-info/20"
+
+  defp session_accessible?(%{workspace_id: ws_id}, org_id) when is_integer(org_id) do
+    org_id
+    |> ControlKeel.Accounts.list_workspaces_for_org()
+    |> Enum.any?(fn ws -> ws.id == ws_id end)
+  end
+end

--- a/lib/controlkeel_web/live/session_reviews_live.ex
+++ b/lib/controlkeel_web/live/session_reviews_live.ex
@@ -40,39 +40,15 @@ defmodule ControlKeelWeb.SessionReviewsLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <section class="mx-auto max-w-[1180px] w-full px-4 pt-8 pb-16">
-      <div class="mb-8">
-        <div class="flex flex-wrap items-start justify-between gap-4">
-          <div class="space-y-1">
-            <h2 class="text-2xl font-semibold text-primary leading-6 tracking-wide uppercase">
-              Review queue
-            </h2>
-            <p class="text-muted-foreground">
-              Plan, diff, and completion submissions for {@session.title}.
-            </p>
-          </div>
-        </div>
+    <div class="space-y-8">
+      <.page_title title={"Review queue: #{@session.title}"} />
 
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-5 max-w-lg">
-          <div class="p-5 rounded-3xl border bg-card/70 backdrop-blur-xl shadow-lg">
-            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-primary mb-1">
-              Total
-            </p>
-            <strong>{@review_counts.total} total</strong>
-          </div>
-          <div class="p-5 rounded-3xl border bg-card/70 backdrop-blur-xl shadow-lg">
-            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-primary mb-1">
-              Pending
-            </p>
-            <strong>{@review_counts.pending} pending</strong>
-          </div>
-          <div class="p-5 rounded-3xl border bg-card/70 backdrop-blur-xl shadow-lg">
-            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-primary mb-1">
-              Resolved
-            </p>
-            <strong>{resolved_count(@reviews)} resolved</strong>
-          </div>
-        </div>
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+        <span>{@review_counts.total} total</span>
+        <span aria-hidden="true" class="size-1.5 rounded-full bg-warning" />
+        <span>{@review_counts.pending} pending</span>
+        <span aria-hidden="true" class="size-1.5 rounded-full bg-success" />
+        <span>{resolved_count(@reviews)} resolved</span>
       </div>
 
       <div class="bg-card border rounded-2xl shadow-card overflow-clip">
@@ -83,8 +59,8 @@ defmodule ControlKeelWeb.SessionReviewsLive do
               <th class="px-5 py-3 font-semibold">Task</th>
               <th class="px-5 py-3 font-semibold">Type</th>
               <th class="px-5 py-3 font-semibold">Submitted by</th>
-              <th class="px-5 py-3 font-semibold">Date</th>
-              <th class="px-5 py-3 font-semibold text-right">Status</th>
+              <th class="px-5 py-3 font-semibold w-px whitespace-nowrap">Date</th>
+              <th class="px-5 py-3 font-semibold w-px whitespace-nowrap text-right">Status</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-border">
@@ -103,10 +79,10 @@ defmodule ControlKeelWeb.SessionReviewsLive do
                 </td>
                 <td class="px-5 py-4 text-muted-foreground capitalize">{review.review_type}</td>
                 <td class="px-5 py-4 text-muted-foreground">{review.submitted_by || "agent"}</td>
-                <td class="px-5 py-4 text-muted-foreground whitespace-nowrap font-mono tabular-nums tracking-tight">
+                <td class="px-5 py-4 text-muted-foreground whitespace-nowrap w-px font-mono tabular-nums tracking-tight">
                   {event_timestamp(review.inserted_at)}
                 </td>
-                <td class="px-5 py-4 text-right">
+                <td class="px-5 py-4 text-right whitespace-nowrap w-px">
                   <span class={review_status_pill_class(review.status)}>{review.status}</span>
                 </td>
               </tr>
@@ -124,7 +100,7 @@ defmodule ControlKeelWeb.SessionReviewsLive do
           </tbody>
         </table>
       </div>
-    </section>
+    </div>
     """
   end
 

--- a/lib/controlkeel_web/live/session_reviews_live.ex
+++ b/lib/controlkeel_web/live/session_reviews_live.ex
@@ -48,7 +48,7 @@ defmodule ControlKeelWeb.SessionReviewsLive do
         <span aria-hidden="true" class="size-1.5 rounded-full bg-warning" />
         <span>{@review_counts.pending} pending</span>
         <span aria-hidden="true" class="size-1.5 rounded-full bg-success" />
-        <span>{resolved_count(@reviews)} resolved</span>
+        <span>{@review_counts.total - @review_counts.pending} resolved</span>
       </div>
 
       <div class="bg-card border rounded-2xl shadow-card overflow-clip">
@@ -122,10 +122,6 @@ defmodule ControlKeelWeb.SessionReviewsLive do
   end
 
   defp schedule_refresh, do: Process.send_after(self(), :refresh, @refresh_interval_ms)
-
-  defp resolved_count(reviews) do
-    Enum.count(reviews, &(&1.status in ["approved", "denied", "superseded"]))
-  end
 
   defp event_timestamp(nil), do: "unknown"
 

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -83,12 +83,13 @@ defmodule ControlKeelWeb.Router do
       live "/sessions", MissionsLive, :index
       live "/sessions/start", OnboardingLive, :new
       live "/sessions/:id", MissionControlLive, :show
+      live "/sessions/:id/reviews", SessionReviewsLive, :index
       live "/findings", FindingsLive, :index
       live "/benchmarks", BenchmarksLive, :index
       live "/benchmarks/runs/:id", BenchmarksLive, :show
       live "/proofs", ProofBrowserLive, :index
       live "/proofs/:id", ProofBrowserLive, :show
-      live "/reviews/:id", ReviewLive, :show
+      live "/sessions/:sid/reviews/:rid", ReviewLive, :show
       live "/cloud/telemetry", CloudTelemetryLive, :index
       live "/cloud/projects", CloudProjectsLive, :index
       live "/cloud/projects/:ws_id", CloudProjectsLive, :show

--- a/test/controlkeel/cli_new_commands_test.exs
+++ b/test/controlkeel/cli_new_commands_test.exs
@@ -296,7 +296,11 @@ defmodule ControlKeel.CLI.NewCommandsTest do
                  tmp_dir
                )
 
-      assert Enum.any?(open_lines, &String.contains?(&1, "/reviews/#{review.id}"))
+      assert Enum.any?(
+               open_lines,
+               &String.contains?(&1, "/sessions/#{review.session_id}/reviews/#{review.id}")
+             )
+
       assert Enum.any?(open_lines, &String.contains?(&1, "Review server serving:"))
       assert Enum.any?(open_lines, &String.contains?(&1, "Opened browser: false"))
 
@@ -433,7 +437,7 @@ defmodule ControlKeel.CLI.NewCommandsTest do
 
       assert is_integer(review_id)
       assert get_in(payload, ["review", "task_id"]) == task.id
-      assert payload["browser_url"] =~ "/reviews/#{review_id}"
+      assert payload["browser_url"] =~ "/sessions/#{session.id}/reviews/#{review_id}"
 
       assert {:ok, [open_json]} =
                CLI.run_command(
@@ -442,7 +446,7 @@ defmodule ControlKeel.CLI.NewCommandsTest do
                )
 
       open_payload = decode_cli_json(open_json)
-      assert open_payload["browser_url"] =~ "/reviews/#{review_id}"
+      assert open_payload["browser_url"] =~ "/sessions/#{session.id}/reviews/#{review_id}"
       assert open_payload["open_target"] == "manual"
       assert open_payload["opened"] == false
       assert open_payload["remote"] == true
@@ -545,7 +549,7 @@ defmodule ControlKeel.CLI.NewCommandsTest do
       assert wait_payload["timed_out"] == true
       assert wait_payload["status"] == "pending"
       assert get_in(wait_payload, ["review", "status"]) == "pending"
-      assert wait_payload["browser_url"] =~ "/reviews/#{review.id}"
+      assert wait_payload["browser_url"] =~ "/sessions/#{review.session_id}/reviews/#{review.id}"
     end
   end
 

--- a/test/controlkeel_web/controllers/api_controller_test.exs
+++ b/test/controlkeel_web/controllers/api_controller_test.exs
@@ -249,7 +249,7 @@ defmodule ControlKeelWeb.ApiControllerTest do
 
       assert %{"review" => review} = json_response(conn, 201)
       assert review["status"] == "pending"
-      assert review["browser_url"] =~ "/reviews/"
+      assert review["browser_url"] =~ "/reviews/#{review["id"]}"
 
       conn = build_conn() |> get(~p"/api/v1/reviews/#{review["id"]}")
       assert %{"review" => fetched} = json_response(conn, 200)

--- a/test/controlkeel_web/live/mission_control_live_test.exs
+++ b/test/controlkeel_web/live/mission_control_live_test.exs
@@ -146,6 +146,18 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
     assert html =~ "mission-observability-recommendations"
   end
 
+  test "mission control links to the session review queue page", %{conn: conn} do
+    session = session_fixture()
+    review_fixture(%{session: session, submitted_by: "opencode"})
+
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}")
+
+    assert html =~ "1 total review gates"
+    assert html =~ "1 pending"
+    assert html =~ "/sessions/#{session.id}/reviews"
+    assert html =~ "View all"
+  end
+
   test "mission control refreshes when new findings and spend data appear", %{conn: conn} do
     session = session_fixture(%{spent_cents: 600, budget_cents: 5_000})
     task_fixture(%{session: session})

--- a/test/controlkeel_web/live/review_live_test.exs
+++ b/test/controlkeel_web/live/review_live_test.exs
@@ -106,4 +106,21 @@ defmodule ControlKeelWeb.ReviewLiveTest do
     assert html =~ "Audit trail"
     assert html =~ "Submitted"
   end
+
+  test "respond with no review loaded flashes an error instead of raising" do
+    socket = %Phoenix.LiveView.Socket{
+      assigns: %{__changed__: %{}, review: nil, flash: %{}}
+    }
+
+    assert {:noreply, socket} =
+             ControlKeelWeb.ReviewLive.handle_event(
+               "respond",
+               %{
+                 "review_response" => %{"decision" => "approved"}
+               },
+               socket
+             )
+
+    assert socket.assigns.flash["error"] == "Review not found."
+  end
 end

--- a/test/controlkeel_web/live/review_live_test.exs
+++ b/test/controlkeel_web/live/review_live_test.exs
@@ -123,4 +123,38 @@ defmodule ControlKeelWeb.ReviewLiveTest do
 
     assert socket.assigns.flash["error"] == "Review not found."
   end
+
+  test "review live renders later resubmissions as revisions", %{conn: conn} do
+    session = session_fixture()
+    task = task_fixture(%{session: session, status: "queued", title: "Revision rendering"})
+
+    assert {:ok, parent} =
+             Mission.submit_review(%{
+               "task_id" => task.id,
+               "review_type" => "plan",
+               "submission_body" => "Original plan submission",
+               "title" => "Original plan"
+             })
+
+    assert {:ok, revision} =
+             Mission.submit_review(%{
+               "task_id" => task.id,
+               "review_type" => "plan",
+               "submission_body" => "Revised plan submission",
+               "title" => "Revised plan",
+               "previous_review_id" => parent.id
+             })
+
+    {:ok, view, html} = live(conn, ~p"/sessions/#{parent.session_id}/reviews/#{parent.id}")
+
+    assert html =~ "Revisions"
+    assert html =~ "Later resubmissions of this review"
+    assert html =~ "Revised plan"
+
+    assert view
+           |> element("#review-revisions-card a[href*='reviews/#{revision.id}']")
+           |> render()
+
+    assert html =~ String.capitalize(revision.status)
+  end
 end

--- a/test/controlkeel_web/live/review_live_test.exs
+++ b/test/controlkeel_web/live/review_live_test.exs
@@ -80,4 +80,30 @@ defmodule ControlKeelWeb.ReviewLiveTest do
     assert html =~ "Harness quality checks"
     assert html =~ "Proof metadata is preserved"
   end
+
+  test "review live renders respond header controls, textareas, and audit trail timeline", %{
+    conn: conn
+  } do
+    session = session_fixture()
+    task = task_fixture(%{session: session, status: "queued", title: "Respond UI test"})
+
+    assert {:ok, review} =
+             Mission.submit_review(%{
+               "task_id" => task.id,
+               "review_type" => "plan",
+               "submission_body" => "Plan submission for UI test"
+             })
+
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{review.session_id}/reviews/#{review.id}")
+
+    assert html =~ "Respond"
+    assert html =~ "Pending"
+    assert html =~ "Approve"
+    assert html =~ "Deny"
+    assert html =~ "Feedback notes"
+    assert html =~ "Annotations"
+    assert html =~ "placeholder=\"Add notes...\""
+    assert html =~ "Audit trail"
+    assert html =~ "Submitted"
+  end
 end

--- a/test/controlkeel_web/live/review_live_test.exs
+++ b/test/controlkeel_web/live/review_live_test.exs
@@ -34,7 +34,7 @@ defmodule ControlKeelWeb.ReviewLiveTest do
                "validation_plan" => ["mix test test/controlkeel_web/live/review_live_test.exs"]
              })
 
-    {:ok, _view, html} = live(conn, ~p"/reviews/#{review.id}")
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{review.session_id}/reviews/#{review.id}")
 
     assert html =~ "Human context gathered before execution"
     assert html =~ "PM confirmed the rollout should stay behind approval gates."
@@ -66,7 +66,7 @@ defmodule ControlKeelWeb.ReviewLiveTest do
                "harness_quality_checks" => ["Proof metadata is preserved"]
              })
 
-    {:ok, _view, html} = live(conn, ~p"/reviews/#{review.id}")
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{review.session_id}/reviews/#{review.id}")
 
     assert html =~ "Agent execution guardrails"
     assert html =~ "Allowed semantic changes"

--- a/test/controlkeel_web/live/session_reviews_live_test.exs
+++ b/test/controlkeel_web/live/session_reviews_live_test.exs
@@ -1,0 +1,69 @@
+defmodule ControlKeelWeb.SessionReviewsLiveTest do
+  use ControlKeelWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import ControlKeel.MissionFixtures
+
+  alias ControlKeel.Mission
+
+  test "session reviews lists the reviews for the session", %{conn: conn} do
+    session = session_fixture()
+    review = review_fixture(%{session: session, submitted_by: "opencode"})
+
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}/reviews")
+
+    assert html =~ "Review queue"
+    assert html =~ review.title
+    assert html =~ "/sessions/#{session.id}/reviews/#{review.id}"
+    assert html =~ "plan"
+    assert html =~ "pending"
+    assert html =~ "opencode"
+    assert html =~ "1 total"
+    assert html =~ "1 pending"
+    assert html =~ "/sessions/#{session.id}"
+  end
+
+  test "session reviews shows the task that a review is scoped to", %{conn: conn} do
+    session = session_fixture()
+    task = task_fixture(%{session: session, title: "Risky plan task"})
+    review_fixture(%{session: session, task: task})
+
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}/reviews")
+
+    assert html =~ "Risky plan task"
+  end
+
+  test "session reviews shows an empty state", %{conn: conn} do
+    session = session_fixture()
+
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}/reviews")
+
+    assert html =~ "Review queue"
+    assert html =~ "No reviews yet."
+    assert html =~ "0 total"
+    assert html =~ "0 pending"
+  end
+
+  test "session reviews updates pending counts after a review is decided", %{conn: conn} do
+    session = session_fixture()
+    review = review_fixture(%{session: session})
+
+    {:ok, view, html} = live(conn, ~p"/sessions/#{session.id}/reviews")
+    assert html =~ "1 pending"
+    assert html =~ "pending"
+
+    assert {:ok, _updated} = Mission.respond_review(review, %{"decision" => "approved"})
+    send(view.pid, :refresh)
+
+    refreshed_html = render(view)
+
+    assert refreshed_html =~ "0 pending"
+    assert refreshed_html =~ "1 resolved"
+    assert refreshed_html =~ "approved"
+  end
+
+  test "session reviews redirects when the session does not exist", %{conn: conn} do
+    assert {:error, {:live_redirect, %{to: "/", flash: %{"error" => "Session not found."}}}} =
+             live(conn, ~p"/sessions/999999/reviews")
+  end
+end


### PR DESCRIPTION
Builds the human half of the review lifecycle in the browser: discover, inspect, and respond to agent-submitted reviews. Review *producing* (submit/diff/pr/wait) stays CLI/MCP-only; the web owns the discover → inspect → respond loop.

Before this branch the web could only *respond* to a review you already had a URL for (`/reviews/:id`); there was no way to find reviews. This closes that gap.

## What changed

- **Nested routes** (`router.ex:86,92`): `GET /sessions/:id/reviews` → `SessionReviewsLive` (index), `GET /sessions/:sid/reviews/:rid` → `ReviewLive` (detail, with ownership check `review.session_id == sid`).
- **SessionReviewsLive** — session-scoped review queue (status/phase/submitted-by), resolved counts as `total - pending`.
- **ReviewLive** — redesigned with app-standard components. Cards: shareable URL (via `ReviewBridge`), alignment context, semantic boundaries, revision diff vs `previous_review`, **Revisions** (forward chain — direct children via `has_many :revisions, foreign_key: :previous_review_id`), respond (approve/deny + notes), audit trail.
- **ReviewBridge** (`lib/controlkeel/mission/review_bridge.ex`) — central `${Endpoint.url()}/sessions/:sid/reviews/:rid` used by all six URL emitters (cli, `ck_review_submit`, `review_helpers`, api_controller, review_live) + `open_review/2`, `wait_for_review/2`, nil-safe guards.
- **Robustness fixes** — nil-review respond → flash error instead of crash; `browser_url` no longer raises on missing env/endpoint.
- **Perf note** — the detail preload originally dropped `:revisions` as unused; restored once the Revisions card became a real feature.

## Testing

- New/updated LiveView tests for queue rendering, resolved counts, alignment/semantic cards, revisions card, respond guards.

## What's missing from the issue, and why the plan changed

The issue plan #77 proposed more than this branch delivers:

- **G1 submission compose flow** (paste diff/PR → governance review → "submit for browser review") — still not built. Compose is agent-orchestrated and needs local repo state a browser can't reach; the branch ships only the consumer half.
- **Index compose entry + inline respond actions** — issue wanted them on `/sessions/:id/reviews`; the index lists and links only, respond lives on detail.
- **Stale `/reviews/:rid` links** — accepted breaking change (no alias per AGENTS.md); old shared URLs 404.

Additions beyond the issue (from code review/UI pass): the **Revisions card** (+`revisions` preload), **nil-respond/browser_url hardening**, **standardized components**, and an unrelated `config/dev.exs` DB-path change (scope creep).

**Why it narrowed:** the issue framed this as "close the submission gap" — implementation shipped the consumer half first and left the actual submit gap (G1 compose) open; the rest is review-driven hardening and UI polish.