### PR TITLE
🎨 Palette: Add accessible focus and ARIA labels to finding fix modal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Standardize keyboard focus states
+**Learning:** Found multiple icon-only close buttons lacking explicit keyboard focus outlines, leading to poor keyboard accessibility.
+**Action:** Always add `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded` to icon-only buttons to ensure they are visible to keyboard users.

--- a/lib/controlkeel_web/live/findings_live.ex
+++ b/lib/controlkeel_web/live/findings_live.ex
@@ -518,7 +518,8 @@ defmodule ControlKeelWeb.FindingsLive do
         <div class="relative rounded-lg border bg-card shadow-2xl p-8 w-full max-w-2xl mx-4 space-y-4">
           <button
             type="button"
-            class="absolute top-2 right-2 text-muted-foreground hover:text-foreground transition"
+            class="absolute top-2 right-2 text-muted-foreground hover:text-foreground transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
+            aria-label="Close guided fix"
             phx-click="close_fix"
           >
             <.icon name="hero-x-mark" class="w-5 h-5" />


### PR DESCRIPTION
### 💡 What
Added an `aria-label` and `focus-visible` ring to the close button of the Guided Fix modal in `findings_live.ex`.

### 🎯 Why
Icon-only buttons are inaccessible to screen readers without an `aria-label`. Furthermore, lacking an explicit focus ring makes it difficult for keyboard users to see when the button is focused.

### 📸 Before/After
*(Visual change only applies to focus state)*
Before: Keyboard focus was unstyled, making it invisible. Screen readers would not read the button's purpose clearly.
After: Keyboard focus displays a clear primary-colored ring. Screen readers announce "Close guided fix".

### ♿ Accessibility
- Added `aria-label="Close guided fix"` for screen readers.
- Added explicit keyboard focus classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded`) to make the active element visible.

---
*PR created automatically by Jules for task [11249375867007662082](https://jules.google.com/task/11249375867007662082) started by @aryaminus*