### PR TITLE
⚡ Bolt: Optimize Elixir list operations to avoid intermediate allocations

### DIFF
--- a/lib/controlkeel/cloud/baseline_analyzer.ex
+++ b/lib/controlkeel/cloud/baseline_analyzer.ex
@@ -94,7 +94,8 @@ defmodule ControlKeel.Cloud.BaselineAnalyzer do
       )
       |> Repo.all()
 
-    sample_sessions = rows |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+    # Bolt: used MapSet to count unique sessions without intermediate list allocations
+    sample_sessions = MapSet.new(rows, & &1.session_id) |> MapSet.size()
 
     baseline =
       rows

--- a/lib/controlkeel/governance.ex
+++ b/lib/controlkeel/governance.ex
@@ -555,7 +555,8 @@ defmodule ControlKeel.Governance do
   end
 
   defp review_summary(decision, findings, fragments) do
-    files_reviewed = fragments |> Enum.map(& &1.path) |> Enum.uniq() |> length()
+    # Bolt: used MapSet to count unique files without intermediate list allocations
+    files_reviewed = MapSet.new(fragments, & &1.path) |> MapSet.size()
     chunks_reviewed = length(fragments)
     added_lines_reviewed = Enum.reduce(fragments, 0, &(&1.added_line_count + &2))
 

--- a/lib/controlkeel/mcp/tool_group_tracker.ex
+++ b/lib/controlkeel/mcp/tool_group_tracker.ex
@@ -162,8 +162,9 @@ defmodule ControlKeel.MCP.ToolGroupTracker do
     else
       total_calls = entries |> Enum.map(fn {_key, _ts, count} -> count end) |> Enum.sum()
 
+      # Bolt: used MapSet to count unique tools without intermediate list allocations
       unique_tools =
-        entries |> Enum.map(fn {key, _ts, _count} -> key end) |> Enum.uniq() |> length()
+        MapSet.new(entries, fn {key, _ts, _count} -> key end) |> MapSet.size()
 
       %{total_calls: total_calls, unique_tools: unique_tools}
     end

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -524,7 +524,8 @@ defmodule ControlKeel.Observability do
       benchmark_drafts: drafts.count,
       approved_drafts: approved_drafts,
       materialized_scenarios: length(scenario_ids),
-      covered_scenarios: length(Enum.filter(scenario_ids, &(&1 in covered_ids))),
+      # Bolt: used Enum.count/2 instead of length(Enum.filter/2) to avoid intermediate list allocation
+      covered_scenarios: Enum.count(scenario_ids, &(&1 in covered_ids)),
       benchmark_runs: length(runs)
     }
 
@@ -1698,7 +1699,8 @@ defmodule ControlKeel.Observability do
       input_tokens: sum_invocation_field(invocations, :input_tokens),
       cached_input_tokens: sum_invocation_field(invocations, :cached_input_tokens),
       output_tokens: sum_invocation_field(invocations, :output_tokens),
-      sessions: invocations |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+      # Bolt: used MapSet to count unique sessions without intermediate list allocations
+      sessions: MapSet.new(invocations, & &1.session_id) |> MapSet.size()
     }
   end
 
@@ -1713,7 +1715,8 @@ defmodule ControlKeel.Observability do
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
         output_tokens: sum_invocation_field(group, :output_tokens),
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+        # Bolt: used MapSet to count unique sessions without intermediate list allocations
+        sessions: MapSet.new(group, & &1.session_id) |> MapSet.size()
       }
     end)
     |> Enum.sort_by(&{&1.estimated_cost_cents, &1.invocations}, :desc)
@@ -1730,7 +1733,8 @@ defmodule ControlKeel.Observability do
       %{
         name: name,
         invocations: invocation_count,
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length(),
+        # Bolt: used MapSet to count unique sessions without intermediate list allocations
+        sessions: MapSet.new(group, & &1.session_id) |> MapSet.size(),
         estimated_cost_cents: total_cost,
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
@@ -2194,7 +2198,8 @@ defmodule ControlKeel.Observability do
       suite: benchmark_run_suite_slug(run),
       subjects: run.subjects || [],
       total_scenarios: run.total_scenarios,
-      observed_scenarios: run.results |> Enum.map(& &1.scenario_id) |> Enum.uniq() |> length(),
+      # Bolt: used MapSet to count unique scenarios without intermediate list allocations
+      observed_scenarios: MapSet.new(run.results, & &1.scenario_id) |> MapSet.size(),
       caught_count: run.caught_count,
       blocked_count: run.blocked_count,
       catch_rate: run.catch_rate || 0.0,


### PR DESCRIPTION
💡 What: Replaced inefficient `length(Enum.filter(...))` calls with `Enum.count/2` and `Enum.map(...) |> Enum.uniq() |> length()` with `MapSet.new/2 |> MapSet.size()` across `Observability`, `BaselineAnalyzer`, `ToolGroupTracker`, and `Governance` modules. Added Bolt comments explaining the changes. Created empty `.jules/bolt.md`.
🎯 Why: The original patterns create intermediate lists (from `Enum.filter`, `Enum.map`, and `Enum.uniq`) which are immediately discarded to just get the count. The replacement patterns avoid intermediate list allocations entirely.
📊 Impact: Reduces memory allocation and garbage collection overhead, particularly for endpoints dealing with many items, improving endpoint latency and lowering CPU usage.
🔬 Measurement: Can be verified by running standard Elixir benchmarks comparing `Enum.count` vs `length(Enum.filter)` and `MapSet.size` vs `length(Enum.uniq(Enum.map))`. Load testing observability APIs and inspecting memory usage should show reduced allocation rates.

---
*PR created automatically by Jules for task [7947523086271246264](https://jules.google.com/task/7947523086271246264) started by @aryaminus*