### PR TITLE
🎨 Palette: Add explicit ARIA labels and focus styles to user menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Conditional Text Rendering Accessibility in Compact Components
+**Learning:** Components that use conditional text rendering (like the `user_menu` component showing a full name in default mode but only a single initial in `@compact` mode) lose their visual meaning and semantic context for screen readers when the text is truncated or omitted.
+**Action:** When designing components with a "compact" mode that removes descriptive text, always add an explicit `aria-label` that provides the full context, regardless of the visual mode, to ensure the element remains accessible to screen readers.

--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -124,9 +124,15 @@ defmodule ControlKeelWeb.Layouts do
     <div {@rest} class={"relative #{@class}"} id={@id}>
       <button
         type="button"
-        phx-click={JS.toggle(to: "##{@id}-popover")}
+        phx-click={
+          JS.toggle(to: "##{@id}-popover")
+          |> JS.toggle_attribute({"aria-expanded", "true", "false"})
+        }
+        aria-label={"User menu for " <> (@current_user.name || @current_user.email)}
+        aria-haspopup="true"
+        aria-expanded="false"
         class={[
-          "transition hover:bg-muted",
+          "transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded",
           if(@compact,
             do:
               "flex items-center gap-2 rounded-full px-1 py-1 text-sm font-semibold text-muted-foreground hover:text-foreground",
@@ -151,7 +157,10 @@ defmodule ControlKeelWeb.Layouts do
       </button>
       <div
         id={"#{@id}-popover"}
-        phx-click-away={JS.hide(to: "##{@id}-popover")}
+        phx-click-away={
+          JS.hide(to: "##{@id}-popover")
+          |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id} button")
+        }
         class={"hidden absolute #{@popover_class} z-50 w-56 rounded-xl border bg-card p-3 shadow-2xl shadow-black/50 backdrop-blur-md"}
       >
         <p class="text-sm font-semibold text-foreground">


### PR DESCRIPTION
💡 What: Added explicit `aria-label`, `aria-haspopup`, dynamic `aria-expanded` attributes, and `focus-visible` styles to the `user_menu` component button in `lib/controlkeel_web/components/layouts.ex`. Also added an associated journal entry documenting the learning about conditional text rendering and accessibility in `.Jules/palette.md`.
🎯 Why: In `@compact` mode, the user menu button only renders a single initial for the user's name/email. This lack of text content removes semantic meaning for screen readers. Furthermore, the toggle behavior required state tracking (aria-expanded) for screen readers to know if the dropdown menu is open or closed. The added `focus-visible` styles improve keyboard navigation visibility.
📸 Before/After: N/A - Visually identical in non-focused state. Focus state now correctly displays a rounded primary-colored ring.
♿ Accessibility:
- Explicit `aria-label` providing full user name/email regardless of compact or normal mode.
- Correct ARIA structural tags (`aria-haspopup="true"`).
- Dynamic ARIA state tracking for the dropdown menu via Phoenix `JS` module (`aria-expanded` dynamically toggles between true/false when menu opens/closes, and resets to false on click-away).
- Improved keyboard focus visibility via explicit Tailwind `focus-visible` utilities.

---
*PR created automatically by Jules for task [12927620503851867916](https://jules.google.com/task/12927620503851867916) started by @aryaminus*