### PR TITLE
🎨 Palette: [Add aria-expanded state to user menu]

### DIFF
--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -265,7 +265,10 @@ defmodule ControlKeelWeb.Layouts do
     <div {@rest} class={"relative #{@class}"} id={@id}>
       <button
         type="button"
-        phx-click={JS.toggle(to: "##{@id}-popover")}
+        id={"#{@id}-button"}
+        aria-haspopup="true"
+        aria-expanded="false"
+        phx-click={JS.toggle(to: "##{@id}-popover") |> JS.toggle_attribute({"aria-expanded", "true", "false"})}
         class={[
           "transition hover:bg-muted",
           if(@compact,
@@ -292,7 +295,7 @@ defmodule ControlKeelWeb.Layouts do
       </button>
       <div
         id={"#{@id}-popover"}
-        phx-click-away={JS.hide(to: "##{@id}-popover")}
+        phx-click-away={JS.hide(to: "##{@id}-popover") |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id}-button")}
         class={"hidden absolute #{@popover_class} z-50 w-56 rounded-xl border bg-card p-3 shadow-2xl shadow-black/50 backdrop-blur-md"}
       >
         <p class="text-sm font-semibold text-foreground">
@@ -303,7 +306,7 @@ defmodule ControlKeelWeb.Layouts do
         <%= if @show_dashboard do %>
           <a
             href={~p"/dashboard"}
-            phx-click={JS.hide(to: "##{@id}-popover")}
+            phx-click={JS.hide(to: "##{@id}-popover") |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id}-button")}
             class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
           >
             <.icon name="hero-squares-2x2" class="size-4" /> Dashboard


### PR DESCRIPTION
## 💡 What
Added dynamic `aria-expanded` and `aria-haspopup` attributes to the user menu dropdown button in the sidebar. Used Phoenix LiveView `JS.toggle_attribute` and `JS.set_attribute` to ensure the ARIA state accurately reflects the popover's visibility.

## 🎯 Why
Without `aria-expanded`, screen reader users have no auditory feedback on whether clicking the user menu button successfully opened the popover or if the popover is currently visible. This change brings the custom dropdown into compliance with accessible menu button patterns.

## ♿ Accessibility
- Added `aria-haspopup="true"` to indicate the button controls a menu/popover.
- Added dynamic `aria-expanded` that toggles when the button is clicked.
- Ensured `aria-expanded="false"` is restored when the popover is closed via click-away or selecting a menu link.
- Leveraged client-side `JS` commands to keep ARIA state synced without server latency.

---
*PR created automatically by Jules for task [6876757094859678427](https://jules.google.com/task/6876757094859678427) started by @aryaminus*