### PR TITLE
Enhance observability web with new features and optimizations

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -28,6 +28,21 @@ const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute
 
 const Hooks = {}
 
+Hooks.FlashTimeout = {
+  mounted() {
+    this.hideTimer = setTimeout(() => {
+      const kind = this.el.dataset.flashKind
+      this.pushEventTo(this.el, "lv:clear-flash", {key: kind})
+      this.el.classList.add("opacity-0", "-translate-y-2")
+      this.el.style.transition = "opacity 300ms ease, transform 300ms ease"
+      setTimeout(() => this.el.classList.add("hidden"), 320)
+    }, this.el.dataset.flashKind === "error" ? 10000 : 6000)
+  },
+  destroyed() {
+    clearTimeout(this.hideTimer)
+  }
+}
+
 Hooks.SidebarNav = {
   mounted() {
     this.restoreScroll()

--- a/lib/controlkeel_web/components/core_components.ex
+++ b/lib/controlkeel_web/components/core_components.ex
@@ -50,26 +50,37 @@ defmodule ControlKeelWeb.CoreComponents do
     <div
       :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
       id={@id}
+      phx-hook="FlashTimeout"
+      data-flash-kind={@kind}
       phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
       role="alert"
-      class="toast toast-top toast-end z-50"
+      class="fixed right-4 top-4 z-50"
       {@rest}
     >
       <div class={[
-        "alert w-80 sm:w-96 max-w-80 sm:max-w-96 text-wrap",
-        @kind == :info && "alert-info",
-        @kind == :error && "alert-error"
+        "w-80 sm:w-96 max-w-[calc(100vw-2rem)] text-wrap rounded-xl border bg-card p-4 shadow-card",
+        @kind == :info && "border-info/30",
+        @kind == :error && "border-destructive/40 bg-destructive/10"
       ]}>
-        <.icon :if={@kind == :info} name="hero-information-circle" class="size-5 shrink-0" />
-        <.icon :if={@kind == :error} name="hero-exclamation-circle" class="size-5 shrink-0" />
-        <div>
-          <p :if={@title} class="font-semibold">{@title}</p>
-          <p>{msg}</p>
+        <div class="flex items-start gap-2">
+          <.icon :if={@kind == :info} name="hero-information-circle" class="size-5 shrink-0 mt-0.5" />
+          <.icon
+            :if={@kind == :error}
+            name="hero-exclamation-circle"
+            class="size-5 shrink-0 mt-0.5 text-destructive"
+          />
+          <div class="min-w-0 flex-1">
+            <p :if={@title} class="font-semibold text-foreground">{@title}</p>
+            <p class="text-foreground/80">{msg}</p>
+          </div>
+          <button
+            type="button"
+            class="group self-start cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            aria-label={gettext("close")}
+          >
+            <.icon name="hero-x-mark" class="size-5 opacity-40 group-hover:opacity-70" />
+          </button>
         </div>
-        <div class="flex-1" />
-        <button type="button" class="group self-start cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded" aria-label={gettext("close")}>
-          <.icon name="hero-x-mark" class="size-5 opacity-40 group-hover:opacity-70" />
-        </button>
       </div>
     </div>
     """

--- a/lib/controlkeel_web/live/observability_benchmark_drafts_live.ex
+++ b/lib/controlkeel_web/live/observability_benchmark_drafts_live.ex
@@ -26,7 +26,12 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
 
     case Observability.update_benchmark_draft_status(id, "approved", opts) do
       {:ok, _result} ->
-        {:noreply, assign(socket, :drafts, Observability.benchmark_drafts(socket.assigns.opts))}
+        materialize = Observability.materialize_benchmark_drafts(socket.assigns.opts)
+
+        {:noreply,
+         socket
+         |> assign(:drafts, Observability.benchmark_drafts(socket.assigns.opts))
+         |> put_flash(:info, approve_materialize_message(materialize))}
 
       {:error, reason} ->
         {:noreply,
@@ -49,6 +54,29 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
     end
   end
 
+  def handle_event("archive-draft", %{"id" => id}, socket) do
+    opts = Keyword.merge(socket.assigns.opts, reviewed_by: "web")
+
+    case Observability.update_benchmark_draft_status(id, "archived", opts) do
+      {:ok, _result} ->
+        {:noreply, assign(socket, :drafts, Observability.benchmark_drafts(socket.assigns.opts))}
+
+      {:error, reason} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, flash_for_status_error(reason))}
+    end
+  end
+
+  def handle_event("generate-drafts", _params, socket) do
+    result = Observability.generate_benchmark_drafts(socket.assigns.opts)
+
+    {:noreply,
+     socket
+     |> assign(:drafts, Observability.benchmark_drafts(socket.assigns.opts))
+     |> put_flash(:info, generate_drafts_message(result))}
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -66,6 +94,14 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
           <span id="observability-benchmark-drafts-count" class={neutral_pill_class()}>
             {@drafts.count} draft(s)
           </span>
+          <.button
+            id="observability-benchmark-drafts-generate"
+            type="button"
+            variant="outline"
+            phx-click="generate-drafts"
+          >
+            Generate drafts
+          </.button>
         </div>
       </div>
 
@@ -158,6 +194,17 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
                   >
                     Reject
                   </button>
+                  <%= if draft.status != "archived" do %>
+                    <button
+                      id={"observability-benchmark-draft-archive-#{draft.id}"}
+                      type="button"
+                      class="inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-semibold text-foreground transition hover:opacity-90"
+                      phx-click="archive-draft"
+                      phx-value-id={draft.id}
+                    >
+                      Archive
+                    </button>
+                  <% end %>
                 </div>
               </div>
             <% end %>
@@ -176,9 +223,29 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
     do:
       "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1 bg-destructive/10 text-destructive ring-destructive/20"
 
+  defp status_pill_class("archived"),
+    do:
+      "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium capitalize ring-1 bg-muted text-foreground/60 ring-border"
+
   defp status_pill_class(_),
     do:
       "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium capitalize ring-1 bg-muted text-foreground ring-border"
+
+  defp approve_materialize_message(%{materialized: materialized, existing: existing}) do
+    count_part = "Approved and materialized #{materialized} draft(s)"
+    existing_part = if existing > 0, do: " · #{existing} already existed", else: ""
+    count_part <> existing_part <> "."
+  end
+
+  defp generate_drafts_message(%{source_count: 0}) do
+    "No open saved eval candidates to generate draft scenarios from."
+  end
+
+  defp generate_drafts_message(%{stored: stored, existing: existing}) do
+    count_part = "Generated #{stored} draft(s)"
+    existing_part = if existing > 0, do: " · #{existing} already existed", else: ""
+    count_part <> existing_part <> "."
+  end
 
   defp materialized_scenario(draft) do
     case get_in(draft.metadata || %{}, ["materialized_scenario_id"]) do

--- a/lib/controlkeel_web/live/observability_benchmark_drafts_live.ex
+++ b/lib/controlkeel_web/live/observability_benchmark_drafts_live.ex
@@ -20,6 +20,15 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
      |> assign(:drafts, drafts)}
   end
 
+  # Currently approve/reject/archive are fully reversible, so devs and users can
+  # test the actions back and forth.
+  #
+  # Consider making approve and reject irreversible decision states: an approved
+  # draft could stop being rejectable, archivable, or approvable again, with the
+  # same holding for rejected drafts. Archive would stay reversible (archived
+  # drafts could be re-opened). If pursued, enforce the transition matrix in
+  # Observability.update_benchmark_draft_status/3 and disable the buttons here
+  # accordingly.
   @impl true
   def handle_event("approve-draft", %{"id" => id}, socket) do
     opts = Keyword.merge(socket.assigns.opts, reviewed_by: "web")
@@ -44,8 +53,11 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
     opts = Keyword.merge(socket.assigns.opts, reviewed_by: "web")
 
     case Observability.update_benchmark_draft_status(id, "rejected", opts) do
-      {:ok, _result} ->
-        {:noreply, assign(socket, :drafts, Observability.benchmark_drafts(socket.assigns.opts))}
+      {:ok, result} ->
+        {:noreply,
+         socket
+         |> assign(:drafts, Observability.benchmark_drafts(socket.assigns.opts))
+         |> put_flash(:info, status_flash_message(result))}
 
       {:error, reason} ->
         {:noreply,
@@ -58,8 +70,11 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
     opts = Keyword.merge(socket.assigns.opts, reviewed_by: "web")
 
     case Observability.update_benchmark_draft_status(id, "archived", opts) do
-      {:ok, _result} ->
-        {:noreply, assign(socket, :drafts, Observability.benchmark_drafts(socket.assigns.opts))}
+      {:ok, result} ->
+        {:noreply,
+         socket
+         |> assign(:drafts, Observability.benchmark_drafts(socket.assigns.opts))
+         |> put_flash(:info, status_flash_message(result))}
 
       {:error, reason} ->
         {:noreply,
@@ -176,34 +191,35 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
                   Scenario: {materialized_scenario(draft)}
                 </p>
                 <div class="flex items-center gap-3 pt-1">
-                  <button
+                  <.button
                     id={"observability-benchmark-draft-approve-#{draft.id}"}
                     type="button"
-                    class="inline-flex items-center rounded-lg bg-primary px-3 py-1.5 text-sm font-semibold text-primary-foreground transition hover:opacity-90"
                     phx-click="approve-draft"
                     phx-value-id={draft.id}
+                    disabled={draft.status == "approved"}
                   >
                     Approve
-                  </button>
-                  <button
+                  </.button>
+                  <.button
                     id={"observability-benchmark-draft-reject-#{draft.id}"}
                     type="button"
-                    class="inline-flex items-center rounded-lg border bg-muted px-3 py-1.5 text-sm font-semibold text-foreground transition hover:opacity-90"
+                    variant="outline"
                     phx-click="reject-draft"
                     phx-value-id={draft.id}
+                    disabled={draft.status == "rejected"}
                   >
                     Reject
-                  </button>
+                  </.button>
                   <%= if draft.status != "archived" do %>
-                    <button
+                    <.button
                       id={"observability-benchmark-draft-archive-#{draft.id}"}
                       type="button"
-                      class="inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-semibold text-foreground transition hover:opacity-90"
+                      variant="outline"
                       phx-click="archive-draft"
                       phx-value-id={draft.id}
                     >
                       Archive
-                    </button>
+                    </.button>
                   <% end %>
                 </div>
               </div>
@@ -235,6 +251,10 @@ defmodule ControlKeelWeb.ObservabilityBenchmarkDraftsLive do
     count_part = "Approved and materialized #{materialized} draft(s)"
     existing_part = if existing > 0, do: " · #{existing} already existed", else: ""
     count_part <> existing_part <> "."
+  end
+
+  defp status_flash_message(%{status: status, draft: draft}) do
+    "#{String.capitalize(status)} draft \"#{draft.title}\"."
   end
 
   defp generate_drafts_message(%{source_count: 0}) do

--- a/lib/controlkeel_web/live/observability_costs_live.ex
+++ b/lib/controlkeel_web/live/observability_costs_live.ex
@@ -1,8 +1,13 @@
 defmodule ControlKeelWeb.ObservabilityCostsLive do
   use ControlKeelWeb, :live_view
 
+  import Ecto.Query, only: [from: 2]
+
+  alias ControlKeel.Budget.CostOptimizer
   alias ControlKeel.Mission
+  alias ControlKeel.Mission.Invocation
   alias ControlKeel.Observability
+  alias ControlKeel.Repo
   alias ControlKeelWeb.CommandPill
 
   on_mount ControlKeelWeb.CommandPill
@@ -21,11 +26,18 @@ defmodule ControlKeelWeb.ObservabilityCostsLive do
 
     primary_costs = grouped_costs |> List.first() |> elem(1)
 
+    {:ok, suggestions} = load_suggestions(recent_session)
+
+    {:ok, comparison} =
+      CostOptimizer.compare_agents("Agent cost comparison", estimated_tokens: 10_000)
+
     {:ok,
      socket
      |> assign(:page_title, "Observability Costs")
      |> assign(:costs, primary_costs)
-     |> assign(:grouped_costs, grouped_costs)}
+     |> assign(:grouped_costs, grouped_costs)
+     |> assign(:suggestions, suggestions)
+     |> assign(:comparison, comparison)}
   end
 
   @impl true
@@ -41,6 +53,82 @@ defmodule ControlKeelWeb.ObservabilityCostsLive do
 
       <div class="flex flex-wrap items-center gap-3">
         <CommandPill.command_pill command="controlkeel obs costs" />
+      </div>
+
+      <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <section
+          id="observability-costs-suggestions"
+          class="rounded-2xl border bg-card p-5 shadow-card space-y-4"
+        >
+          <div class="flex items-center justify-between gap-3">
+            <.section_title>Cost optimization suggestions</.section_title>
+            <span class="rounded-full bg-muted px-3 py-1.5 text-sm font-medium text-foreground">
+              {length(@suggestions)} suggestion(s)
+            </span>
+          </div>
+          <%= if @suggestions == [] do %>
+            <p class="text-sm text-muted-foreground">
+              No cost optimization suggestions at this time.
+            </p>
+          <% else %>
+            <div class="divide-y divide-border">
+              <%= for suggestion <- @suggestions do %>
+                <div class="space-y-1.5 py-3 first:pt-0 last:pb-0">
+                  <div class="flex items-center justify-between gap-3">
+                    <p class="text-sm font-medium text-foreground">{suggestion.title}</p>
+                    <span class={priority_pill_class(suggestion.priority)}>
+                      {suggestion.priority}
+                    </span>
+                  </div>
+                  <p class="text-xs leading-relaxed text-muted-foreground">
+                    {suggestion.description}
+                  </p>
+                  <%= if suggestion.savings_percent do %>
+                    <p class="text-xs font-medium text-success">
+                      Potential savings: {suggestion.savings_percent}%
+                    </p>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </section>
+
+        <section
+          id="observability-costs-comparison"
+          class="rounded-2xl border bg-card p-5 shadow-card space-y-4"
+        >
+          <div class="flex items-center justify-between gap-3">
+            <.section_title>Agent cost comparison</.section_title>
+            <span class="rounded-full bg-muted px-3 py-1.5 text-sm font-medium text-foreground">
+              {format_number(@comparison.estimated_tokens)} tokens
+            </span>
+          </div>
+          <%= if @comparison.comparisons == [] do %>
+            <p class="text-sm text-muted-foreground">No agent cost comparison available.</p>
+          <% else %>
+            <div class="divide-y divide-border">
+              <%= for comparison <- @comparison.comparisons do %>
+                <div class="flex items-center justify-between gap-3 py-2.5 first:pt-0 last:pb-0">
+                  <div class="min-w-0">
+                    <p class="text-sm font-medium text-foreground">{comparison.agent}</p>
+                    <p class="text-xs text-muted-foreground">
+                      {comparison.provider} / {comparison.model}
+                    </p>
+                  </div>
+                  <span class={cheapest_pill_class(comparison, @comparison.cheapest)}>
+                    {format_currency(comparison.estimated_cost_cents)}
+                  </span>
+                </div>
+              <% end %>
+            </div>
+            <%= if @comparison.savings_range > 0 do %>
+              <p class="text-xs font-medium text-success">
+                Potential savings vs most expensive: {format_currency(@comparison.savings_range)}
+              </p>
+            <% end %>
+          <% end %>
+        </section>
       </div>
 
       <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -117,4 +205,58 @@ defmodule ControlKeelWeb.ObservabilityCostsLive do
 
   defp format_currency(cents) when is_integer(cents), do: cents |> Kernel./(100) |> Float.round(2)
   defp format_currency(_cents), do: 0.0
+
+  defp format_number(number) when is_integer(number),
+    do: number |> Integer.to_string() |> add_thousands_separators()
+
+  defp format_number(number), do: to_string(number)
+
+  defp add_thousands_separators(digits) do
+    digits
+    |> String.reverse()
+    |> String.graphemes()
+    |> Enum.chunk_every(3)
+    |> Enum.map(&Enum.join/1)
+    |> Enum.join(",")
+    |> String.reverse()
+  end
+
+  defp load_suggestions(nil), do: {:ok, []}
+
+  defp load_suggestions(session) do
+    spending =
+      from(i in Invocation,
+        where: i.session_id == ^session.id,
+        select: %{
+          estimated_cost_cents: i.estimated_cost_cents,
+          tool: i.tool,
+          metadata: i.metadata
+        }
+      )
+      |> Repo.all()
+
+    CostOptimizer.suggest(session.id, spending: spending)
+  end
+
+  defp priority_pill_class("high"),
+    do:
+      "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1 bg-warning/10 text-warning ring-warning/20"
+
+  defp priority_pill_class("medium"),
+    do:
+      "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1 bg-warning/10 text-warning ring-warning/20"
+
+  defp priority_pill_class(_),
+    do:
+      "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium capitalize ring-1 bg-muted text-foreground ring-border"
+
+  defp cheapest_pill_class(comparison, cheapest) do
+    base = "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ring-1"
+
+    if cheapest && comparison.agent == cheapest.agent do
+      "#{base} bg-success/10 text-success ring-success/20"
+    else
+      "#{base} bg-muted text-foreground ring-border"
+    end
+  end
 end

--- a/lib/controlkeel_web/live/observability_evals_live.ex
+++ b/lib/controlkeel_web/live/observability_evals_live.ex
@@ -226,6 +226,10 @@ defmodule ControlKeelWeb.ObservabilityEvalsLive do
     "No active eval candidates to save."
   end
 
+  defp save_summary_message(%{stored: 0, existing: existing}) when existing > 0 do
+    "Nothing new to save — #{existing} candidate(s) already saved."
+  end
+
   defp save_summary_message(%{stored: stored, existing: existing}) do
     count_part = "Saved #{stored} candidate(s)"
     existing_part = if existing > 0, do: " · #{existing} already existed", else: ""

--- a/lib/controlkeel_web/live/observability_evals_live.ex
+++ b/lib/controlkeel_web/live/observability_evals_live.ex
@@ -17,8 +17,22 @@ defmodule ControlKeelWeb.ObservabilityEvalsLive do
     {:ok,
      socket
      |> assign(:page_title, "Observability Eval Candidates")
+     |> assign(:opts, opts)
      |> assign(:eval_candidates, eval_candidates)
      |> assign(:saved, saved)}
+  end
+
+  @impl true
+  def handle_event("save-candidates", _params, socket) do
+    opts = socket.assigns.opts
+    result = Observability.save_eval_candidates(opts)
+
+    socket =
+      socket
+      |> assign(:eval_candidates, Observability.eval_candidates(opts))
+      |> assign(:saved, Observability.saved_eval_candidates(opts))
+
+    {:noreply, put_flash(socket, :info, save_summary_message(result))}
   end
 
   @impl true
@@ -41,12 +55,19 @@ defmodule ControlKeelWeb.ObservabilityEvalsLive do
           <span class="rounded-full bg-muted px-3 py-1.5 text-sm font-medium text-foreground">
             {@eval_candidates.count} candidate(s)
           </span>
+          <button
+            id="observability-evals-save"
+            type="button"
+            phx-click="save-candidates"
+            class="inline-flex items-center rounded-lg bg-primary px-3 py-1.5 text-sm font-semibold text-primary-foreground transition hover:opacity-90"
+          >
+            Review &amp; save candidates
+          </button>
         </div>
       </div>
 
       <div class="flex flex-wrap items-center gap-3">
         <CommandPill.command_pill command="controlkeel obs evals" />
-        <CommandPill.command_pill command="controlkeel obs evals save" />
         <p class="text-xs text-muted-foreground">
           Save persists the current advisory candidates locally for human-gated review.
         </p>
@@ -200,6 +221,16 @@ defmodule ControlKeelWeb.ObservabilityEvalsLive do
   defp priority_pill_class(_),
     do:
       "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ring-1 bg-muted text-foreground ring-border"
+
+  defp save_summary_message(%{stored: 0, existing: _existing, source_count: 0}) do
+    "No active eval candidates to save."
+  end
+
+  defp save_summary_message(%{stored: stored, existing: existing}) do
+    count_part = "Saved #{stored} candidate(s)"
+    existing_part = if existing > 0, do: " · #{existing} already existed", else: ""
+    count_part <> existing_part <> "."
+  end
 
   defp format_frequency(map) when map == %{}, do: "none"
 

--- a/lib/controlkeel_web/live/observability_loop_live.ex
+++ b/lib/controlkeel_web/live/observability_loop_live.ex
@@ -12,11 +12,31 @@ defmodule ControlKeelWeb.ObservabilityLoopLive do
     recent_session = Mission.list_recent_sessions(1) |> List.first()
     opts = if recent_session, do: [workspace_id: recent_session.workspace_id], else: []
     loop = Observability.loop_status(opts)
+    diagnostics = Observability.loop_diagnostics(opts)
 
     {:ok,
      socket
      |> assign(:page_title, "Observability Learning Loop")
-     |> assign(:loop, loop)}
+     |> assign(:opts, opts)
+     |> assign(:session_id, recent_session && recent_session.id)
+     |> assign(:loop, loop)
+     |> assign(:diagnostics, diagnostics)
+     |> assign(:snapshot, nil)}
+  end
+
+  @impl true
+  def handle_event("capture-perf-snapshot", _params, socket) do
+    opts =
+      socket.assigns.opts
+      |> maybe_put_session(socket.assigns.session_id)
+      |> Keyword.put(:persist, true)
+
+    snapshot = Observability.perf_snapshot(opts)
+
+    {:noreply,
+     socket
+     |> assign(:snapshot, snapshot)
+     |> put_flash(:info, perf_flash_message(snapshot))}
   end
 
   @impl true
@@ -142,6 +162,181 @@ defmodule ControlKeelWeb.ObservabilityLoopLive do
           </ul>
         </section>
       <% end %>
+
+      <section id="observability-loop-diagnostics" class="space-y-4">
+        <div class="flex items-start justify-between gap-3 flex-wrap">
+          <div class="space-y-1">
+            <.section_title>Loop diagnostics</.section_title>
+            <p class="text-xs text-muted-foreground">
+              Repeated identical tool-event and invocation runs detected in the sampled window.
+            </p>
+          </div>
+          <span class={neutral_pill_class()}>
+            {@diagnostics.totals.event_runs} event run(s) · {@diagnostics.totals.invocation_runs} invocation run(s)
+          </span>
+        </div>
+
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <section
+            id="observability-loop-diagnostics-events"
+            class="rounded-2xl border bg-card p-5 shadow-card space-y-3"
+          >
+            <div class="flex items-center justify-between gap-2">
+              <p class="text-sm font-medium text-muted-foreground">Repeated tool events</p>
+              <span class="rounded-full bg-muted px-3 py-1.5 text-sm font-medium text-foreground">
+                {@diagnostics.totals.event_runs} run(s)
+              </span>
+            </div>
+            <%= if @diagnostics.repeated_tool_events == [] do %>
+              <p class="text-sm text-muted-foreground">
+                No repeated identical tool-event runs detected.
+              </p>
+            <% else %>
+              <div class="divide-y divide-border">
+                <%= for run <- @diagnostics.repeated_tool_events do %>
+                  <div class="space-y-1.5 py-3 first:pt-0 last:pb-0">
+                    <div class="flex items-center justify-between gap-3">
+                      <p class="text-sm font-medium text-foreground">{run.sample.event_type}</p>
+                      <span class="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-foreground">
+                        {run.count}×
+                      </span>
+                    </div>
+                    <p class="text-xs text-muted-foreground">
+                      actor: {run.sample.actor || "—"} · session #{run.sample.session_id}
+                    </p>
+                    <p class="text-xs leading-relaxed text-foreground">{run.sample.summary}</p>
+                    <p class="text-xs text-muted-foreground">
+                      {format_dt(run.first_at)} → {format_dt(run.last_at)}
+                    </p>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+          </section>
+
+          <section
+            id="observability-loop-diagnostics-invocations"
+            class="rounded-2xl border bg-card p-5 shadow-card space-y-3"
+          >
+            <div class="flex items-center justify-between gap-2">
+              <p class="text-sm font-medium text-muted-foreground">Repeated invocations</p>
+              <span class="rounded-full bg-muted px-3 py-1.5 text-sm font-medium text-foreground">
+                {@diagnostics.totals.invocation_runs} run(s)
+              </span>
+            </div>
+            <%= if @diagnostics.repeated_invocations == [] do %>
+              <p class="text-sm text-muted-foreground">
+                No repeated identical invocation runs detected.
+              </p>
+            <% else %>
+              <div class="divide-y divide-border">
+                <%= for run <- @diagnostics.repeated_invocations do %>
+                  <div class="space-y-1.5 py-3 first:pt-0 last:pb-0">
+                    <div class="flex items-center justify-between gap-3">
+                      <p class="text-sm font-medium text-foreground">{run.sample.tool}</p>
+                      <span class="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-foreground">
+                        {run.count}×
+                      </span>
+                    </div>
+                    <p class="text-xs text-muted-foreground">
+                      {run.sample.source} · {run.sample.provider} / {run.sample.model}
+                    </p>
+                    <p class="text-xs text-muted-foreground">session #{run.sample.session_id}</p>
+                    <p class="text-xs text-muted-foreground">
+                      {format_dt(run.first_at)} → {format_dt(run.last_at)}
+                    </p>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+          </section>
+        </div>
+
+        <%= if @diagnostics.recommendations != [] do %>
+          <section class="rounded-2xl border bg-card p-5 shadow-card space-y-3">
+            <.section_title>Diagnostics recommendations</.section_title>
+            <ul class="space-y-2 text-sm leading-relaxed text-muted-foreground list-disc ml-5">
+              <%= for recommendation <- @diagnostics.recommendations do %>
+                <li>{recommendation}</li>
+              <% end %>
+            </ul>
+          </section>
+        <% end %>
+      </section>
+
+      <section
+        id="observability-perf-snapshot"
+        class="rounded-2xl border bg-card p-5 shadow-card space-y-4"
+      >
+        <div class="flex items-start justify-between gap-3 flex-wrap">
+          <div class="space-y-1">
+            <.section_title>Performance snapshot</.section_title>
+            <p class="text-xs text-muted-foreground">
+              Measures observability read-path timing; capturing persists a durable memory record.
+            </p>
+          </div>
+          <.button
+            id="observability-perf-capture"
+            type="button"
+            variant="outline"
+            phx-click="capture-perf-snapshot"
+          >
+            Capture performance snapshot
+          </.button>
+        </div>
+
+        <%= if @snapshot do %>
+          <p class="text-xs text-muted-foreground">
+            Generated at {format_dt(@snapshot.generated_at)}
+          </p>
+
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <article class="rounded-2xl border bg-card p-4">
+              <p class="text-sm font-medium text-muted-foreground">Items</p>
+              <p class="mt-2 text-xl font-semibold text-foreground/90">
+                {@snapshot.summary.item_count}
+              </p>
+            </article>
+            <article class="rounded-2xl border bg-card p-4">
+              <p class="text-sm font-medium text-muted-foreground">Total wall time</p>
+              <p class="mt-2 text-xl font-semibold text-foreground/90">
+                {format_ms(@snapshot.summary.total_wall_ms)}
+              </p>
+            </article>
+            <article class="rounded-2xl border bg-card p-4">
+              <p class="text-sm font-medium text-muted-foreground">Ecto queries</p>
+              <p class="mt-2 text-xl font-semibold text-foreground/90">
+                {@snapshot.summary.total_ecto_queries}
+              </p>
+            </article>
+            <article class="rounded-2xl border bg-card p-4">
+              <p class="text-sm font-medium text-muted-foreground">Payload</p>
+              <p class="mt-2 text-xl font-semibold text-foreground/90">
+                {format_bytes(@snapshot.summary.total_payload_bytes)}
+              </p>
+            </article>
+          </div>
+
+          <div id="observability-perf-items" class="divide-y divide-border">
+            <%= for item <- @snapshot.items do %>
+              <div class="flex items-center justify-between gap-3 py-2.5 first:pt-0 last:pb-0">
+                <div class="min-w-0">
+                  <p class="text-sm font-medium text-foreground leading-snug">{item.label}</p>
+                </div>
+                <p class="shrink-0 text-xs text-muted-foreground">
+                  {format_ms(item.wall_ms)} · {item.ecto_query_count} query(s) · {format_bytes(
+                    item.payload_bytes
+                  )}
+                </p>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <p class="text-sm text-muted-foreground">
+            No performance snapshot captured yet. Capture one to persist a durable perf memory record.
+          </p>
+        <% end %>
+      </section>
     </section>
     """
   end
@@ -166,4 +361,23 @@ defmodule ControlKeelWeb.ObservabilityLoopLive do
     |> Enum.map(fn {key, count} -> "#{key}: #{count}" end)
     |> Enum.join(", ")
   end
+
+  defp perf_flash_message(%{summary: summary}) do
+    "Performance snapshot captured and persisted: #{summary.item_count} item(s), #{summary.total_wall_ms} ms total."
+  end
+
+  defp maybe_put_session(opts, nil), do: opts
+  defp maybe_put_session(opts, session_id), do: Keyword.put(opts, :session_id, session_id)
+
+  defp format_dt(nil), do: "—"
+  defp format_dt(%DateTime{} = dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
+  defp format_dt(%NaiveDateTime{} = dt), do: Calendar.strftime(dt, "%Y-%m-%d %H:%M")
+  defp format_dt(_), do: "—"
+
+  defp format_ms(value) when is_number(value), do: "#{value} ms"
+  defp format_ms(_), do: "—"
+
+  defp format_bytes(nil), do: "—"
+  defp format_bytes(bytes) when is_integer(bytes), do: "#{bytes} B"
+  defp format_bytes(_), do: "—"
 end

--- a/test/controlkeel_web/live/observability_evals_live_test.exs
+++ b/test/controlkeel_web/live/observability_evals_live_test.exs
@@ -1,0 +1,52 @@
+defmodule ControlKeelWeb.ObservabilityEvalsLiveTest do
+  use ControlKeelWeb.ConnCase, async: false
+
+  import ControlKeel.MissionFixtures
+  import Phoenix.LiveViewTest
+
+  test "save button flashes a summary after saving candidates", %{conn: conn} do
+    session = session_fixture()
+
+    finding_fixture(%{
+      session: session,
+      title: "Eval candidate finding",
+      severity: "high",
+      status: "open",
+      category: "security",
+      rule_id: "security.evals"
+    })
+
+    {:ok, view, _html} = live(conn, ~p"/observability/evals")
+
+    view
+    |> element("#observability-evals-save")
+    |> render_click()
+
+    assert render(view) =~ "Saved 1 candidate(s)"
+  end
+
+  test "repeat save flashes a nothing-new message", %{conn: conn} do
+    session = session_fixture()
+
+    finding_fixture(%{
+      session: session,
+      title: "Eval candidate finding",
+      severity: "high",
+      status: "open",
+      category: "security",
+      rule_id: "security.evals"
+    })
+
+    {:ok, view, _html} = live(conn, ~p"/observability/evals")
+
+    view
+    |> element("#observability-evals-save")
+    |> render_click()
+
+    view
+    |> element("#observability-evals-save")
+    |> render_click()
+
+    assert render(view) =~ "Nothing new to save"
+  end
+end

--- a/test/controlkeel_web/live/observability_loop_live_test.exs
+++ b/test/controlkeel_web/live/observability_loop_live_test.exs
@@ -2,7 +2,11 @@ defmodule ControlKeelWeb.ObservabilityLoopLiveTest do
   use ControlKeelWeb.ConnCase, async: false
 
   import ControlKeel.MissionFixtures
+  import Ecto.Query
   import Phoenix.LiveViewTest
+
+  alias ControlKeel.Memory.Record
+  alias ControlKeel.Repo
 
   test "loop page renders read-only learning loop status", %{conn: conn} do
     session = session_fixture()
@@ -23,5 +27,45 @@ defmodule ControlKeelWeb.ObservabilityLoopLiveTest do
     assert html =~ "Automatic benchmark execution: false"
     assert html =~ "Automatic promotion: false"
     assert html =~ "controlkeel obs loop"
+  end
+
+  test "loop page renders loop diagnostics section with no detected runs", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/observability/loop")
+
+    assert html =~ "Loop diagnostics"
+    assert html =~ "Repeated tool events"
+    assert html =~ "Repeated invocations"
+    assert html =~ "No repeated identical tool-event runs detected."
+    assert html =~ "No repeated identical invocation runs detected."
+  end
+
+  test "capture performance snapshot persists a memory record and renders results", %{conn: conn} do
+    session = session_fixture()
+
+    {:ok, view, html} = live(conn, ~p"/observability/loop")
+
+    assert html =~ "No performance snapshot captured yet."
+
+    view |> element("#observability-perf-capture") |> render_click()
+
+    rendered = render(view)
+
+    assert rendered =~ "Performance snapshot"
+    assert rendered =~ "Total wall time"
+    assert rendered =~ "Ecto queries"
+    assert rendered =~ "Payload"
+
+    persisted =
+      from(r in Record,
+        where: r.source_type == "observability" and r.session_id == ^session.id,
+        order_by: [desc: :id],
+        limit: 1
+      )
+      |> Repo.one()
+
+    assert persisted
+    assert persisted.title == "Performance Snapshot"
+    assert persisted.workspace_id == session.workspace_id
+    assert persisted.metadata["total_wall_ms"] >= 0
   end
 end


### PR DESCRIPTION
## Summary

The observability section of the ControlKeel dashboard was read-only: it surfaced data but pushed every meaningful action back to the terminal ("run `controlkeel obs …`"). This PR moves the actions users would rather do in a browser onto the dashboard — saving eval candidates, archiving/generating/materializing benchmark drafts, and cost optimization guidance — and adds two observability insights to the Loop page: repeated-loop diagnostics and a capturable performance snapshot that persists a durable memory record.

Promotion is deliberate, not exhaustive: each feature is included only when it gives a human something to do in the browser or a decision-driving signal. Agent-facing execution, secrets and configuration, and long-running jobs stay CLI by design.

### Issue ref: #91 

## Changes

| Area                                                      | Before                           | After                                                                                                                                                                                                                                                                                                                                        |
| --------------------------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **Evals** (`/observability/evals`)                        | read-only; `obs evals save` pill | "Review & save candidates" button → `Observability.save_eval_candidates/1`; refreshes both active + saved lists; gets a summary flash.                                                                                                                                                                                                       |
| **Benchmark drafts** (`/observability/benchmarks/drafts`) | approve/reject buttons           | Approve now materializes in the same click (`materialize_benchmark_drafts/1`); new per-draft Archive + Generate drafts buttons; archived status pill styling; buttons disabled at terminal states.                                                                                                                                           |
| **Costs** (`/observability/costs`)                        | read-only spend                  | "Cost optimization suggestions" panel (`CostOptimizer.suggest/2`) + "Agent cost comparison" (`CostOptimizer.compare_agents/2`), both with clean empty states.                                                                                                                                                                                |
| **Loop** (`/observability/loop`)                          | read-only loop status            | New read-only "Loop diagnostics" section (`Observability.loop_diagnostics/1`): repeated tool-event + invocation runs and recommendations. New "Performance snapshot" section: capture button runs `Observability.perf_snapshot/1` with `persist: true`, persists a durable perf memory record, renders summary stat cards + per-item timing. |
| **Flash toasts**                                          | daisyUI alert styling            | Auto-hiding `FlashTimeout` hook (6s info / 10s error) with fade-out; restyled toast + close button with focus ring.                                                                                                                                                                                                                          |

## Acceptance criteria

- [x] Evals save button persists candidates and refreshes both lists.
- [x] Benchmarks approve/reject/archive/materialize update statuses and counts.
- [x] Costs renders suggestions and comparison (or a clean empty state).
- [x] No `obs evals save` / `obs benchmarks materialize|archive` pills remain in `lib/controlkeel_web` (verified via `rg`).
- [x] Loop diagnostics renders `Observability.loop_diagnostics/1` read-only on the Loop page.
- [x] Performance snapshot button calls `Observability.perf_snapshot/1` with `persist: true`, persisting a durable perf memory record and rendering the itemized results.
- [x] `mix test` + `mix precommit` green — **2175 passed, 1 excluded** (performance-tagged).

## Verification

```sh
mix test                                   # 2175 passed, 1 excluded
mix precommit                              # green; CI workflow guard passed
mix format --check-formatted               # clean
```
