### PR TITLE
⚡ Bolt: Eliminate intermediate list allocations in standard library operations

### DIFF
--- a/lib/controlkeel/cloud/baseline_analyzer.ex
+++ b/lib/controlkeel/cloud/baseline_analyzer.ex
@@ -94,7 +94,8 @@ defmodule ControlKeel.Cloud.BaselineAnalyzer do
       )
       |> Repo.all()
 
-    sample_sessions = rows |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+    # Bolt: Replaced Enum.map/2 |> Enum.uniq/1 |> length/1 with MapSet.new/2 |> MapSet.size/1 to avoid intermediate list allocations
+    sample_sessions = rows |> MapSet.new(& &1.session_id) |> MapSet.size()
 
     baseline =
       rows

--- a/lib/controlkeel/governance.ex
+++ b/lib/controlkeel/governance.ex
@@ -555,7 +555,8 @@ defmodule ControlKeel.Governance do
   end
 
   defp review_summary(decision, findings, fragments) do
-    files_reviewed = fragments |> Enum.map(& &1.path) |> Enum.uniq() |> length()
+    # Bolt: Replaced Enum.map/2 |> Enum.uniq/1 |> length/1 with MapSet.new/2 |> MapSet.size/1 to avoid intermediate list allocations
+    files_reviewed = fragments |> MapSet.new(& &1.path) |> MapSet.size()
     chunks_reviewed = length(fragments)
     added_lines_reviewed = Enum.reduce(fragments, 0, &(&1.added_line_count + &2))
 

--- a/lib/controlkeel/mcp/tool_group_tracker.ex
+++ b/lib/controlkeel/mcp/tool_group_tracker.ex
@@ -162,8 +162,9 @@ defmodule ControlKeel.MCP.ToolGroupTracker do
     else
       total_calls = entries |> Enum.map(fn {_key, _ts, count} -> count end) |> Enum.sum()
 
+      # Bolt: Replaced Enum.map/2 |> Enum.uniq/1 |> length/1 with MapSet.new/2 |> MapSet.size/1 to avoid intermediate list allocations
       unique_tools =
-        entries |> Enum.map(fn {key, _ts, _count} -> key end) |> Enum.uniq() |> length()
+        entries |> MapSet.new(fn {key, _ts, _count} -> key end) |> MapSet.size()
 
       %{total_calls: total_calls, unique_tools: unique_tools}
     end

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -524,7 +524,8 @@ defmodule ControlKeel.Observability do
       benchmark_drafts: drafts.count,
       approved_drafts: approved_drafts,
       materialized_scenarios: length(scenario_ids),
-      covered_scenarios: length(Enum.filter(scenario_ids, &(&1 in covered_ids))),
+      # Bolt: Replaced length(Enum.filter/2) with Enum.count/2 to avoid intermediate list allocations
+      covered_scenarios: Enum.count(scenario_ids, &(&1 in covered_ids)),
       benchmark_runs: length(runs)
     }
 
@@ -1698,7 +1699,8 @@ defmodule ControlKeel.Observability do
       input_tokens: sum_invocation_field(invocations, :input_tokens),
       cached_input_tokens: sum_invocation_field(invocations, :cached_input_tokens),
       output_tokens: sum_invocation_field(invocations, :output_tokens),
-      sessions: invocations |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+      # Bolt: Replaced Enum.map/2 |> Enum.uniq/1 |> length/1 with MapSet.new/2 |> MapSet.size/1 to avoid intermediate list allocations
+      sessions: invocations |> MapSet.new(& &1.session_id) |> MapSet.size()
     }
   end
 
@@ -1713,7 +1715,8 @@ defmodule ControlKeel.Observability do
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
         output_tokens: sum_invocation_field(group, :output_tokens),
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+        # Bolt: Replaced Enum.map/2 |> Enum.uniq/1 |> length/1 with MapSet.new/2 |> MapSet.size/1 to avoid intermediate list allocations
+        sessions: group |> MapSet.new(& &1.session_id) |> MapSet.size()
       }
     end)
     |> Enum.sort_by(&{&1.estimated_cost_cents, &1.invocations}, :desc)
@@ -1730,7 +1733,8 @@ defmodule ControlKeel.Observability do
       %{
         name: name,
         invocations: invocation_count,
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length(),
+        # Bolt: Replaced Enum.map/2 |> Enum.uniq/1 |> length/1 with MapSet.new/2 |> MapSet.size/1 to avoid intermediate list allocations
+        sessions: group |> MapSet.new(& &1.session_id) |> MapSet.size(),
         estimated_cost_cents: total_cost,
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
@@ -2194,7 +2198,8 @@ defmodule ControlKeel.Observability do
       suite: benchmark_run_suite_slug(run),
       subjects: run.subjects || [],
       total_scenarios: run.total_scenarios,
-      observed_scenarios: run.results |> Enum.map(& &1.scenario_id) |> Enum.uniq() |> length(),
+      # Bolt: Replaced Enum.map/2 |> Enum.uniq/1 |> length/1 with MapSet.new/2 |> MapSet.size/1 to avoid intermediate list allocations
+      observed_scenarios: run.results |> MapSet.new(& &1.scenario_id) |> MapSet.size(),
       caught_count: run.caught_count,
       blocked_count: run.blocked_count,
       catch_rate: run.catch_rate || 0.0,

--- a/test/controlkeel/budget/cost_optimizer_test.exs
+++ b/test/controlkeel/budget/cost_optimizer_test.exs
@@ -30,7 +30,8 @@ defmodule ControlKeel.Budget.CostOptimizerTest do
       end
 
     assert {:ok, suggestions} = CostOptimizer.suggest("session_3", spending: spending)
-    cache_count = length(Enum.filter(suggestions, &(&1.type == :caching)))
+    # Bolt: Replaced length(Enum.filter/2) with Enum.count/2 to avoid intermediate list allocations
+    cache_count = Enum.count(suggestions, &(&1.type == :caching))
     assert cache_count >= 0
   end
 
@@ -41,7 +42,8 @@ defmodule ControlKeel.Budget.CostOptimizerTest do
       end
 
     assert {:ok, suggestions} = CostOptimizer.suggest("session_4", spending: spending)
-    local_count = length(Enum.filter(suggestions, &(&1.type == :local_model)))
+    # Bolt: Replaced length(Enum.filter/2) with Enum.count/2 to avoid intermediate list allocations
+    local_count = Enum.count(suggestions, &(&1.type == :local_model))
     assert local_count >= 0
   end
 


### PR DESCRIPTION
💡 What: Replaced instances of `length(Enum.filter/2)` with `Enum.count/2` and `Enum.map/2 |> Enum.uniq/1 |> length/1` with `MapSet.new/2 |> MapSet.size/1` across observability, baseline analysis, governance, and test files. Added explanatory inline comments.
🎯 Why: The original patterns forced the Elixir runtime to allocate intermediate lists before counting elements, increasing unnecessary garbage collection overhead, especially in hot paths parsing telemetry data or observability results.
📊 Impact: Completely eliminates two kinds of temporary list allocations in frequently invoked collection processing pipelines, reducing memory spikes and speeding up execution time in observability and governance loops.
🔬 Measurement: Verify changes in `lib/controlkeel/observability.ex`, `test/controlkeel/budget/cost_optimizer_test.exs`, and other affected files via code inspection. `MapSet.new/2` natively builds a unique set in one pass, avoiding the dual intermediate list generation of `Enum.map` into `Enum.uniq`.

---
*PR created automatically by Jules for task [33153761463475798](https://jules.google.com/task/33153761463475798) started by @aryaminus*