### PR TITLE
⚡ Bolt: [performance improvement] Optimize Elixir list counting patterns

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-08-14 - Optimize Elixir List Counting Operations
+**Learning:** Elixir's `length(Enum.filter(...))` and `Enum.map(...) |> Enum.uniq() |> length()` cause unnecessary intermediate list allocations, which can add overhead on large collections.
+**Action:** Use `Enum.count/2` instead of `length(Enum.filter/2)`, and use `MapSet.new/2 |> MapSet.size()` instead of `Enum.map/2 |> Enum.uniq/1 |> length/1` to compute unique counts efficiently without intermediate lists.

--- a/lib/controlkeel/cloud/baseline_analyzer.ex
+++ b/lib/controlkeel/cloud/baseline_analyzer.ex
@@ -94,7 +94,8 @@ defmodule ControlKeel.Cloud.BaselineAnalyzer do
       )
       |> Repo.all()
 
-    sample_sessions = rows |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+    # ⚡ Bolt: Use MapSet.new/2 |> MapSet.size() to avoid intermediate list allocations
+    sample_sessions = rows |> MapSet.new(& &1.session_id) |> MapSet.size()
 
     baseline =
       rows

--- a/lib/controlkeel/governance.ex
+++ b/lib/controlkeel/governance.ex
@@ -555,7 +555,8 @@ defmodule ControlKeel.Governance do
   end
 
   defp review_summary(decision, findings, fragments) do
-    files_reviewed = fragments |> Enum.map(& &1.path) |> Enum.uniq() |> length()
+    # ⚡ Bolt: Use MapSet.new/2 |> MapSet.size() to avoid intermediate list allocations
+    files_reviewed = fragments |> MapSet.new(& &1.path) |> MapSet.size()
     chunks_reviewed = length(fragments)
     added_lines_reviewed = Enum.reduce(fragments, 0, &(&1.added_line_count + &2))
 

--- a/lib/controlkeel/mcp/tool_group_tracker.ex
+++ b/lib/controlkeel/mcp/tool_group_tracker.ex
@@ -162,8 +162,9 @@ defmodule ControlKeel.MCP.ToolGroupTracker do
     else
       total_calls = entries |> Enum.map(fn {_key, _ts, count} -> count end) |> Enum.sum()
 
+      # ⚡ Bolt: Use MapSet.new/2 |> MapSet.size() to avoid intermediate list allocations
       unique_tools =
-        entries |> Enum.map(fn {key, _ts, _count} -> key end) |> Enum.uniq() |> length()
+        entries |> MapSet.new(fn {key, _ts, _count} -> key end) |> MapSet.size()
 
       %{total_calls: total_calls, unique_tools: unique_tools}
     end

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -524,7 +524,8 @@ defmodule ControlKeel.Observability do
       benchmark_drafts: drafts.count,
       approved_drafts: approved_drafts,
       materialized_scenarios: length(scenario_ids),
-      covered_scenarios: length(Enum.filter(scenario_ids, &(&1 in covered_ids))),
+      # ⚡ Bolt: optimized list operations to avoid intermediate list allocations
+      covered_scenarios: Enum.count(scenario_ids, &(&1 in covered_ids)),
       benchmark_runs: length(runs)
     }
 
@@ -1698,7 +1699,8 @@ defmodule ControlKeel.Observability do
       input_tokens: sum_invocation_field(invocations, :input_tokens),
       cached_input_tokens: sum_invocation_field(invocations, :cached_input_tokens),
       output_tokens: sum_invocation_field(invocations, :output_tokens),
-      sessions: invocations |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+      # ⚡ Bolt: Use MapSet.new/2 |> MapSet.size() to avoid intermediate list allocations
+      sessions: invocations |> MapSet.new(& &1.session_id) |> MapSet.size()
     }
   end
 
@@ -1713,7 +1715,8 @@ defmodule ControlKeel.Observability do
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
         output_tokens: sum_invocation_field(group, :output_tokens),
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+        # ⚡ Bolt: Use MapSet.new/2 |> MapSet.size() to avoid intermediate list allocations
+        sessions: group |> MapSet.new(& &1.session_id) |> MapSet.size()
       }
     end)
     |> Enum.sort_by(&{&1.estimated_cost_cents, &1.invocations}, :desc)
@@ -1730,7 +1733,8 @@ defmodule ControlKeel.Observability do
       %{
         name: name,
         invocations: invocation_count,
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length(),
+        # ⚡ Bolt: Use MapSet.new/2 |> MapSet.size() to avoid intermediate list allocations
+        sessions: group |> MapSet.new(& &1.session_id) |> MapSet.size(),
         estimated_cost_cents: total_cost,
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
@@ -2194,7 +2198,8 @@ defmodule ControlKeel.Observability do
       suite: benchmark_run_suite_slug(run),
       subjects: run.subjects || [],
       total_scenarios: run.total_scenarios,
-      observed_scenarios: run.results |> Enum.map(& &1.scenario_id) |> Enum.uniq() |> length(),
+      # ⚡ Bolt: Use MapSet.new/2 |> MapSet.size() to avoid intermediate list allocations
+      observed_scenarios: run.results |> MapSet.new(& &1.scenario_id) |> MapSet.size(),
       caught_count: run.caught_count,
       blocked_count: run.blocked_count,
       catch_rate: run.catch_rate || 0.0,


### PR DESCRIPTION
💡 **What:** Optimized list operations by refactoring instances of `length(Enum.filter(...))` to use `Enum.count/2` and replacing `Enum.map(...) |> Enum.uniq() |> length()` with `MapSet.new(...) |> MapSet.size()`.
🎯 **Why:** To improve performance by preventing multiple unnecessary intermediate list allocations during evaluation in large arrays.
📊 **Impact:** Reduces memory overhead and time-complexity slightly during these operations across modules interacting with data streams and benchmark outcomes.
🔬 **Measurement:** Use load testing and manual unit benchmarks over operations executing `Enum.map |> Enum.uniq |> length` and `length(Enum.filter)` pattern blocks, expecting reduced GC pauses and constant memory scale.

---
*PR created automatically by Jules for task [8868055383075583303](https://jules.google.com/task/8868055383075583303) started by @aryaminus*