### PR TITLE
⚡ Bolt: [performance improvement] Optimize Elixir list allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - [Optimize Elixir list allocations]
+**Learning:** Chaining `Enum.filter` with `length`, or `Enum.map` with `Enum.uniq` and `length`, creates unnecessary intermediate lists which adds memory overhead in Elixir.
+**Action:** Use `Enum.count/2` instead of `length(Enum.filter/2)`, and `MapSet.new/2 |> MapSet.size()` instead of `Enum.map/2 |> Enum.uniq/1 |> length/1` to minimize allocations.

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -524,7 +524,7 @@ defmodule ControlKeel.Observability do
       benchmark_drafts: drafts.count,
       approved_drafts: approved_drafts,
       materialized_scenarios: length(scenario_ids),
-      covered_scenarios: length(Enum.filter(scenario_ids, &(&1 in covered_ids))),
+      covered_scenarios: Enum.count(scenario_ids, &(&1 in covered_ids)),
       benchmark_runs: length(runs)
     }
 
@@ -1698,7 +1698,7 @@ defmodule ControlKeel.Observability do
       input_tokens: sum_invocation_field(invocations, :input_tokens),
       cached_input_tokens: sum_invocation_field(invocations, :cached_input_tokens),
       output_tokens: sum_invocation_field(invocations, :output_tokens),
-      sessions: invocations |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+      sessions: MapSet.new(invocations, & &1.session_id) |> MapSet.size()
     }
   end
 
@@ -1713,7 +1713,7 @@ defmodule ControlKeel.Observability do
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
         output_tokens: sum_invocation_field(group, :output_tokens),
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+        sessions: MapSet.new(group, & &1.session_id) |> MapSet.size()
       }
     end)
     |> Enum.sort_by(&{&1.estimated_cost_cents, &1.invocations}, :desc)
@@ -1730,7 +1730,7 @@ defmodule ControlKeel.Observability do
       %{
         name: name,
         invocations: invocation_count,
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length(),
+        sessions: MapSet.new(group, & &1.session_id) |> MapSet.size(),
         estimated_cost_cents: total_cost,
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
@@ -2194,7 +2194,7 @@ defmodule ControlKeel.Observability do
       suite: benchmark_run_suite_slug(run),
       subjects: run.subjects || [],
       total_scenarios: run.total_scenarios,
-      observed_scenarios: run.results |> Enum.map(& &1.scenario_id) |> Enum.uniq() |> length(),
+      observed_scenarios: MapSet.new(run.results, & &1.scenario_id) |> MapSet.size(),
       caught_count: run.caught_count,
       blocked_count: run.blocked_count,
       catch_rate: run.catch_rate || 0.0,


### PR DESCRIPTION
## 💡 What
Replaced `length(Enum.filter/2)` with `Enum.count/2`, and `Enum.map/2 |> Enum.uniq/1 |> length/1` with `MapSet.new/2 |> MapSet.size()` across `lib/controlkeel/observability.ex`. Added a critical learning journal entry in `.jules/bolt.md`.

## 🎯 Why
Chaining multiple `Enum` functions like `map` and `uniq` followed by `length` forces Elixir to iterate the collection multiple times and allocate intermediate lists on the heap. This causes unnecessary garbage collection and memory bloat. Replacing them with `Enum.count` and `MapSet` resolves these inefficiencies. 

## 📊 Impact
Reduces intermediate list allocations by eliminating temporary lists during iteration, leading to reduced garbage collection overhead. This should marginally increase the performance of the observability reporting functions.

## 🔬 Measurement
Run standard benchmarks or check observability report latency and memory profiles when executed against large datasets.

---
*PR created automatically by Jules for task [2646343826956504699](https://jules.google.com/task/2646343826956504699) started by @aryaminus*