### PR TITLE
⚡ Bolt: Elixir intermediate list allocation optimizations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-08-15 - [Elixir MapSet and Enum.count Intermediate List Allocation Optimization]
+**Learning:** Using `length(Enum.filter(enumerable, condition))` and `enumerable |> Enum.map(transform) |> Enum.uniq() |> length()` causes intermediate lists to be allocated in memory, which adds noticeable GC overhead in high-throughput data processing pathways (like observability benchmarks and token tracking).
+**Action:** Always prefer `Enum.count/2` over `length(Enum.filter/2)`, and `MapSet.new/2 |> MapSet.size()` over `Enum.map/2 |> Enum.uniq/1 |> length/1` to compute lengths of filtered or mapped unique items without allocating intermediate data structures.

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -524,7 +524,7 @@ defmodule ControlKeel.Observability do
       benchmark_drafts: drafts.count,
       approved_drafts: approved_drafts,
       materialized_scenarios: length(scenario_ids),
-      covered_scenarios: length(Enum.filter(scenario_ids, &(&1 in covered_ids))),
+      covered_scenarios: Enum.count(scenario_ids, &(&1 in covered_ids)),
       benchmark_runs: length(runs)
     }
 
@@ -1698,7 +1698,7 @@ defmodule ControlKeel.Observability do
       input_tokens: sum_invocation_field(invocations, :input_tokens),
       cached_input_tokens: sum_invocation_field(invocations, :cached_input_tokens),
       output_tokens: sum_invocation_field(invocations, :output_tokens),
-      sessions: invocations |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+      sessions: MapSet.new(invocations, & &1.session_id) |> MapSet.size()
     }
   end
 
@@ -1713,7 +1713,7 @@ defmodule ControlKeel.Observability do
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
         output_tokens: sum_invocation_field(group, :output_tokens),
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+        sessions: MapSet.new(group, & &1.session_id) |> MapSet.size()
       }
     end)
     |> Enum.sort_by(&{&1.estimated_cost_cents, &1.invocations}, :desc)
@@ -1730,7 +1730,7 @@ defmodule ControlKeel.Observability do
       %{
         name: name,
         invocations: invocation_count,
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length(),
+        sessions: MapSet.new(group, & &1.session_id) |> MapSet.size(),
         estimated_cost_cents: total_cost,
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
@@ -2194,7 +2194,7 @@ defmodule ControlKeel.Observability do
       suite: benchmark_run_suite_slug(run),
       subjects: run.subjects || [],
       total_scenarios: run.total_scenarios,
-      observed_scenarios: run.results |> Enum.map(& &1.scenario_id) |> Enum.uniq() |> length(),
+      observed_scenarios: MapSet.new(run.results, & &1.scenario_id) |> MapSet.size(),
       caught_count: run.caught_count,
       blocked_count: run.blocked_count,
       catch_rate: run.catch_rate || 0.0,


### PR DESCRIPTION
💡 What: Replaced intermediate list allocations in Elixir data pipelines with memory-efficient alternatives. Changed `length(Enum.filter(...))` to `Enum.count(...)` and `Enum.map(...) |> Enum.uniq() |> length()` to `MapSet.new(...) |> MapSet.size()`.

🎯 Why: In high-throughput pathways like observability benchmarks and token tracking, allocating intermediate lists during data transformation pipelines causes unnecessary memory spikes and adds garbage collection overhead. Using functions that count or track uniqueness directly avoids creating these intermediate structures.

📊 Impact: Reduces GC overhead and memory allocations for dataset parsing in observability features.

🔬 Measurement: Profile the memory usage of observability run metric generation. The allocations per run will be noticeably lower, especially for larger datasets containing many sessions or scenarios.

---
*PR created automatically by Jules for task [8967027316472397724](https://jules.google.com/task/8967027316472397724) started by @aryaminus*