### PR TITLE
Findings Browser Web Parity, Escalation & Security Summary

### DIFF
--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -39,7 +39,7 @@ defmodule ControlKeel.Mission do
   alias ControlKeel.Scanner
   alias ControlKeel.Utils
 
-  @findings_page_size 20
+  @findings_page_size 10
   @proofs_page_size 20
   @plan_phases ~w(ticket research_packet design_options narrowed_decision implementation_plan code_backed_plan)
   @execution_ready_plan_phases ~w(implementation_plan code_backed_plan)

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -1255,6 +1255,7 @@ defmodule ControlKeel.Mission do
   end
 
   @disposition_actions ~w(resolve dismiss escalate)
+  @disposition_statuses ~w(open blocked escalated)
 
   @doc """
   Disposition a single finding via a high-level action so agents (and bulk paths) can
@@ -1315,6 +1316,35 @@ defmodule ControlKeel.Mission do
   end
 
   def dispose_session_findings(_session_id, _filter, _action), do: {:error, :invalid_action}
+
+  @doc """
+  Bulk-disposition a list of finding ids via a single action (`resolve`,
+  `dismiss`, or `escalate`). Dismissals record `opts[:reason]` on the finding
+  metadata and audit event. Only findings currently in an active status
+  (`open`, `blocked`, `escalated`) are touched, so the operation is idempotent.
+  Returns `{:ok, %{count: n, ids: [finding_id]}}`.
+  """
+  def dispose_findings(ids, action, opts \\ []) when is_list(ids) do
+    if action in @disposition_actions do
+      disposition_opts = Keyword.put(opts, :reason, opts[:reason] && to_string(opts[:reason]))
+
+      ids =
+        Enum.reduce(ids, [], fn id, acc ->
+          with %Finding{status: status} <- get_finding(id),
+               true <- status in @disposition_statuses,
+               {:ok, updated} <- do_dispose_finding(action, id, disposition_opts) do
+            [updated.id | acc]
+          else
+            _ -> acc
+          end
+        end)
+        |> Enum.reverse()
+
+      {:ok, %{count: length(ids), ids: ids}}
+    else
+      {:error, :invalid_action}
+    end
+  end
 
   defp matches_disposition_filter?(finding, filter) do
     statuses = Map.get(filter, :statuses) || ~w(open blocked escalated)

--- a/lib/controlkeel_web/live/findings_live.ex
+++ b/lib/controlkeel_web/live/findings_live.ex
@@ -5,6 +5,9 @@ defmodule ControlKeelWeb.FindingsLive do
 
   @severities ~w(critical high medium low)
   @statuses ~w(open blocked escalated approved rejected)
+  @patch_statuses ~w(none drafted validated merged)
+  @disclosure_statuses ~w(draft triaged reported patched public wont_fix)
+  @maintainer_scopes ~w(first_party open_source third_party_vendor)
 
   @impl true
   def mount(_params, _session, socket) do
@@ -20,6 +23,9 @@ defmodule ControlKeelWeb.FindingsLive do
      |> assign(:reject_reason, "")
      |> assign(:severities, @severities)
      |> assign(:statuses, @statuses)
+     |> assign(:patch_statuses, @patch_statuses)
+     |> assign(:disclosure_statuses, @disclosure_statuses)
+     |> assign(:maintainer_scopes, @maintainer_scopes)
      |> assign(:open_dropdown_id, nil)
      |> assign(:form, to_form(%{}, as: :filters))}
   end
@@ -78,6 +84,24 @@ defmodule ControlKeelWeb.FindingsLive do
          socket
          |> assign(:open_dropdown_id, nil)
          |> put_flash(:error, "ControlKeel could not approve that finding.")}
+    end
+  end
+
+  @impl true
+  def handle_event("escalate", %{"id" => id}, socket) do
+    with {:ok, finding_id} <- parse_id(id),
+         %{} = finding <- Mission.get_finding(finding_id),
+         {:ok, _updated} <- Mission.escalate_finding(finding) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Finding escalated.")
+       |> refresh_browser()}
+    else
+      _error ->
+        {:noreply,
+         socket
+         |> assign(:open_dropdown_id, nil)
+         |> put_flash(:error, "ControlKeel could not escalate that finding.")}
     end
   end
 
@@ -189,7 +213,7 @@ defmodule ControlKeelWeb.FindingsLive do
       <div class="rounded-lg border bg-card">
         <div class="space-y-4 p-4">
           <.form for={@form} phx-change="filter">
-            <div class="grid gap-4 xl:grid-cols-5">
+            <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
               <div class="space-y-2">
                 <label for="filters-q" class="text-xs uppercase tracking-[0.28em]">Search</label>
                 <input
@@ -269,6 +293,57 @@ defmodule ControlKeelWeb.FindingsLive do
                       selected={to_string(@form[:session_id].value) == to_string(id)}
                     >
                       {label}
+                    </option>
+                  <% end %>
+                </select>
+              </div>
+              <div class="space-y-2">
+                <label for="filters-patch_status" class="text-xs uppercase tracking-[0.28em]">
+                  Patch status
+                </label>
+                <select
+                  id="filters-patch_status"
+                  name="filters[patch_status]"
+                  class="w-full rounded-md border border-input bg-background px-4 py-3 text-sm text-foreground focus:border-primary focus:ring-2 focus:ring-primary/15 focus:outline-none"
+                >
+                  <option value="">All patch statuses</option>
+                  <%= for s <- @patch_statuses do %>
+                    <option value={s} selected={@form[:patch_status].value == s}>
+                      {option_label(s)}
+                    </option>
+                  <% end %>
+                </select>
+              </div>
+              <div class="space-y-2">
+                <label for="filters-disclosure_status" class="text-xs uppercase tracking-[0.28em]">
+                  Disclosure status
+                </label>
+                <select
+                  id="filters-disclosure_status"
+                  name="filters[disclosure_status]"
+                  class="w-full rounded-md border border-input bg-background px-4 py-3 text-sm text-foreground focus:border-primary focus:ring-2 focus:ring-primary/15 focus:outline-none"
+                >
+                  <option value="">All disclosure statuses</option>
+                  <%= for s <- @disclosure_statuses do %>
+                    <option value={s} selected={@form[:disclosure_status].value == s}>
+                      {option_label(s)}
+                    </option>
+                  <% end %>
+                </select>
+              </div>
+              <div class="space-y-2">
+                <label for="filters-maintainer_scope" class="text-xs uppercase tracking-[0.28em]">
+                  Maintainer scope
+                </label>
+                <select
+                  id="filters-maintainer_scope"
+                  name="filters[maintainer_scope]"
+                  class="w-full rounded-md border border-input bg-background px-4 py-3 text-sm text-foreground focus:border-primary focus:ring-2 focus:ring-primary/15 focus:outline-none"
+                >
+                  <option value="">All scopes</option>
+                  <%= for s <- @maintainer_scopes do %>
+                    <option value={s} selected={@form[:maintainer_scope].value == s}>
+                      {option_label(s)}
                     </option>
                   <% end %>
                 </select>
@@ -402,6 +477,16 @@ defmodule ControlKeelWeb.FindingsLive do
                             phx-value-id={finding.id}
                           >
                             Reject
+                          </button>
+                        <% end %>
+                        <%= if finding.status in ~w(open blocked) do %>
+                          <button
+                            type="button"
+                            class="w-full text-left px-4 py-2 text-sm text-muted-foreground hover:bg-muted transition-colors"
+                            phx-click="escalate"
+                            phx-value-id={finding.id}
+                          >
+                            Escalate
                           </button>
                         <% end %>
                         <button
@@ -670,6 +755,9 @@ defmodule ControlKeelWeb.FindingsLive do
       "status" => filters.status || "",
       "category" => filters.category || "",
       "session_id" => filters.session_id || "",
+      "patch_status" => filters.patch_status || "",
+      "disclosure_status" => filters.disclosure_status || "",
+      "maintainer_scope" => filters.maintainer_scope || "",
       "page" => filters.page
     }
   end
@@ -727,11 +815,27 @@ defmodule ControlKeelWeb.FindingsLive do
   defp empty_browser do
     %{
       entries: [],
-      filters: %{q: nil, severity: nil, status: nil, category: nil, session_id: nil, page: 1},
+      filters: %{
+        q: nil,
+        severity: nil,
+        status: nil,
+        category: nil,
+        session_id: nil,
+        patch_status: nil,
+        disclosure_status: nil,
+        maintainer_scope: nil,
+        page: 1
+      },
       total_count: 0,
       total_pages: 1,
       page: 1,
       page_size: 20
     }
   end
+
+  defp option_label("open_source"), do: "Open source"
+  defp option_label("third_party_vendor"), do: "Third party vendor"
+  defp option_label("first_party"), do: "First party"
+  defp option_label("wont_fix"), do: "Won't fix"
+  defp option_label(value), do: value |> String.replace("_", " ") |> String.capitalize()
 end

--- a/lib/controlkeel_web/live/findings_live.ex
+++ b/lib/controlkeel_web/live/findings_live.ex
@@ -1,7 +1,9 @@
 defmodule ControlKeelWeb.FindingsLive do
   use ControlKeelWeb, :live_view
 
+  alias ControlKeel.Governance.SecurityWorkflow
   alias ControlKeel.Mission
+  alias ControlKeel.Mission.FindingPlainEnglish
 
   @severities ~w(critical high medium low)
   @statuses ~w(open blocked escalated approved rejected)
@@ -19,6 +21,9 @@ defmodule ControlKeelWeb.FindingsLive do
      |> assign(:session_options, Mission.list_findings_browser_sessions())
      |> assign(:selected_finding, nil)
      |> assign(:selected_fix, nil)
+     |> assign(:selected_plain_english, nil)
+     |> assign(:selected_vuln, nil)
+     |> assign(:selected_audit_events, [])
      |> assign(:reject_id, nil)
      |> assign(:reject_reason, "")
      |> assign(:severities, @severities)
@@ -161,7 +166,10 @@ defmodule ControlKeelWeb.FindingsLive do
        socket
        |> assign(:open_dropdown_id, nil)
        |> assign(:selected_finding, finding)
-       |> assign(:selected_fix, fix)}
+       |> assign(:selected_fix, fix)
+       |> assign(:selected_plain_english, FindingPlainEnglish.translate(finding))
+       |> assign(:selected_vuln, vuln_case_summary(finding))
+       |> assign(:selected_audit_events, Mission.finding_audit_events(finding_id))}
     else
       _error ->
         {:noreply,
@@ -194,6 +202,9 @@ defmodule ControlKeelWeb.FindingsLive do
      socket
      |> assign(:selected_finding, nil)
      |> assign(:selected_fix, nil)
+     |> assign(:selected_plain_english, nil)
+     |> assign(:selected_vuln, nil)
+     |> assign(:selected_audit_events, [])
      |> assign(:open_dropdown_id, nil)}
   end
 
@@ -362,6 +373,77 @@ defmodule ControlKeelWeb.FindingsLive do
             >
               Reset all
             </.link>
+          </div>
+        </div>
+
+        <div
+          :if={@browser.security_summary["case_count"] > 0}
+          class="border-t bg-overlay/20 px-6 py-4"
+        >
+          <div class="flex flex-wrap items-center gap-x-6 gap-y-2">
+            <p class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+              Security cases
+            </p>
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="rounded-full border border-input px-3 py-1 text-sm text-muted-foreground">
+                {summary_count(@browser.security_summary, "case_count")} total
+              </span>
+              <span class="inline-flex items-center gap-1.5 rounded-full border border-[var(--ck-warning)]/40 bg-[var(--ck-warning)]/10 px-3 py-1 text-sm text-[var(--ck-warning)]">
+                {summary_count(@browser.security_summary, "unresolved")} unresolved
+              </span>
+              <span
+                :if={summary_count(@browser.security_summary, "critical_unresolved") > 0}
+                class="inline-flex items-center gap-1.5 rounded-full border border-destructive/40 bg-destructive/10 px-3 py-1 text-sm text-destructive"
+              >
+                {summary_count(@browser.security_summary, "critical_unresolved")} critical unresolved
+              </span>
+            </div>
+          </div>
+          <div class="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <div class="rounded-md border border-input bg-background/50 px-3 py-2">
+              <p class="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">Patch</p>
+              <div class="mt-1 flex flex-wrap gap-1.5">
+                <%= for {value, count} <- breakdown_entries(@browser.security_summary, "patch_status") do %>
+                  <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                    {option_label(value)} {count}
+                  </span>
+                <% end %>
+              </div>
+            </div>
+            <div class="rounded-md border border-input bg-background/50 px-3 py-2">
+              <p class="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">Disclosure</p>
+              <div class="mt-1 flex flex-wrap gap-1.5">
+                <%= for {value, count} <- breakdown_entries(@browser.security_summary, "disclosure_status") do %>
+                  <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                    {option_label(value)} {count}
+                  </span>
+                <% end %>
+              </div>
+            </div>
+            <div class="rounded-md border border-input bg-background/50 px-3 py-2">
+              <p class="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                Maintainer scope
+              </p>
+              <div class="mt-1 flex flex-wrap gap-1.5">
+                <%= for {value, count} <- breakdown_entries(@browser.security_summary, "maintainer_scope") do %>
+                  <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                    {option_label(value)} {count}
+                  </span>
+                <% end %>
+              </div>
+            </div>
+            <div class="rounded-md border border-input bg-background/50 px-3 py-2">
+              <p class="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+                Exploitability
+              </p>
+              <div class="mt-1 flex flex-wrap gap-1.5">
+                <%= for {value, count} <- breakdown_entries(@browser.security_summary, "exploitability_status") do %>
+                  <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                    {option_label(value)} {count}
+                  </span>
+                <% end %>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -627,6 +709,45 @@ defmodule ControlKeelWeb.FindingsLive do
 
           <p class="text-sm text-muted-foreground">{@selected_fix["summary"]}</p>
 
+          <div :if={@selected_plain_english && @selected_plain_english.explanation != ""}>
+            <h4 class="text-xs font-semibold uppercase tracking-[0.14em] text-primary">
+              In plain English
+            </h4>
+            <p class="mt-1 text-sm">{@selected_plain_english.explanation}</p>
+            <p :if={@selected_plain_english.fix} class="mt-2 text-sm">
+              <span class="font-semibold">Recommended:</span> {@selected_plain_english.fix}
+            </p>
+            <p
+              :if={@selected_plain_english.risk_if_ignored}
+              class="mt-2 text-sm text-[var(--ck-warning)]"
+            >
+              If ignored: {@selected_plain_english.risk_if_ignored}
+            </p>
+          </div>
+
+          <div :if={@selected_vuln} class="rounded-md border border-input bg-background/50 px-3 py-2">
+            <p class="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+              Security case
+            </p>
+            <div class="mt-1 flex flex-wrap gap-1.5">
+              <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                {option_label(@selected_vuln["patch_status"])}
+              </span>
+              <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                {option_label(@selected_vuln["disclosure_status"])}
+              </span>
+              <span class={[
+                "rounded-full px-2 py-0.5 text-[11px] border",
+                @selected_vuln["is_resolved"] &&
+                  "border-primary/40 bg-primary/10 text-primary",
+                !@selected_vuln["is_resolved"] &&
+                  "border-[var(--ck-warning)]/40 bg-[var(--ck-warning)]/10 text-[var(--ck-warning)]"
+              ]}>
+                {if @selected_vuln["is_resolved"], do: "resolved", else: "unresolved"}
+              </span>
+            </div>
+          </div>
+
           <div class="grid grid-cols-2 gap-4">
             <div>
               <h4 class="text-xs font-semibold uppercase tracking-[0.14em] text-primary">
@@ -667,6 +788,20 @@ defmodule ControlKeelWeb.FindingsLive do
               Agent prompt
             </h4>
             <pre class="mt-1 rounded-lg border border-input bg-background p-4 font-mono text-sm leading-relaxed whitespace-pre-wrap break-words max-h-60 overflow-y-auto"><code>{@selected_fix["agent_prompt"]}</code></pre>
+          </div>
+
+          <div :if={length(@selected_audit_events) > 0}>
+            <h4 class="text-xs font-semibold uppercase tracking-[0.14em] text-primary">
+              Audit trail
+            </h4>
+            <ul class="mt-1 space-y-1 list-none p-0">
+              <%= for event <- @selected_audit_events do %>
+                <li class="text-xs text-muted-foreground">
+                  {ControlKeelWeb.FormatHelpers.format_datetime(event.inserted_at, "short")} · {event.action} · {event.user_email ||
+                    "system"}
+                </li>
+              <% end %>
+            </ul>
           </div>
 
           <div class="flex items-center justify-between pt-2">
@@ -741,6 +876,14 @@ defmodule ControlKeelWeb.FindingsLive do
 
   defp maybe_regenerate_fix(nil), do: nil
   defp maybe_regenerate_fix(finding), do: Mission.auto_fix_for_finding(finding)
+
+  defp vuln_case_summary(finding) do
+    if SecurityWorkflow.vulnerability_case?(finding) do
+      SecurityWorkflow.vulnerability_case_summary(finding)
+    else
+      nil
+    end
+  end
 
   defp filter_params(params) do
     params
@@ -831,6 +974,14 @@ defmodule ControlKeelWeb.FindingsLive do
       page: 1,
       page_size: 20
     }
+  end
+
+  defp summary_count(security_summary, key), do: Map.get(security_summary, key, 0)
+
+  defp breakdown_entries(security_summary, key) do
+    security_summary
+    |> Map.get(key, %{})
+    |> Enum.sort_by(fn {_value, count} -> -count end)
   end
 
   defp option_label("open_source"), do: "Open source"

--- a/lib/controlkeel_web/live/findings_live.ex
+++ b/lib/controlkeel_web/live/findings_live.ex
@@ -26,6 +26,9 @@ defmodule ControlKeelWeb.FindingsLive do
      |> assign(:selected_audit_events, [])
      |> assign(:reject_id, nil)
      |> assign(:reject_reason, "")
+     |> assign(:selected_ids, MapSet.new())
+     |> assign(:bulk_action, nil)
+     |> assign(:bulk_reason, "")
      |> assign(:severities, @severities)
      |> assign(:statuses, @statuses)
      |> assign(:patch_statuses, @patch_statuses)
@@ -78,7 +81,7 @@ defmodule ControlKeelWeb.FindingsLive do
   def handle_event("approve", %{"id" => id}, socket) do
     with {:ok, finding_id} <- parse_id(id),
          %{} = finding <- Mission.get_finding(finding_id),
-         {:ok, _updated} <- Mission.approve_finding(finding) do
+         {:ok, _updated} <- Mission.approve_finding(finding, actor_opts(socket)) do
       {:noreply,
        socket
        |> put_flash(:info, "Finding approved.")
@@ -96,7 +99,7 @@ defmodule ControlKeelWeb.FindingsLive do
   def handle_event("escalate", %{"id" => id}, socket) do
     with {:ok, finding_id} <- parse_id(id),
          %{} = finding <- Mission.get_finding(finding_id),
-         {:ok, _updated} <- Mission.escalate_finding(finding) do
+         {:ok, _updated} <- Mission.escalate_finding(finding, actor_opts(socket)) do
       {:noreply,
        socket
        |> put_flash(:info, "Finding escalated.")
@@ -133,7 +136,7 @@ defmodule ControlKeelWeb.FindingsLive do
 
     with {:ok, finding_id} <- parse_id(id),
          %{} = finding <- Mission.get_finding(finding_id),
-         {:ok, _updated} <- Mission.reject_finding(finding, reason) do
+         {:ok, _updated} <- Mission.reject_finding(finding, reason, actor_opts(socket)) do
       {:noreply,
        socket
        |> assign(:reject_id, nil)
@@ -153,6 +156,99 @@ defmodule ControlKeelWeb.FindingsLive do
      |> assign(:reject_id, nil)
      |> assign(:reject_reason, "")
      |> assign(:open_dropdown_id, nil)}
+  end
+
+  @impl true
+  def handle_event("toggle_select", %{"id" => id}, socket) do
+    with {:ok, finding_id} <- parse_id(id) do
+      selected =
+        if MapSet.member?(socket.assigns.selected_ids, finding_id),
+          do: MapSet.delete(socket.assigns.selected_ids, finding_id),
+          else: MapSet.put(socket.assigns.selected_ids, finding_id)
+
+      {:noreply, assign(socket, :selected_ids, selected)}
+    else
+      _error -> {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("select_page", _params, socket) do
+    page_ids = Enum.map(socket.assigns.browser.entries, & &1.id)
+    selected = socket.assigns.selected_ids
+
+    all_selected? = page_ids != [] and Enum.all?(page_ids, &MapSet.member?(selected, &1))
+
+    selected =
+      if all_selected?,
+        do: Enum.reduce(page_ids, selected, &MapSet.delete(&2, &1)),
+        else: Enum.reduce(page_ids, selected, &MapSet.put(&2, &1))
+
+    {:noreply, assign(socket, :selected_ids, selected)}
+  end
+
+  @impl true
+  def handle_event("clear_selection", _params, socket) do
+    {:noreply, assign(socket, :selected_ids, MapSet.new())}
+  end
+
+  @impl true
+  def handle_event("open_bulk", %{"action" => action}, socket) do
+    if action in ~w(resolve dismiss escalate) and MapSet.size(socket.assigns.selected_ids) > 0 do
+      {:noreply,
+       socket
+       |> assign(:bulk_action, action)
+       |> assign(:bulk_reason, "")}
+    else
+      {:noreply,
+       socket
+       |> put_flash(:error, "Select at least one finding first.")}
+    end
+  end
+
+  @impl true
+  def handle_event("set_bulk_reason", %{"value" => reason}, socket) do
+    {:noreply, assign(socket, :bulk_reason, reason)}
+  end
+
+  @impl true
+  def handle_event("confirm_bulk", _params, socket) do
+    action = socket.assigns.bulk_action
+    ids = MapSet.to_list(socket.assigns.selected_ids)
+
+    reason =
+      socket.assigns.bulk_reason |> String.trim() |> then(&if &1 == "", do: nil, else: &1)
+
+    opts =
+      actor_opts(socket) ++
+        if(reason, do: [reason: reason], else: [])
+
+    with true <- action in ~w(resolve dismiss escalate),
+         true <- ids != [],
+         {:ok, %{count: count}} <- Mission.dispose_findings(ids, action, opts) do
+      {:noreply,
+       socket
+       |> assign(:selected_ids, MapSet.new())
+       |> assign(:bulk_action, nil)
+       |> assign(:bulk_reason, "")
+       |> put_flash(:info, "#{count} finding(s) #{bulk_verb(action, count)}.")
+       |> refresh_browser()}
+    else
+      _error ->
+        {:noreply,
+         socket
+         |> assign(:bulk_action, nil)
+         |> assign(:bulk_reason, "")
+         |> put_flash(:error, "ControlKeel could not dispose those findings.")}
+    end
+  end
+
+  @impl true
+  def handle_event("cancel_bulk", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:bulk_action, nil)
+     |> assign(:bulk_reason, "")}
   end
 
   @impl true
@@ -447,11 +543,65 @@ defmodule ControlKeelWeb.FindingsLive do
           </div>
         </div>
 
+        <div
+          :if={MapSet.size(@selected_ids) > 0}
+          class="border-t bg-overlay/30 px-6 py-3"
+        >
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <p class="text-sm text-muted-foreground">
+              <span class="font-semibold text-primary">{MapSet.size(@selected_ids)}</span>
+              finding(s) selected
+            </p>
+            <div class="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                class="rounded-md border border-primary bg-primary px-4 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-primary-foreground transition hover:brightness-110"
+                phx-click="open_bulk"
+                phx-value-action="resolve"
+              >
+                Resolve
+              </button>
+              <button
+                type="button"
+                class="rounded-md border border-[var(--ck-warning)]/40 bg-[var(--ck-warning)]/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-[var(--ck-warning)] transition hover:brightness-110"
+                phx-click="open_bulk"
+                phx-value-action="dismiss"
+              >
+                Dismiss
+              </button>
+              <button
+                type="button"
+                class="rounded-md border border-input bg-background px-4 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground transition hover:border-primary hover:text-primary"
+                phx-click="open_bulk"
+                phx-value-action="escalate"
+              >
+                Escalate
+              </button>
+              <button
+                type="button"
+                class="rounded-md border border-input bg-background px-4 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground transition hover:text-destructive"
+                phx-click="clear_selection"
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+        </div>
+
         <div class="overflow-x-auto w-full">
           <div class="overflow-hidden border-t bg-overlay/30">
             <table class="min-w-full divide-y divide-border">
               <thead class="bg-muted">
                 <tr>
+                  <th class="w-8 px-4 py-6 text-left">
+                    <input
+                      type="checkbox"
+                      aria-label="Select all on this page"
+                      checked={all_page_selected?(@selected_ids, @browser.entries)}
+                      phx-click="select_page"
+                      class="h-4 w-4 rounded border-input text-primary focus:ring-primary/15"
+                    />
+                  </th>
                   <th class="px-8 py-6 text-left text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
                     Finding
                   </th>
@@ -474,7 +624,7 @@ defmodule ControlKeelWeb.FindingsLive do
               </thead>
               <tbody class="divide-y divide-border">
                 <tr :if={@browser.entries == []}>
-                  <td colspan="6" class="px-8 py-12 text-center text-sm text-muted-foreground">
+                  <td colspan="7" class="px-8 py-12 text-center text-sm text-muted-foreground">
                     No findings match the current filters.
                   </td>
                 </tr>
@@ -482,6 +632,16 @@ defmodule ControlKeelWeb.FindingsLive do
                   :for={finding <- @browser.entries}
                   class="transition hover:bg-muted/[0.02]"
                 >
+                  <td class="w-8 px-4 py-6 align-top">
+                    <input
+                      type="checkbox"
+                      aria-label={"Select #{finding.title}"}
+                      checked={MapSet.member?(@selected_ids, finding.id)}
+                      phx-click="toggle_select"
+                      phx-value-id={finding.id}
+                      class="h-4 w-4 rounded border-input text-primary focus:ring-primary/15"
+                    />
+                  </td>
                   <td class="px-8 py-6 align-top">
                     <div>
                       <p class="font-bold text-foreground">{finding.title}</p>
@@ -675,6 +835,51 @@ defmodule ControlKeelWeb.FindingsLive do
       </div>
 
       <div
+        :if={@bulk_action}
+        class="fixed inset-0 z-50 flex items-center justify-center"
+        phx-key="Escape"
+        phx-key-target="window"
+      >
+        <div class="fixed inset-0 bg-overlay/60" phx-click="cancel_bulk"></div>
+        <div class="relative rounded-lg border bg-card shadow-2xl p-6 w-full max-w-md mx-4">
+          <h3 class="text-lg font-semibold text-foreground">
+            {bulk_title(@bulk_action)} findings
+          </h3>
+          <p class="mt-1 text-sm text-muted-foreground">
+            {MapSet.size(@selected_ids)} finding(s) selected.
+            <%= if @bulk_action != "dismiss" do %>
+              Only findings currently open, blocked, or escalated will be changed.
+            <% end %>
+          </p>
+          <textarea
+            :if={@bulk_action == "dismiss"}
+            class="mt-4 w-full rounded-md border border-input bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/15 focus:outline-none"
+            placeholder="Reason for dismissal..."
+            value={@bulk_reason}
+            phx-keyup="set_bulk_reason"
+            phx-debounce="blur"
+            rows="3"
+          ></textarea>
+          <div class="flex justify-end gap-3 mt-4">
+            <button
+              type="button"
+              class="rounded-md border bg-overlay px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground transition hover:border-destructive/40 hover:text-destructive"
+              phx-click="cancel_bulk"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="rounded-md border bg-overlay px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-primary transition hover:border-primary"
+              phx-click="confirm_bulk"
+            >
+              Confirm
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div
         :if={@selected_finding && @selected_fix}
         class="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto"
         phx-click-away="close_fix"
@@ -797,8 +1002,8 @@ defmodule ControlKeelWeb.FindingsLive do
             <ul class="mt-1 space-y-1 list-none p-0">
               <%= for event <- @selected_audit_events do %>
                 <li class="text-xs text-muted-foreground">
-                  {ControlKeelWeb.FormatHelpers.format_datetime(event.inserted_at, "short")} · {event.action} · {event.user_email ||
-                    "system"}
+                  {ControlKeelWeb.FormatHelpers.format_datetime(event.recorded_at, "short")} · {event.event_type} · {event.actor_identifier ||
+                    event.actor_source}
                 </li>
               <% end %>
             </ul>
@@ -977,6 +1182,30 @@ defmodule ControlKeelWeb.FindingsLive do
   end
 
   defp summary_count(security_summary, key), do: Map.get(security_summary, key, 0)
+
+  defp actor_opts(socket) do
+    case socket.assigns[:current_user] do
+      nil -> [actor_source: "web", actor_identifier: "web"]
+      user -> [actor_source: "web", actor_user_id: user.id, actor_identifier: user.email]
+    end
+  end
+
+  defp all_page_selected?(selected_ids, entries) do
+    entries != [] and Enum.all?(entries, &MapSet.member?(selected_ids, &1.id))
+  end
+
+  defp bulk_verb("resolve", count), do: pluralize(count, "resolved")
+  defp bulk_verb("dismiss", count), do: pluralize(count, "dismissed")
+  defp bulk_verb("escalate", count), do: pluralize(count, "escalated")
+  defp bulk_verb(_, _), do: "disposed"
+
+  defp pluralize(1, singular), do: singular
+  defp pluralize(_, word), do: word
+
+  defp bulk_title("resolve"), do: "Resolve"
+  defp bulk_title("dismiss"), do: "Dismiss"
+  defp bulk_title("escalate"), do: "Escalate"
+  defp bulk_title(_), do: "Dispose"
 
   defp breakdown_entries(security_summary, key) do
     security_summary

--- a/lib/controlkeel_web/live/findings_live.ex
+++ b/lib/controlkeel_web/live/findings_live.ex
@@ -24,18 +24,15 @@ defmodule ControlKeelWeb.FindingsLive do
      |> assign(:selected_plain_english, nil)
      |> assign(:selected_vuln, nil)
      |> assign(:selected_audit_events, [])
-     |> assign(:reject_id, nil)
-     |> assign(:reject_reason, "")
-     |> assign(:selected_ids, MapSet.new())
-     |> assign(:bulk_action, nil)
-     |> assign(:bulk_reason, "")
-     |> assign(:severities, @severities)
-     |> assign(:statuses, @statuses)
-     |> assign(:patch_statuses, @patch_statuses)
-     |> assign(:disclosure_statuses, @disclosure_statuses)
-     |> assign(:maintainer_scopes, @maintainer_scopes)
-     |> assign(:open_dropdown_id, nil)
-     |> assign(:form, to_form(%{}, as: :filters))}
+|> assign(:reject_id, nil)
+      |> assign(:reject_reason, "")
+      |> assign(:severities, @severities)
+      |> assign(:statuses, @statuses)
+      |> assign(:patch_statuses, @patch_statuses)
+      |> assign(:disclosure_statuses, @disclosure_statuses)
+      |> assign(:maintainer_scopes, @maintainer_scopes)
+      |> assign(:more_filters_open?, false)
+      |> assign(:form, to_form(%{}, as: :filters))}
   end
 
   @impl true
@@ -57,7 +54,7 @@ defmodule ControlKeelWeb.FindingsLive do
      |> assign(:browser, browser)
      |> assign(:selected_finding, selected_finding)
      |> assign(:selected_fix, maybe_regenerate_fix(selected_finding))
-     |> assign(:open_dropdown_id, nil)
+     |> assign(:more_filters_open?, advanced_active?(browser.filters))
      |> assign(:form, to_form(browser_form_params(browser.filters), as: :filters))}
   end
 
@@ -67,14 +64,8 @@ defmodule ControlKeelWeb.FindingsLive do
   end
 
   @impl true
-  def handle_event("toggle_dropdown", %{"id" => id}, socket) do
-    current = socket.assigns.open_dropdown_id
-    {:noreply, assign(socket, :open_dropdown_id, if(current == id, do: nil, else: id))}
-  end
-
-  @impl true
-  def handle_event("close_dropdown", _params, socket) do
-    {:noreply, assign(socket, :open_dropdown_id, nil)}
+  def handle_event("toggle_more_filters", _params, socket) do
+    {:noreply, assign(socket, :more_filters_open?, !socket.assigns.more_filters_open?)}
   end
 
   @impl true
@@ -85,13 +76,11 @@ defmodule ControlKeelWeb.FindingsLive do
       {:noreply,
        socket
        |> put_flash(:info, "Finding approved.")
-       |> refresh_browser()}
+       |> refresh_browser()
+       |> refresh_modal_context()}
     else
       _error ->
-        {:noreply,
-         socket
-         |> assign(:open_dropdown_id, nil)
-         |> put_flash(:error, "ControlKeel could not approve that finding.")}
+        {:noreply, put_flash(socket, :error, "ControlKeel could not approve that finding.")}
     end
   end
 
@@ -103,13 +92,11 @@ defmodule ControlKeelWeb.FindingsLive do
       {:noreply,
        socket
        |> put_flash(:info, "Finding escalated.")
-       |> refresh_browser()}
+       |> refresh_browser()
+       |> refresh_modal_context()}
     else
       _error ->
-        {:noreply,
-         socket
-         |> assign(:open_dropdown_id, nil)
-         |> put_flash(:error, "ControlKeel could not escalate that finding.")}
+        {:noreply, put_flash(socket, :error, "ControlKeel could not escalate that finding.")}
     end
   end
 
@@ -118,8 +105,7 @@ defmodule ControlKeelWeb.FindingsLive do
     {:noreply,
      socket
      |> assign(:reject_id, id)
-     |> assign(:reject_reason, "")
-     |> assign(:open_dropdown_id, nil)}
+     |> assign(:reject_reason, "")}
   end
 
   @impl true
@@ -142,7 +128,8 @@ defmodule ControlKeelWeb.FindingsLive do
        |> assign(:reject_id, nil)
        |> assign(:reject_reason, "")
        |> put_flash(:info, "Finding rejected.")
-       |> refresh_browser()}
+       |> refresh_browser()
+       |> refresh_modal_context()}
     else
       _error ->
         {:noreply, put_flash(socket, :error, "ControlKeel could not reject that finding.")}
@@ -154,101 +141,7 @@ defmodule ControlKeelWeb.FindingsLive do
     {:noreply,
      socket
      |> assign(:reject_id, nil)
-     |> assign(:reject_reason, "")
-     |> assign(:open_dropdown_id, nil)}
-  end
-
-  @impl true
-  def handle_event("toggle_select", %{"id" => id}, socket) do
-    with {:ok, finding_id} <- parse_id(id) do
-      selected =
-        if MapSet.member?(socket.assigns.selected_ids, finding_id),
-          do: MapSet.delete(socket.assigns.selected_ids, finding_id),
-          else: MapSet.put(socket.assigns.selected_ids, finding_id)
-
-      {:noreply, assign(socket, :selected_ids, selected)}
-    else
-      _error -> {:noreply, socket}
-    end
-  end
-
-  @impl true
-  def handle_event("select_page", _params, socket) do
-    page_ids = Enum.map(socket.assigns.browser.entries, & &1.id)
-    selected = socket.assigns.selected_ids
-
-    all_selected? = page_ids != [] and Enum.all?(page_ids, &MapSet.member?(selected, &1))
-
-    selected =
-      if all_selected?,
-        do: Enum.reduce(page_ids, selected, &MapSet.delete(&2, &1)),
-        else: Enum.reduce(page_ids, selected, &MapSet.put(&2, &1))
-
-    {:noreply, assign(socket, :selected_ids, selected)}
-  end
-
-  @impl true
-  def handle_event("clear_selection", _params, socket) do
-    {:noreply, assign(socket, :selected_ids, MapSet.new())}
-  end
-
-  @impl true
-  def handle_event("open_bulk", %{"action" => action}, socket) do
-    if action in ~w(resolve dismiss escalate) and MapSet.size(socket.assigns.selected_ids) > 0 do
-      {:noreply,
-       socket
-       |> assign(:bulk_action, action)
-       |> assign(:bulk_reason, "")}
-    else
-      {:noreply,
-       socket
-       |> put_flash(:error, "Select at least one finding first.")}
-    end
-  end
-
-  @impl true
-  def handle_event("set_bulk_reason", %{"value" => reason}, socket) do
-    {:noreply, assign(socket, :bulk_reason, reason)}
-  end
-
-  @impl true
-  def handle_event("confirm_bulk", _params, socket) do
-    action = socket.assigns.bulk_action
-    ids = MapSet.to_list(socket.assigns.selected_ids)
-
-    reason =
-      socket.assigns.bulk_reason |> String.trim() |> then(&if &1 == "", do: nil, else: &1)
-
-    opts =
-      actor_opts(socket) ++
-        if(reason, do: [reason: reason], else: [])
-
-    with true <- action in ~w(resolve dismiss escalate),
-         true <- ids != [],
-         {:ok, %{count: count}} <- Mission.dispose_findings(ids, action, opts) do
-      {:noreply,
-       socket
-       |> assign(:selected_ids, MapSet.new())
-       |> assign(:bulk_action, nil)
-       |> assign(:bulk_reason, "")
-       |> put_flash(:info, "#{count} finding(s) #{bulk_verb(action, count)}.")
-       |> refresh_browser()}
-    else
-      _error ->
-        {:noreply,
-         socket
-         |> assign(:bulk_action, nil)
-         |> assign(:bulk_reason, "")
-         |> put_flash(:error, "ControlKeel could not dispose those findings.")}
-    end
-  end
-
-  @impl true
-  def handle_event("cancel_bulk", _params, socket) do
-    {:noreply,
-     socket
-     |> assign(:bulk_action, nil)
-     |> assign(:bulk_reason, "")}
+     |> assign(:reject_reason, "")}
   end
 
   @impl true
@@ -260,7 +153,6 @@ defmodule ControlKeelWeb.FindingsLive do
 
       {:noreply,
        socket
-       |> assign(:open_dropdown_id, nil)
        |> assign(:selected_finding, finding)
        |> assign(:selected_fix, fix)
        |> assign(:selected_plain_english, FindingPlainEnglish.translate(finding))
@@ -270,7 +162,6 @@ defmodule ControlKeelWeb.FindingsLive do
       _error ->
         {:noreply,
          socket
-         |> assign(:open_dropdown_id, nil)
          |> put_flash(:error, "ControlKeel could not load that fix.")}
     end
   end
@@ -300,27 +191,91 @@ defmodule ControlKeelWeb.FindingsLive do
      |> assign(:selected_fix, nil)
      |> assign(:selected_plain_english, nil)
      |> assign(:selected_vuln, nil)
-     |> assign(:selected_audit_events, [])
-     |> assign(:open_dropdown_id, nil)}
+     |> assign(:selected_audit_events, [])}
   end
 
   @impl true
   def render(assigns) do
     ~H"""
-    <section class="mx-auto w-[min(1180px,calc(100%-2rem))] pt-8 pb-16">
-      <div class="space-y-1 mb-12">
-        <h2 class="text-2xl font-semibold text-primary leading-6 tracking-wide uppercase">
-          Findings browser
-        </h2>
-        <p class="text-muted-foreground">
-          Filter, approve, reject, and inspect guided fixes without leaving the governed ControlKeel workflow.
-        </p>
+    <section>
+      <.page_title
+        title="Findings browser"
+        subtitle="Filter, approve, reject, and inspect guided fixes without leaving the governed ControlKeel workflow."
+        class="mb-6"
+      />
+
+      <div
+        :if={@browser.security_summary["case_count"] > 0}
+        class="rounded-2xl border bg-card shadow-card p-5 mb-4"
+      >
+        <div class="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
+          <.section_title>Security cases</.section_title>
+          <p class="text-sm text-muted-foreground">
+            <span class="font-semibold text-foreground/90">
+              {summary_count(@browser.security_summary, "case_count")} total
+            </span>
+            <span class="mx-2 text-border">·</span>
+            <span class="text-warning">
+              {summary_count(@browser.security_summary, "unresolved")} unresolved
+            </span>
+            <span
+              :if={summary_count(@browser.security_summary, "critical_unresolved") > 0}
+              class="text-destructive"
+            >
+              <span class="mx-2 text-border">·</span>
+              {summary_count(@browser.security_summary, "critical_unresolved")} critical
+              unresolved
+            </span>
+          </p>
+        </div>
+        <div class="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div>
+            <p class="text-sm font-medium text-muted-foreground">Patch</p>
+            <div class="mt-2 flex flex-wrap gap-1.5">
+              <%= for {value, count} <- breakdown_entries(@browser.security_summary, "patch_status") do %>
+                <span class="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                  {option_label(value)} {count}
+                </span>
+              <% end %>
+            </div>
+          </div>
+          <div>
+            <p class="text-sm font-medium text-muted-foreground">Disclosure</p>
+            <div class="mt-2 flex flex-wrap gap-1.5">
+              <%= for {value, count} <- breakdown_entries(@browser.security_summary, "disclosure_status") do %>
+                <span class="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                  {option_label(value)} {count}
+                </span>
+              <% end %>
+            </div>
+          </div>
+          <div>
+            <p class="text-sm font-medium text-muted-foreground">Maintainer scope</p>
+            <div class="mt-2 flex flex-wrap gap-1.5">
+              <%= for {value, count} <- breakdown_entries(@browser.security_summary, "maintainer_scope") do %>
+                <span class="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                  {option_label(value)} {count}
+                </span>
+              <% end %>
+            </div>
+          </div>
+          <div>
+            <p class="text-sm font-medium text-muted-foreground">Exploitability</p>
+            <div class="mt-2 flex flex-wrap gap-1.5">
+              <%= for {value, count} <- breakdown_entries(@browser.security_summary, "exploitability_status") do %>
+                <span class="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                  {option_label(value)} {count}
+                </span>
+              <% end %>
+            </div>
+          </div>
+        </div>
       </div>
 
-      <div class="rounded-lg border bg-card">
-        <div class="space-y-4 p-4">
+      <div class="rounded-2xl border bg-card shadow-card overflow-clip">
+        <div class="space-y-4 p-5">
           <.form for={@form} phx-change="filter">
-            <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
               <div class="space-y-2">
                 <label for="filters-q" class="text-xs uppercase tracking-[0.28em]">Search</label>
                 <input
@@ -368,23 +323,6 @@ defmodule ControlKeelWeb.FindingsLive do
                 </select>
               </div>
               <div class="space-y-2">
-                <label for="filters-category" class="text-xs uppercase tracking-[0.28em]">
-                  Category
-                </label>
-                <select
-                  id="filters-category"
-                  name="filters[category]"
-                  class="w-full rounded-md border border-input bg-background px-4 py-3 text-sm text-foreground focus:border-primary focus:ring-2 focus:ring-primary/15 focus:outline-none"
-                >
-                  <option value="">All categories</option>
-                  <%= for c <- @categories do %>
-                    <option value={c} selected={@form[:category].value == c}>
-                      {String.capitalize(c)}
-                    </option>
-                  <% end %>
-                </select>
-              </div>
-              <div class="space-y-2">
                 <label for="filters-session_id" class="text-xs uppercase tracking-[0.28em]">
                   Session
                 </label>
@@ -400,6 +338,41 @@ defmodule ControlKeelWeb.FindingsLive do
                       selected={to_string(@form[:session_id].value) == to_string(id)}
                     >
                       {label}
+                    </option>
+                  <% end %>
+                </select>
+              </div>
+            </div>
+
+            <div class="flex justify-end mt-4">
+              <button
+                type="button"
+                class="rounded-md border border-input bg-background px-4 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground transition hover:border-primary hover:text-primary"
+                phx-click="toggle_more_filters"
+              >
+                {more_filters_label(@form, @more_filters_open?)}
+              </button>
+            </div>
+
+            <div
+              class={[
+                "grid gap-4 md:grid-cols-2 xl:grid-cols-3 mt-4",
+                !@more_filters_open? && "hidden"
+              ]}
+            >
+              <div class="space-y-2">
+                <label for="filters-category" class="text-xs uppercase tracking-[0.28em]">
+                  Category
+                </label>
+                <select
+                  id="filters-category"
+                  name="filters[category]"
+                  class="w-full rounded-md border border-input bg-background px-4 py-3 text-sm text-foreground focus:border-primary focus:ring-2 focus:ring-primary/15 focus:outline-none"
+                >
+                  <option value="">All categories</option>
+                  <%= for c <- @categories do %>
+                    <option value={c} selected={@form[:category].value == c}>
+                      {String.capitalize(c)}
                     </option>
                   <% end %>
                 </select>
@@ -472,283 +445,58 @@ defmodule ControlKeelWeb.FindingsLive do
           </div>
         </div>
 
-        <div
-          :if={@browser.security_summary["case_count"] > 0}
-          class="border-t bg-overlay/20 px-6 py-4"
-        >
-          <div class="flex flex-wrap items-center gap-x-6 gap-y-2">
-            <p class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-              Security cases
-            </p>
-            <div class="flex flex-wrap items-center gap-2">
-              <span class="rounded-full border border-input px-3 py-1 text-sm text-muted-foreground">
-                {summary_count(@browser.security_summary, "case_count")} total
-              </span>
-              <span class="inline-flex items-center gap-1.5 rounded-full border border-[var(--ck-warning)]/40 bg-[var(--ck-warning)]/10 px-3 py-1 text-sm text-[var(--ck-warning)]">
-                {summary_count(@browser.security_summary, "unresolved")} unresolved
-              </span>
-              <span
-                :if={summary_count(@browser.security_summary, "critical_unresolved") > 0}
-                class="inline-flex items-center gap-1.5 rounded-full border border-destructive/40 bg-destructive/10 px-3 py-1 text-sm text-destructive"
-              >
-                {summary_count(@browser.security_summary, "critical_unresolved")} critical unresolved
-              </span>
-            </div>
-          </div>
-          <div class="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-            <div class="rounded-md border border-input bg-background/50 px-3 py-2">
-              <p class="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">Patch</p>
-              <div class="mt-1 flex flex-wrap gap-1.5">
-                <%= for {value, count} <- breakdown_entries(@browser.security_summary, "patch_status") do %>
-                  <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-                    {option_label(value)} {count}
+        <div class="border-t bg-muted/20">
+          <ul class="divide-y divide-border">
+            <li
+              :if={@browser.entries == []}
+              class="px-6 py-12 text-center text-sm text-muted-foreground"
+            >
+              No findings match the current filters.
+            </li>
+            <li
+              :for={finding <- @browser.entries}
+              class="px-6 py-5 transition hover:bg-muted/[0.02]"
+            >
+              <div class="flex items-start justify-between gap-4">
+                <div class="flex flex-wrap items-center gap-3">
+                  <span class={[pill_base(), severity_colors(finding.severity)]}>
+                    {finding.severity}
                   </span>
-                <% end %>
-              </div>
-            </div>
-            <div class="rounded-md border border-input bg-background/50 px-3 py-2">
-              <p class="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">Disclosure</p>
-              <div class="mt-1 flex flex-wrap gap-1.5">
-                <%= for {value, count} <- breakdown_entries(@browser.security_summary, "disclosure_status") do %>
-                  <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-                    {option_label(value)} {count}
-                  </span>
-                <% end %>
-              </div>
-            </div>
-            <div class="rounded-md border border-input bg-background/50 px-3 py-2">
-              <p class="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
-                Maintainer scope
-              </p>
-              <div class="mt-1 flex flex-wrap gap-1.5">
-                <%= for {value, count} <- breakdown_entries(@browser.security_summary, "maintainer_scope") do %>
-                  <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-                    {option_label(value)} {count}
-                  </span>
-                <% end %>
-              </div>
-            </div>
-            <div class="rounded-md border border-input bg-background/50 px-3 py-2">
-              <p class="text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
-                Exploitability
-              </p>
-              <div class="mt-1 flex flex-wrap gap-1.5">
-                <%= for {value, count} <- breakdown_entries(@browser.security_summary, "exploitability_status") do %>
-                  <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-                    {option_label(value)} {count}
-                  </span>
-                <% end %>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div
-          :if={MapSet.size(@selected_ids) > 0}
-          class="border-t bg-overlay/30 px-6 py-3"
-        >
-          <div class="flex flex-wrap items-center justify-between gap-3">
-            <p class="text-sm text-muted-foreground">
-              <span class="font-semibold text-primary">{MapSet.size(@selected_ids)}</span>
-              finding(s) selected
-            </p>
-            <div class="flex flex-wrap items-center gap-2">
-              <button
-                type="button"
-                class="rounded-md border border-primary bg-primary px-4 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-primary-foreground transition hover:brightness-110"
-                phx-click="open_bulk"
-                phx-value-action="resolve"
-              >
-                Resolve
-              </button>
-              <button
-                type="button"
-                class="rounded-md border border-[var(--ck-warning)]/40 bg-[var(--ck-warning)]/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-[var(--ck-warning)] transition hover:brightness-110"
-                phx-click="open_bulk"
-                phx-value-action="dismiss"
-              >
-                Dismiss
-              </button>
-              <button
-                type="button"
-                class="rounded-md border border-input bg-background px-4 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground transition hover:border-primary hover:text-primary"
-                phx-click="open_bulk"
-                phx-value-action="escalate"
-              >
-                Escalate
-              </button>
-              <button
-                type="button"
-                class="rounded-md border border-input bg-background px-4 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground transition hover:text-destructive"
-                phx-click="clear_selection"
-              >
-                Clear
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <div class="overflow-x-auto w-full">
-          <div class="overflow-hidden border-t bg-overlay/30">
-            <table class="min-w-full divide-y divide-border">
-              <thead class="bg-muted">
-                <tr>
-                  <th class="w-8 px-4 py-6 text-left">
-                    <input
-                      type="checkbox"
-                      aria-label="Select all on this page"
-                      checked={all_page_selected?(@selected_ids, @browser.entries)}
-                      phx-click="select_page"
-                      class="h-4 w-4 rounded border-input text-primary focus:ring-primary/15"
-                    />
-                  </th>
-                  <th class="px-8 py-6 text-left text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-                    Finding
-                  </th>
-                  <th class="px-8 py-6 text-left text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-                    Session
-                  </th>
-                  <th class="px-8 py-6 text-left text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-                    Severity
-                  </th>
-                  <th class="px-8 py-6 text-left text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-                    Status
-                  </th>
-                  <th class="px-8 py-6 text-left text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-                    Rule
-                  </th>
-                  <th class="w-0 px-2 py-6 text-right text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-border">
-                <tr :if={@browser.entries == []}>
-                  <td colspan="7" class="px-8 py-12 text-center text-sm text-muted-foreground">
-                    No findings match the current filters.
-                  </td>
-                </tr>
-                <tr
-                  :for={finding <- @browser.entries}
-                  class="transition hover:bg-muted/[0.02]"
+                  <span class={status_pill(finding.status)}>{finding.status}</span>
+                </div>
+                <button
+                  type="button"
+                  class="shrink-0 rounded-md border border-input bg-background px-4 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-primary transition hover:border-primary"
+                  phx-click="view_fix"
+                  phx-value-id={finding.id}
                 >
-                  <td class="w-8 px-4 py-6 align-top">
-                    <input
-                      type="checkbox"
-                      aria-label={"Select #{finding.title}"}
-                      checked={MapSet.member?(@selected_ids, finding.id)}
-                      phx-click="toggle_select"
-                      phx-value-id={finding.id}
-                      class="h-4 w-4 rounded border-input text-primary focus:ring-primary/15"
-                    />
-                  </td>
-                  <td class="px-8 py-6 align-top">
-                    <div>
-                      <p class="font-bold text-foreground">{finding.title}</p>
-                      <p class="mt-2 max-w-md text-sm text-muted-foreground">
-                        {finding.plain_message}
-                      </p>
-                    </div>
-                  </td>
-                  <td class="px-8 py-6 align-top">
-                    <.link
-                      navigate={~p"/sessions/#{finding.session_id}"}
-                      class="text-xs font-semibold tracking-[0.14em] text-primary hover:underline"
-                    >
-                      {finding.session.title}
-                    </.link>
-                  </td>
-                  <td class="px-8 py-6 align-top">
-                    <span class={[pill_base(), severity_colors(finding.severity)]}>
-                      {finding.severity}
-                    </span>
-                  </td>
-                  <td class="px-8 py-6 align-top">
-                    <span class={[pill_base(), "bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]"]}>
-                      {finding.status}
-                    </span>
-                    <p
-                      :if={finding.status == "rejected" && finding.metadata["rejection_reason"]}
-                      class="mt-2 text-xs text-muted-foreground italic"
-                    >
-                      {finding.metadata["rejection_reason"]}
-                    </p>
-                  </td>
-                  <td class="px-8 py-6 align-top">
-                    <p>{rule_label(finding.rule_id)}</p>
-                  </td>
-                  <td class="px-2 py-6 text-right align-top">
-                    <div class="relative inline-flex">
-                      <button
-                        type="button"
-                        aria-label="Finding actions"
-                        class="flex items-center justify-center w-8 h-8 rounded-md border border-input bg-background hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                        phx-click="toggle_dropdown"
-                        phx-value-id={finding.id}
-                      >
-                        ⋮
-                      </button>
-                      <div
-                        :if={@open_dropdown_id == to_string(finding.id)}
-                        class="absolute right-0 top-full mt-1 z-50 min-w-[140px] rounded-lg border bg-card shadow-2xl py-1"
-                        phx-click-away="close_dropdown"
-                      >
-                        <%= if finding.status == "approved" do %>
-                          <span class="block w-full text-left px-4 py-2 text-sm text-muted-foreground cursor-not-allowed">
-                            Approved
-                          </span>
-                        <% else %>
-                          <button
-                            type="button"
-                            class="w-full text-left px-4 py-2 text-sm text-muted-foreground hover:bg-muted transition-colors"
-                            phx-click="approve"
-                            phx-value-id={finding.id}
-                          >
-                            Approve
-                          </button>
-                        <% end %>
-                        <%= if finding.status == "rejected" do %>
-                          <span class="block w-full text-left px-4 py-2 text-sm text-muted-foreground cursor-not-allowed">
-                            Rejected
-                          </span>
-                        <% else %>
-                          <button
-                            type="button"
-                            class="w-full text-left px-4 py-2 text-sm text-muted-foreground hover:bg-muted transition-colors"
-                            phx-click="reject"
-                            phx-value-id={finding.id}
-                          >
-                            Reject
-                          </button>
-                        <% end %>
-                        <%= if finding.status in ~w(open blocked) do %>
-                          <button
-                            type="button"
-                            class="w-full text-left px-4 py-2 text-sm text-muted-foreground hover:bg-muted transition-colors"
-                            phx-click="escalate"
-                            phx-value-id={finding.id}
-                          >
-                            Escalate
-                          </button>
-                        <% end %>
-                        <button
-                          type="button"
-                          class="w-full text-left px-4 py-2 text-sm text-muted-foreground hover:bg-muted transition-colors"
-                          phx-click="view_fix"
-                          phx-value-id={finding.id}
-                        >
-                          View fix
-                        </button>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+                  View
+                </button>
+              </div>
+              <h3 class="mt-3 font-bold text-foreground break-words">{finding.title}</h3>
+              <p class="mt-1 text-sm text-muted-foreground break-words">{finding.plain_message}</p>
+              <div class="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                <span>session:</span>
+                <.link
+                  navigate={~p"/sessions/#{finding.session_id}"}
+                  class="font-semibold text-primary hover:underline"
+                >
+                  {finding.session.title}
+                </.link>
+                <span aria-hidden="true">·</span>
+                <span>rule: {rule_label(finding.rule_id)}</span>
+              </div>
+              <p
+                :if={finding.status == "rejected" && finding.metadata["rejection_reason"]}
+                class="mt-2 text-xs text-muted-foreground italic"
+              >
+                {finding.metadata["rejection_reason"]}
+              </p>
+            </li>
+          </ul>
         </div>
 
-        <div class="border-t bg-overlay/40 px-6 py-4">
+        <div class="border-t bg-muted/20 px-6 py-4">
           <div class="flex flex-wrap items-center justify-between gap-4">
             <div class="text-xs uppercase tracking-[0.15em] text-muted-foreground">
               Page {@browser.page} of {@browser.total_pages}
@@ -797,12 +545,12 @@ defmodule ControlKeelWeb.FindingsLive do
 
       <div
         :if={@reject_id}
-        class="fixed inset-0 z-50 flex items-center justify-center"
+        class="fixed inset-0 z-[60] flex items-center justify-center"
         phx-key="Escape"
         phx-key-target="window"
       >
         <div class="fixed inset-0 bg-overlay/60" phx-click="cancel_reject"></div>
-        <div class="relative rounded-lg border bg-card shadow-2xl p-6 w-full max-w-md mx-4">
+        <div class="relative rounded-2xl border bg-card shadow-card p-6 w-full max-w-md mx-4">
           <h3 class="text-lg font-semibold text-foreground">Reject finding</h3>
           <p class="mt-1 text-sm text-muted-foreground">
             Rule: {rejected_finding_title(@browser.entries, @reject_id)}
@@ -835,51 +583,6 @@ defmodule ControlKeelWeb.FindingsLive do
       </div>
 
       <div
-        :if={@bulk_action}
-        class="fixed inset-0 z-50 flex items-center justify-center"
-        phx-key="Escape"
-        phx-key-target="window"
-      >
-        <div class="fixed inset-0 bg-overlay/60" phx-click="cancel_bulk"></div>
-        <div class="relative rounded-lg border bg-card shadow-2xl p-6 w-full max-w-md mx-4">
-          <h3 class="text-lg font-semibold text-foreground">
-            {bulk_title(@bulk_action)} findings
-          </h3>
-          <p class="mt-1 text-sm text-muted-foreground">
-            {MapSet.size(@selected_ids)} finding(s) selected.
-            <%= if @bulk_action != "dismiss" do %>
-              Only findings currently open, blocked, or escalated will be changed.
-            <% end %>
-          </p>
-          <textarea
-            :if={@bulk_action == "dismiss"}
-            class="mt-4 w-full rounded-md border border-input bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/15 focus:outline-none"
-            placeholder="Reason for dismissal..."
-            value={@bulk_reason}
-            phx-keyup="set_bulk_reason"
-            phx-debounce="blur"
-            rows="3"
-          ></textarea>
-          <div class="flex justify-end gap-3 mt-4">
-            <button
-              type="button"
-              class="rounded-md border bg-overlay px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground transition hover:border-destructive/40 hover:text-destructive"
-              phx-click="cancel_bulk"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              class="rounded-md border bg-overlay px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-primary transition hover:border-primary"
-              phx-click="confirm_bulk"
-            >
-              Confirm
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <div
         :if={@selected_finding && @selected_fix}
         class="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto"
         phx-click-away="close_fix"
@@ -887,7 +590,7 @@ defmodule ControlKeelWeb.FindingsLive do
         phx-key-target="window"
       >
         <div class="fixed inset-0 bg-overlay/60" phx-click="close_fix"></div>
-        <div class="relative rounded-lg border bg-card shadow-2xl p-8 w-full max-w-2xl mx-4 space-y-4">
+        <div class="relative rounded-2xl border bg-card shadow-card p-8 w-full max-w-2xl mx-4 space-y-4">
           <button
             type="button"
             class="absolute top-2 right-2 text-muted-foreground hover:text-foreground transition"
@@ -902,14 +605,19 @@ defmodule ControlKeelWeb.FindingsLive do
               </p>
               <h3 class="text-lg font-semibold text-foreground mt-1">{@selected_finding.title}</h3>
             </div>
-            <span class={[
-              "inline-flex items-center px-3 py-1 text-xs font-semibold rounded-full border uppercase tracking-wider",
-              @selected_fix["supported"] && "border-primary/40 bg-primary/10 text-primary",
-              !@selected_fix["supported"] &&
-                "border-[var(--ck-warning)]/40 bg-[var(--ck-warning)]/10 text-[var(--ck-warning)]"
-            ]}>
-              {if @selected_fix["supported"], do: "supported", else: "manual review"}
-            </span>
+            <div class="flex shrink-0 items-center gap-2">
+              <span class={status_pill(@selected_finding.status)}>
+                {@selected_finding.status}
+              </span>
+              <span class={[
+                "inline-flex items-center px-3 py-1 text-xs font-semibold rounded-full border uppercase tracking-wider",
+                @selected_fix["supported"] && "border-primary/40 bg-primary/10 text-primary",
+                !@selected_fix["supported"] &&
+                  "border-warning/40 bg-warning/10 text-warning"
+              ]}>
+                {if @selected_fix["supported"], do: "supported", else: "manual review"}
+              </span>
+            </div>
           </div>
 
           <p class="text-sm text-muted-foreground">{@selected_fix["summary"]}</p>
@@ -924,7 +632,7 @@ defmodule ControlKeelWeb.FindingsLive do
             </p>
             <p
               :if={@selected_plain_english.risk_if_ignored}
-              class="mt-2 text-sm text-[var(--ck-warning)]"
+              class="mt-2 text-sm text-warning"
             >
               If ignored: {@selected_plain_english.risk_if_ignored}
             </p>
@@ -946,7 +654,7 @@ defmodule ControlKeelWeb.FindingsLive do
                 @selected_vuln["is_resolved"] &&
                   "border-primary/40 bg-primary/10 text-primary",
                 !@selected_vuln["is_resolved"] &&
-                  "border-[var(--ck-warning)]/40 bg-[var(--ck-warning)]/10 text-[var(--ck-warning)]"
+                  "border-warning/40 bg-warning/10 text-warning"
               ]}>
                 {if @selected_vuln["is_resolved"], do: "resolved", else: "unresolved"}
               </span>
@@ -1009,16 +717,52 @@ defmodule ControlKeelWeb.FindingsLive do
             </ul>
           </div>
 
-          <div class="flex items-center justify-between pt-2">
+          <div class="flex flex-wrap items-center gap-3 border-t border-border pt-4">
             <button
-              :if={@selected_fix["agent_prompt"]}
+              :if={@selected_finding.status != "approved"}
               type="button"
               class="rounded-md border border-primary bg-primary px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-primary-foreground transition hover:brightness-110"
-              phx-click="copy_fix_prompt"
+              phx-click="approve"
               phx-value-id={@selected_finding.id}
             >
-              Copy fix prompt
+              Approve
             </button>
+            <button
+              :if={@selected_finding.status != "rejected"}
+              type="button"
+              class="rounded-md border border-warning/40 bg-warning/10 px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-warning transition hover:brightness-110"
+              phx-click="reject"
+              phx-value-id={@selected_finding.id}
+            >
+              Reject
+            </button>
+            <button
+              :if={@selected_finding.status in ~w(open blocked)}
+              type="button"
+              class="rounded-md border border-input bg-background px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground transition hover:border-primary hover:text-primary"
+              phx-click="escalate"
+              phx-value-id={@selected_finding.id}
+            >
+              Escalate
+            </button>
+            <div class="ml-auto flex flex-wrap items-center gap-3">
+              <button
+                :if={@selected_fix["agent_prompt"]}
+                type="button"
+                class="rounded-md border border-primary bg-primary px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-primary-foreground transition hover:brightness-110"
+                phx-click="copy_fix_prompt"
+                phx-value-id={@selected_finding.id}
+              >
+                Copy fix prompt
+              </button>
+              <button
+                type="button"
+                class="rounded-md border bg-overlay px-5 py-2 text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground transition hover:border-destructive/40 hover:text-destructive"
+                phx-click="close_fix"
+              >
+                Close
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -1038,14 +782,21 @@ defmodule ControlKeelWeb.FindingsLive do
   end
 
   defp pill_base do
-    "inline-flex items-center px-3 py-1.5 text-sm rounded-full border"
+    "inline-flex items-center px-2.5 py-1 text-xs font-semibold capitalize ring-1"
   end
 
-  defp severity_colors("critical"), do: "bg-[rgba(255,143,107,0.12)] text-[#ffd6cb]"
-  defp severity_colors("high"), do: "bg-[rgba(255,143,107,0.12)] text-[#ffd6cb]"
-  defp severity_colors("medium"), do: "bg-[rgba(255,207,107,0.12)] text-[#fff0bf]"
-  defp severity_colors("low"), do: "bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]"
-  defp severity_colors(_), do: "bg-muted text-foreground/70"
+  defp severity_colors(severe) when severe in ~w(critical high),
+    do: "bg-destructive/10 text-destructive ring-destructive/20"
+
+  defp severity_colors("medium"), do: "bg-warning/10 text-warning ring-warning/20"
+  defp severity_colors("low"), do: "bg-success/10 text-success ring-success/20"
+  defp severity_colors(_), do: "bg-muted text-muted-foreground ring-border"
+
+  defp status_pill("approved"), do: [pill_base(), "bg-success/10 text-success ring-success/20"]
+  defp status_pill("rejected"), do: [pill_base(), "bg-destructive/10 text-destructive ring-destructive/20"]
+  defp status_pill("escalated"), do: [pill_base(), "bg-primary/10 text-primary ring-primary/20"]
+  defp status_pill("blocked"), do: [pill_base(), "bg-warning/10 text-warning ring-warning/20"]
+  defp status_pill(_status), do: [pill_base(), "bg-muted text-muted-foreground ring-border"]
 
   defp rejected_finding_title(entries, reject_id) do
     case Enum.find(entries, &(to_string(&1.id) == reject_id)) do
@@ -1075,12 +826,57 @@ defmodule ControlKeelWeb.FindingsLive do
     |> assign(:browser, browser)
     |> assign(:selected_finding, selected_finding)
     |> assign(:selected_fix, maybe_regenerate_fix(selected_finding))
-    |> assign(:open_dropdown_id, nil)
     |> assign(:form, to_form(browser_form_params(browser.filters), as: :filters))
   end
 
   defp maybe_regenerate_fix(nil), do: nil
   defp maybe_regenerate_fix(finding), do: Mission.auto_fix_for_finding(finding)
+
+  defp refresh_modal_context(socket) do
+    case socket.assigns.selected_finding do
+      %{id: id} ->
+        with %{} = finding <- Mission.get_finding_with_context(id) do
+          socket
+          |> assign(:selected_finding, finding)
+          |> assign(:selected_fix, Mission.auto_fix_for_finding(finding))
+          |> assign(:selected_plain_english, FindingPlainEnglish.translate(finding))
+          |> assign(:selected_vuln, vuln_case_summary(finding))
+          |> assign(:selected_audit_events, Mission.finding_audit_events(id))
+        else
+          _error -> socket
+        end
+
+      _other ->
+        socket
+    end
+  end
+
+  defp more_filters_label(_form, true), do: "Fewer filters"
+
+  defp more_filters_label(form, false) do
+    case advanced_filter_count(form) do
+      0 -> "More filters"
+      n -> "More filters (#{n} active)"
+    end
+  end
+
+defp advanced_filter_count(form) do
+  Enum.count(advanced_filter_keys(), &(not empty_filter_value?(input_value(form, &1))))
+end
+
+defp advanced_active?(filters) do
+  Enum.any?(advanced_filter_keys(), &(not empty_filter_value?(Map.get(filters, &1))))
+end
+
+defp advanced_filter_keys do
+  [:category, :patch_status, :disclosure_status, :maintainer_scope]
+end
+
+defp input_value(form, key), do: Phoenix.HTML.Form.input_value(form, key)
+
+  defp empty_filter_value?(nil), do: true
+  defp empty_filter_value?(value) when is_binary(value), do: value == ""
+  defp empty_filter_value?(_value), do: false
 
   defp vuln_case_summary(finding) do
     if SecurityWorkflow.vulnerability_case?(finding) do
@@ -1177,7 +973,7 @@ defmodule ControlKeelWeb.FindingsLive do
       total_count: 0,
       total_pages: 1,
       page: 1,
-      page_size: 20
+      page_size: 10
     }
   end
 
@@ -1189,23 +985,6 @@ defmodule ControlKeelWeb.FindingsLive do
       user -> [actor_source: "web", actor_user_id: user.id, actor_identifier: user.email]
     end
   end
-
-  defp all_page_selected?(selected_ids, entries) do
-    entries != [] and Enum.all?(entries, &MapSet.member?(selected_ids, &1.id))
-  end
-
-  defp bulk_verb("resolve", count), do: pluralize(count, "resolved")
-  defp bulk_verb("dismiss", count), do: pluralize(count, "dismissed")
-  defp bulk_verb("escalate", count), do: pluralize(count, "escalated")
-  defp bulk_verb(_, _), do: "disposed"
-
-  defp pluralize(1, singular), do: singular
-  defp pluralize(_, word), do: word
-
-  defp bulk_title("resolve"), do: "Resolve"
-  defp bulk_title("dismiss"), do: "Dismiss"
-  defp bulk_title("escalate"), do: "Escalate"
-  defp bulk_title(_), do: "Dispose"
 
   defp breakdown_entries(security_summary, key) do
     security_summary

--- a/lib/controlkeel_web/live/mission_control_live.ex
+++ b/lib/controlkeel_web/live/mission_control_live.ex
@@ -111,7 +111,7 @@ defmodule ControlKeelWeb.MissionControlLive do
   def handle_event("approve_finding", %{"id" => id}, socket) do
     with {:ok, finding_id} <- parse_id(id),
          %{} = finding <- Enum.find(socket.assigns.session.findings, &(&1.id == finding_id)),
-         {:ok, _updated} <- Mission.approve_finding(finding) do
+         {:ok, _updated} <- Mission.approve_finding(finding, actor_opts(socket)) do
       case Mission.get_session_context(socket.assigns.session.id) do
         nil ->
           {:noreply, socket}
@@ -135,7 +135,7 @@ defmodule ControlKeelWeb.MissionControlLive do
 
     with {:ok, finding_id} <- parse_id(id),
          %{} = finding <- Enum.find(socket.assigns.session.findings, &(&1.id == finding_id)),
-         {:ok, _updated} <- Mission.reject_finding(finding, reason) do
+         {:ok, _updated} <- Mission.reject_finding(finding, reason, actor_opts(socket)) do
       case Mission.get_session_context(socket.assigns.session.id) do
         nil ->
           {:noreply, socket}
@@ -1330,6 +1330,13 @@ defmodule ControlKeelWeb.MissionControlLive do
     case Integer.parse(to_string(value)) do
       {parsed, ""} -> {:ok, parsed}
       _ -> {:error, :invalid_id}
+    end
+  end
+
+  defp actor_opts(socket) do
+    case socket.assigns[:current_user] do
+      nil -> [actor_source: "web", actor_identifier: "web"]
+      user -> [actor_source: "web", actor_user_id: user.id, actor_identifier: user.email]
     end
   end
 

--- a/test/controlkeel/mission_test.exs
+++ b/test/controlkeel/mission_test.exs
@@ -272,6 +272,58 @@ defmodule ControlKeel.MissionTest do
     assert event.actor_identifier == "ck_finding"
   end
 
+  test "dispose_findings/3 bulk-disposes selected ids and is idempotent" do
+    resolve = finding_fixture(%{status: "open"})
+    dismiss = finding_fixture(%{status: "open"})
+    escalate = finding_fixture(%{status: "blocked"})
+    settled = finding_fixture(%{status: "approved"})
+
+    assert {:ok, %{count: 3, ids: ids}} =
+             Mission.dispose_findings(
+               [resolve.id, dismiss.id, escalate.id, settled.id],
+               "resolve"
+             )
+
+    # settle was already approved, so it is untouched
+    assert Enum.sort(ids) == Enum.sort([resolve.id, dismiss.id, escalate.id])
+
+    assert Mission.get_finding!(resolve.id).status == "approved"
+    assert Mission.get_finding!(dismiss.id).status == "approved"
+    assert Mission.get_finding!(escalate.id).status == "approved"
+    assert Mission.get_finding!(settled.id).status == "approved"
+
+    # idempotent re-run touches nothing new
+    assert {:ok, %{count: 0, ids: []}} =
+             Mission.dispose_findings([resolve.id, dismiss.id], "resolve")
+  end
+
+  test "dispose_findings/3 records reason for dismiss and actor opts" do
+    finding = finding_fixture(%{status: "open"})
+
+    assert {:ok, %{count: 1}} =
+             Mission.dispose_findings([finding.id], "dismiss",
+               reason: "New build removes this path",
+               actor_source: "web",
+               actor_identifier: "operator@example.com"
+             )
+
+    updated = Mission.get_finding!(finding.id)
+    assert updated.status == "rejected"
+    assert updated.metadata["rejection_reason"] == "New build removes this path"
+
+    assert [event] = Mission.finding_audit_events(finding.id)
+    assert event.event_type == "rejected"
+    assert event.reason == "New build removes this path"
+    assert event.actor_source == "web"
+    assert event.actor_identifier == "operator@example.com"
+  end
+
+  test "dispose_findings/3 rejects unknown actions" do
+    finding = finding_fixture()
+
+    assert {:error, :invalid_action} = Mission.dispose_findings([finding.id], "archive")
+  end
+
   test "browse_findings/1 applies filters and paginates deterministically" do
     session_a = session_fixture(%{title: "Alpha mission"})
     session_b = session_fixture(%{title: "Bravo mission"})

--- a/test/controlkeel/mission_test.exs
+++ b/test/controlkeel/mission_test.exs
@@ -376,10 +376,12 @@ defmodule ControlKeel.MissionTest do
 
     first_page = Mission.browse_findings(%{"page" => "1"})
     second_page = Mission.browse_findings(%{"page" => "2"})
+    third_page = Mission.browse_findings(%{"page" => "3"})
 
-    assert first_page.total_pages == 2
-    assert length(first_page.entries) == 20
-    assert length(second_page.entries) == 3
+    assert first_page.total_pages == 3
+    assert length(first_page.entries) == 10
+    assert length(second_page.entries) == 10
+    assert length(third_page.entries) == 3
   end
 
   test "browse_findings/1 filters vulnerability lifecycle metadata and summarizes filtered cases" do

--- a/test/controlkeel_web/live/findings_live_test.exs
+++ b/test/controlkeel_web/live/findings_live_test.exs
@@ -299,4 +299,170 @@ defmodule ControlKeelWeb.FindingsLiveTest do
     assert detail_html =~ "parameterized queries"
     assert detail_html =~ "Copy fix prompt"
   end
+
+  test "findings browser bulk-resolves and bulk-dismisses selected findings", %{conn: conn} do
+    session = session_fixture()
+
+    first =
+      finding_fixture(%{
+        session: session,
+        title: "Bulk resolve me",
+        rule_id: "security.sql_injection",
+        severity: "high",
+        category: "security",
+        status: "open"
+      })
+
+    second =
+      finding_fixture(%{
+        session: session,
+        title: "Bulk dismiss me",
+        rule_id: "security.xss_unsafe_html",
+        severity: "medium",
+        category: "security",
+        status: "open"
+      })
+
+    settled =
+      finding_fixture(%{
+        session: session,
+        title: "Already approved",
+        rule_id: "security.csp_inline_script",
+        severity: "medium",
+        category: "security",
+        status: "approved"
+      })
+
+    dismissable =
+      finding_fixture(%{
+        session: session,
+        title: "Dismiss with reason",
+        rule_id: "security.loose_tls_cert",
+        severity: "low",
+        category: "ops",
+        status: "open"
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/findings")
+
+    refute has_element?(view, "button[phx-click=\"open_bulk\"]")
+
+    render_click(
+      element(view, "input[phx-click=\"toggle_select\"][phx-value-id=\"#{first.id}\"]")
+    )
+
+    render_click(
+      element(view, "input[phx-click=\"toggle_select\"][phx-value-id=\"#{second.id}\"]")
+    )
+
+    assert has_element?(view, "button[phx-click=\"open_bulk\"][phx-value-action=\"resolve\"]")
+    assert render(view) =~ "finding(s) selected"
+
+    render_click(element(view, "button[phx-click=\"open_bulk\"][phx-value-action=\"resolve\"]"))
+
+    assert has_element?(view, "button[phx-click=\"confirm_bulk\"]")
+    assert render(view) =~ "Resolve findings"
+
+    render_click(element(view, "button[phx-click=\"confirm_bulk\"]"))
+
+    assert Mission.get_finding!(first.id).status == "approved"
+    assert Mission.get_finding!(second.id).status == "approved"
+    assert Mission.get_finding!(settled.id).status == "approved"
+    assert Mission.get_finding!(dismissable.id).status == "open"
+
+    refute has_element?(view, "button[phx-click=\"open_bulk\"]")
+
+    # Bulk dismiss records an optional reason
+    render_click(
+      element(view, "input[phx-click=\"toggle_select\"][phx-value-id=\"#{dismissable.id}\"]")
+    )
+
+    render_click(element(view, "button[phx-click=\"open_bulk\"][phx-value-action=\"dismiss\"]"))
+
+    assert render(view) =~ "Dismiss findings"
+
+    render_click(view, "set_bulk_reason", %{"value" => "Duplicate of CK-123"})
+    render_click(element(view, "button[phx-click=\"confirm_bulk\"]"))
+
+    dismissed = Mission.get_finding!(dismissable.id)
+    assert dismissed.status == "rejected"
+    assert dismissed.metadata["rejection_reason"] == "Duplicate of CK-123"
+  end
+
+  test "findings browser select-page checkbox selects and clears the page", %{conn: conn} do
+    session = session_fixture()
+
+    finding = finding_fixture(%{session: session, title: "One", status: "open"})
+    other = finding_fixture(%{session: session, title: "Two", status: "open"})
+
+    {:ok, view, _html} = live(conn, ~p"/findings")
+
+    render_click(element(view, "input[phx-click=\"select_page\"]"))
+
+    assert render(view) =~ "finding(s) selected"
+
+    render_click(element(view, "input[phx-click=\"select_page\"]"))
+
+    refute has_element?(view, "button[phx-click=\"open_bulk\"]")
+
+    # Individual toggle still works
+    render_click(
+      element(view, "input[phx-click=\"toggle_select\"][phx-value-id=\"#{finding.id}\"]")
+    )
+
+    assert render(view) =~ "finding(s) selected"
+
+    render_click(element(view, "button[phx-click=\"clear_selection\"]"))
+    refute has_element?(view, "button[phx-click=\"open_bulk\"]")
+
+    _ = other
+  end
+
+  test "web-disposed findings record web actor attribution on audit events", %{conn: conn} do
+    session = session_fixture()
+
+    finding =
+      finding_fixture(%{
+        session: session,
+        title: "Actor tracked",
+        rule_id: "security.sql_injection",
+        severity: "high",
+        category: "security",
+        status: "open"
+      })
+
+    escalated =
+      finding_fixture(%{
+        session: session,
+        title: "Bulk actor tracked",
+        rule_id: "security.xss_unsafe_html",
+        severity: "medium",
+        category: "security",
+        status: "open"
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/findings")
+
+    render_click(
+      element(view, "button[phx-click=\"toggle_dropdown\"][phx-value-id=\"#{finding.id}\"]")
+    )
+
+    render_click(element(view, "button[phx-click=\"approve\"]"))
+
+    event = Mission.finding_audit_events(finding.id) |> List.last()
+    assert event.actor_source == "web"
+    assert event.actor_identifier == "web"
+
+    render_click(
+      element(view, "input[phx-click=\"toggle_select\"][phx-value-id=\"#{escalated.id}\"]")
+    )
+
+    render_click(element(view, "button[phx-click=\"open_bulk\"][phx-value-action=\"escalate\"]"))
+
+    render_click(element(view, "button[phx-click=\"confirm_bulk\"]"))
+
+    event = Mission.finding_audit_events(escalated.id) |> List.last()
+    assert event.event_type == "escalated"
+    assert event.actor_source == "web"
+  end
 end

--- a/test/controlkeel_web/live/findings_live_test.exs
+++ b/test/controlkeel_web/live/findings_live_test.exs
@@ -99,27 +99,35 @@ defmodule ControlKeelWeb.FindingsLiveTest do
       })
 
     {:ok, view, html} = live(conn, ~p"/findings")
-    assert html =~ "Page 1 of 2"
+    assert html =~ "Page 1 of 3"
     assert has_element?(view, "a[href*=\"page=2\"]", "Next")
 
-    # Open 3-dot menu then click approve
+    # Open the guided-fix modal then approve from the modal footer
     render_click(
-      element(view, "button[phx-click=\"toggle_dropdown\"][phx-value-id=\"#{actionable.id}\"]")
+      element(view, "button[phx-click=\"view_fix\"][phx-value-id=\"#{actionable.id}\"]")
     )
 
-    render_click(element(view, "button[phx-click=\"approve\"]"))
+    render_click(
+      element(view, "button[phx-click=\"approve\"][phx-value-id=\"#{actionable.id}\"]")
+    )
 
     assert render(view) =~ "Finding approved."
     assert Mission.get_finding!(actionable.id).status == "approved"
 
-    # Open 3-dot menu then click reject
+    # Approve keeps the modal open showing the updated status
+    assert render(view) =~ "Guided fix"
+    assert render(view) =~ "approved"
+
+    # Open the modal for the rejectable finding then reject from the footer
     render_click(
-      element(view, "button[phx-click=\"toggle_dropdown\"][phx-value-id=\"#{rejectable.id}\"]")
+      element(view, "button[phx-click=\"view_fix\"][phx-value-id=\"#{rejectable.id}\"]")
     )
 
-    render_click(element(view, "button[phx-click=\"reject\"]"))
+    render_click(element(view, "button[phx-click=\"reject\"][phx-value-id=\"#{rejectable.id}\"]"))
+
     # Confirm the rejection (without a reason)
     render_click(element(view, "button[phx-click=\"confirm_reject\"]"))
+    assert render(view) =~ "Finding rejected."
     assert Mission.get_finding!(rejectable.id).status == "rejected"
   end
 
@@ -138,12 +146,12 @@ defmodule ControlKeelWeb.FindingsLiveTest do
 
     {:ok, view, _html} = live(conn, ~p"/findings")
 
-    # Open dropdown and click reject
+    # Open the guided-fix modal then reject
     render_click(
-      element(view, "button[phx-click=\"toggle_dropdown\"][phx-value-id=\"#{rejectable.id}\"]")
+      element(view, "button[phx-click=\"view_fix\"][phx-value-id=\"#{rejectable.id}\"]")
     )
 
-    render_click(element(view, "button[phx-click=\"reject\"]"))
+    render_click(element(view, "button[phx-click=\"reject\"][phx-value-id=\"#{rejectable.id}\"]"))
 
     # Type a rejection reason via the set_reject_reason event
     render_click(view, "set_reject_reason", %{"value" => "False positive on legacy code"})
@@ -155,11 +163,11 @@ defmodule ControlKeelWeb.FindingsLiveTest do
     assert finding.status == "rejected"
     assert finding.metadata["rejection_reason"] == "False positive on legacy code"
 
-    # The reason should be visible in the findings table
+    # The reason should be visible on the rejected finding's card
     assert render(view) =~ "False positive on legacy code"
   end
 
-  test "findings browser escalates an active finding from the row menu", %{conn: conn} do
+  test "findings browser escalates an active finding from the fix modal", %{conn: conn} do
     session = session_fixture()
 
     open_finding =
@@ -184,17 +192,18 @@ defmodule ControlKeelWeb.FindingsLiveTest do
 
     {:ok, view, _html} = live(conn, ~p"/findings")
 
+    # No modal is open, so no decision buttons are on the page
+    refute has_element?(view, "button[phx-click=\"escalate\"]")
+
+    render_click(element(view, "button[phx-click=\"view_fix\"][phx-value-id=\"#{approved.id}\"]"))
+
     # Escalate only appears for active (open/blocked) findings, not settled ones
     refute has_element?(view, "button[phx-click=\"escalate\"]")
 
-    render_click(
-      element(view, "button[phx-click=\"toggle_dropdown\"][phx-value-id=\"#{approved.id}\"]")
-    )
-
-    refute has_element?(view, "button[phx-click=\"escalate\"]")
+    render_click(element(view, "button[phx-click=\"close_fix\"][class~=\"bg-overlay\"]"))
 
     render_click(
-      element(view, "button[phx-click=\"toggle_dropdown\"][phx-value-id=\"#{open_finding.id}\"]")
+      element(view, "button[phx-click=\"view_fix\"][phx-value-id=\"#{open_finding.id}\"]")
     )
 
     assert has_element?(view, "button[phx-click=\"escalate\"]")
@@ -288,137 +297,85 @@ defmodule ControlKeelWeb.FindingsLiveTest do
 
     {:ok, view, _html} = live(conn, ~p"/findings")
 
-    render_click(
-      element(view, "button[phx-click=\"toggle_dropdown\"][phx-value-id=\"#{finding.id}\"]")
-    )
-
     detail_html =
-      render_click(element(view, "button[phx-click=\"view_fix\"]"))
+      render_click(
+        element(view, "button[phx-click=\"view_fix\"][phx-value-id=\"#{finding.id}\"]")
+      )
 
     assert detail_html =~ "Guided fix"
     assert detail_html =~ "parameterized queries"
     assert detail_html =~ "Copy fix prompt"
   end
 
-  test "findings browser bulk-resolves and bulk-dismisses selected findings", %{conn: conn} do
+  test "findings browser modal decision guards hide settled actions", %{conn: conn} do
     session = session_fixture()
 
-    first =
+    approved =
       finding_fixture(%{
         session: session,
-        title: "Bulk resolve me",
+        title: "Approved guard",
         rule_id: "security.sql_injection",
         severity: "high",
-        category: "security",
-        status: "open"
-      })
-
-    second =
-      finding_fixture(%{
-        session: session,
-        title: "Bulk dismiss me",
-        rule_id: "security.xss_unsafe_html",
-        severity: "medium",
-        category: "security",
-        status: "open"
-      })
-
-    settled =
-      finding_fixture(%{
-        session: session,
-        title: "Already approved",
-        rule_id: "security.csp_inline_script",
-        severity: "medium",
         category: "security",
         status: "approved"
       })
 
-    dismissable =
+    rejected =
       finding_fixture(%{
         session: session,
-        title: "Dismiss with reason",
-        rule_id: "security.loose_tls_cert",
-        severity: "low",
-        category: "ops",
-        status: "open"
+        title: "Rejected guard",
+        rule_id: "security.xss_unsafe_html",
+        severity: "medium",
+        category: "security",
+        status: "rejected"
       })
 
     {:ok, view, _html} = live(conn, ~p"/findings")
 
-    refute has_element?(view, "button[phx-click=\"open_bulk\"]")
+    render_click(element(view, "button[phx-click=\"view_fix\"][phx-value-id=\"#{approved.id}\"]"))
 
-    render_click(
-      element(view, "input[phx-click=\"toggle_select\"][phx-value-id=\"#{first.id}\"]")
-    )
+    refute has_element?(view, "button[phx-click=\"approve\"]")
+    refute has_element?(view, "button[phx-click=\"escalate\"]")
+    assert has_element?(view, "button[phx-click=\"reject\"]")
 
-    render_click(
-      element(view, "input[phx-click=\"toggle_select\"][phx-value-id=\"#{second.id}\"]")
-    )
+    render_click(element(view, "button[phx-click=\"close_fix\"][class~=\"bg-overlay\"]"))
 
-    assert has_element?(view, "button[phx-click=\"open_bulk\"][phx-value-action=\"resolve\"]")
-    assert render(view) =~ "finding(s) selected"
+    render_click(element(view, "button[phx-click=\"view_fix\"][phx-value-id=\"#{rejected.id}\"]"))
 
-    render_click(element(view, "button[phx-click=\"open_bulk\"][phx-value-action=\"resolve\"]"))
-
-    assert has_element?(view, "button[phx-click=\"confirm_bulk\"]")
-    assert render(view) =~ "Resolve findings"
-
-    render_click(element(view, "button[phx-click=\"confirm_bulk\"]"))
-
-    assert Mission.get_finding!(first.id).status == "approved"
-    assert Mission.get_finding!(second.id).status == "approved"
-    assert Mission.get_finding!(settled.id).status == "approved"
-    assert Mission.get_finding!(dismissable.id).status == "open"
-
-    refute has_element?(view, "button[phx-click=\"open_bulk\"]")
-
-    # Bulk dismiss records an optional reason
-    render_click(
-      element(view, "input[phx-click=\"toggle_select\"][phx-value-id=\"#{dismissable.id}\"]")
-    )
-
-    render_click(element(view, "button[phx-click=\"open_bulk\"][phx-value-action=\"dismiss\"]"))
-
-    assert render(view) =~ "Dismiss findings"
-
-    render_click(view, "set_bulk_reason", %{"value" => "Duplicate of CK-123"})
-    render_click(element(view, "button[phx-click=\"confirm_bulk\"]"))
-
-    dismissed = Mission.get_finding!(dismissable.id)
-    assert dismissed.status == "rejected"
-    assert dismissed.metadata["rejection_reason"] == "Duplicate of CK-123"
+    refute has_element?(view, "button[phx-click=\"reject\"]")
+    assert has_element?(view, "button[phx-click=\"approve\"]")
   end
 
-  test "findings browser select-page checkbox selects and clears the page", %{conn: conn} do
+  test "findings browser advanced filters are hidden by default and toggle open", %{conn: conn} do
     session = session_fixture()
+    finding_fixture(%{session: session, title: "Toggle me", status: "open"})
 
-    finding = finding_fixture(%{session: session, title: "One", status: "open"})
-    other = finding_fixture(%{session: session, title: "Two", status: "open"})
+    {:ok, view, html} = live(conn, ~p"/findings")
 
-    {:ok, view, _html} = live(conn, ~p"/findings")
+    assert html =~ "More filters"
+    refute html =~ "Fewer filters"
 
-    render_click(element(view, "input[phx-click=\"select_page\"]"))
+    render_click(element(view, "button[phx-click=\"toggle_more_filters\"]"))
+    assert render(view) =~ "Fewer filters"
 
-    assert render(view) =~ "finding(s) selected"
-
-    render_click(element(view, "input[phx-click=\"select_page\"]"))
-
-    refute has_element?(view, "button[phx-click=\"open_bulk\"]")
-
-    # Individual toggle still works
-    render_click(
-      element(view, "input[phx-click=\"toggle_select\"][phx-value-id=\"#{finding.id}\"]")
-    )
-
-    assert render(view) =~ "finding(s) selected"
-
-    render_click(element(view, "button[phx-click=\"clear_selection\"]"))
-    refute has_element?(view, "button[phx-click=\"open_bulk\"]")
-
-    _ = other
+    render_click(element(view, "button[phx-click=\"toggle_more_filters\"]"))
+    assert render(view) =~ "More filters"
   end
 
-  test "web-disposed findings record web actor attribution on audit events", %{conn: conn} do
+  test "findings browser auto-opens advanced filters and counts active ones", %{conn: conn} do
+    session = session_fixture()
+    finding_fixture(%{session: session, title: "Autopen", status: "open"})
+
+    {:ok, view, html} = live(conn, ~p"/findings?#{%{patch_status: "merged"}}")
+
+    assert html =~ "Fewer filters"
+
+    render_click(element(view, "button[phx-click=\"toggle_more_filters\"]"))
+
+    assert render(view) =~ "More filters (1 active)"
+  end
+
+  test "web-initiated finding actions record web actor attribution on audit events", %{conn: conn} do
     session = session_fixture()
 
     finding =
@@ -434,7 +391,7 @@ defmodule ControlKeelWeb.FindingsLiveTest do
     escalated =
       finding_fixture(%{
         session: session,
-        title: "Bulk actor tracked",
+        title: "Escalated actor tracked",
         rule_id: "security.xss_unsafe_html",
         severity: "medium",
         category: "security",
@@ -443,23 +400,23 @@ defmodule ControlKeelWeb.FindingsLiveTest do
 
     {:ok, view, _html} = live(conn, ~p"/findings")
 
-    render_click(
-      element(view, "button[phx-click=\"toggle_dropdown\"][phx-value-id=\"#{finding.id}\"]")
-    )
+    render_click(element(view, "button[phx-click=\"view_fix\"][phx-value-id=\"#{finding.id}\"]"))
 
-    render_click(element(view, "button[phx-click=\"approve\"]"))
+    render_click(element(view, "button[phx-click=\"approve\"][phx-value-id=\"#{finding.id}\"]"))
 
     event = Mission.finding_audit_events(finding.id) |> List.last()
     assert event.actor_source == "web"
     assert event.actor_identifier == "web"
 
+    render_click(element(view, "button[phx-click=\"close_fix\"][class~=\"bg-overlay\"]"))
+
     render_click(
-      element(view, "input[phx-click=\"toggle_select\"][phx-value-id=\"#{escalated.id}\"]")
+      element(view, "button[phx-click=\"view_fix\"][phx-value-id=\"#{escalated.id}\"]")
     )
 
-    render_click(element(view, "button[phx-click=\"open_bulk\"][phx-value-action=\"escalate\"]"))
-
-    render_click(element(view, "button[phx-click=\"confirm_bulk\"]"))
+    render_click(
+      element(view, "button[phx-click=\"escalate\"][phx-value-id=\"#{escalated.id}\"]")
+    )
 
     event = Mission.finding_audit_events(escalated.id) |> List.last()
     assert event.event_type == "escalated"

--- a/test/controlkeel_web/live/findings_live_test.exs
+++ b/test/controlkeel_web/live/findings_live_test.exs
@@ -159,6 +159,120 @@ defmodule ControlKeelWeb.FindingsLiveTest do
     assert render(view) =~ "False positive on legacy code"
   end
 
+  test "findings browser escalates an active finding from the row menu", %{conn: conn} do
+    session = session_fixture()
+
+    open_finding =
+      finding_fixture(%{
+        session: session,
+        title: "Escalatable finding",
+        rule_id: "security.sql_injection",
+        severity: "high",
+        category: "security",
+        status: "open"
+      })
+
+    approved =
+      finding_fixture(%{
+        session: session,
+        title: "Approved finding",
+        rule_id: "security.xss_unsafe_html",
+        severity: "medium",
+        category: "security",
+        status: "approved"
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/findings")
+
+    # Escalate only appears for active (open/blocked) findings, not settled ones
+    refute has_element?(view, "button[phx-click=\"escalate\"]")
+
+    render_click(
+      element(view, "button[phx-click=\"toggle_dropdown\"][phx-value-id=\"#{approved.id}\"]")
+    )
+
+    refute has_element?(view, "button[phx-click=\"escalate\"]")
+
+    render_click(
+      element(view, "button[phx-click=\"toggle_dropdown\"][phx-value-id=\"#{open_finding.id}\"]")
+    )
+
+    assert has_element?(view, "button[phx-click=\"escalate\"]")
+
+    render_click(element(view, "button[phx-click=\"escalate\"]"))
+
+    assert render(view) =~ "Finding escalated."
+    assert Mission.get_finding!(open_finding.id).status == "escalated"
+  end
+
+  test "findings browser filters by vulnerability-case metadata", %{conn: conn} do
+    session = session_fixture()
+
+    patched =
+      finding_fixture(%{
+        session: session,
+        title: "Patched case",
+        rule_id: "security.sql_injection",
+        severity: "high",
+        category: "security",
+        status: "open",
+        metadata: %{
+          "finding_family" => "vulnerability_case",
+          "patch_status" => "merged",
+          "disclosure_status" => "public",
+          "maintainer_scope" => "first_party"
+        }
+      })
+
+    _draft =
+      finding_fixture(%{
+        session: session,
+        title: "Draft case",
+        rule_id: "security.xss_unsafe_html",
+        severity: "medium",
+        category: "security",
+        status: "open",
+        metadata: %{
+          "finding_family" => "vulnerability_case",
+          "patch_status" => "none",
+          "disclosure_status" => "draft",
+          "maintainer_scope" => "third_party_vendor"
+        }
+      })
+
+    {:ok, view, _html} =
+      live(conn, ~p"/findings?#{%{patch_status: "merged"}}")
+
+    assert render(view) =~ "Patched case"
+    refute render(view) =~ "Draft case"
+
+    patched_change =
+      render_change(
+        form(view, "form",
+          filters: %{
+            "q" => "",
+            "severity" => "",
+            "status" => "",
+            "category" => "",
+            "session_id" => "",
+            "patch_status" => "",
+            "disclosure_status" => "draft",
+            "maintainer_scope" => "third_party_vendor"
+          }
+        )
+      )
+
+    assert patched_change =~ "Draft case"
+    refute patched_change =~ "Patched case"
+
+    assert_patch(
+      view,
+      ~p"/findings?#{%{disclosure_status: "draft", maintainer_scope: "third_party_vendor"}}"
+    )
+
+    _ = patched
+  end
+
   test "findings browser renders the guided fix panel", %{conn: conn} do
     session = session_fixture()
 


### PR DESCRIPTION
## Summary
This branch brings the web findings experience (`/findings` and session findings panels) to feature parity with CLI and control-plane capabilities. Browser users can now view the security case summary strip, filter by vulnerability-case metadata, escalate active findings, inspect full finding details with audit trail history, and record proper web actor attribution on mutations.

## Motivation & Context
Previously, web findings only exposed basic browse, approve/reject, and guided fixes. Core capabilities available in the CLI and control plane were missing in the browser interface across both local and cloud modes:
- **No Escalation in Web UI**: Escalation was only exposed via `ApiController` (`POST /findings/:id/action`), with no LiveView action or button.
- **Unused Security Summary & Filters**: `Mission.browse_findings/1` computed `security_summary` and supported vulnerability metadata filters (`patch_status`, `disclosure_status`, `maintainer_scope`), but `FindingsLive` rendered neither.
- **Audit Trails Missing**: `finding_audit_events` were accessible via CLI/control-plane only.

## Related issue: #97 

## Key Changes

### 1. Domain Layer (`ControlKeel.Mission`)
- **Bulk & Single Disposition (`Mission.dispose_findings/3`)**: Added unified disposition handling (`resolve`, `dismiss`, `escalate`) with support for dismissal reasons, idempotency over active statuses (`open`, `blocked`, `escalated`), and actor attribution.

### 2. Findings Browser (`ControlKeelWeb.FindingsLive`)
- **Security Case Summary Strip**: Added top-level summary metrics bar above the findings list displaying case counts, unresolved count, critical unresolved count, and breakdown by status.
- **Escalation Support**: Added direct escalation action in the finding detail/fix modal for active findings (`open`/`blocked`).
- **Audit Trail & Vulnerability-Case Inspection**: 
  - Rendered `finding_audit_events` timeline in the finding detail modal.
  - Added read-only display for vulnerability-case fields (`patch_status`, `disclosure_status`, `exploitability_status`, `maintainer_scope`, `CWE`/`CVE`).
  - Added plain-English risk description and metadata inspection.
- **Metadata Filters**: Added filters for `patch_status`, `disclosure_status`, and `maintainer_scope` with toggleable advanced filter panel and active filter counters.
- **Web Actor Attribution**: Ensured mutations initiated through the web UI carry `actor_source: "web"` and the active user identifier in the audit log.

## Acceptance Criteria Status

- [x] **Escalate finding**: Active findings can be escalated directly from the modal/row actions (`status -> escalated`).
- [x] **Security case summary strip**: Summary metrics render above findings table (`case_count`, `unresolved`, `critical_unresolved`, status breakdowns).
- [x] **Finding detail modal**: Renders plain message, risk explanation, full metadata, vulnerability-case fields, and audit trail (`finding_audit_events`).
- [x] **Read-only vulnerability fields**: Vulnerability lifecycle fields render read-only in the UI.
- [x] **Vulnerability metadata filters**: Added filters for `patch_status`, `disclosure_status`, and `maintainer_scope`.
- [x] **Web attribution**: Web-initiated actions record `actor_source: "web"`.
- [x] **Cloud & Local parity**: Implemented within shared `FindingsLive` under `:cloud_auth`.
- [x] **Automated test coverage**: Unit and LiveView tests cover all actions, filters, and audit trail attribution.

## Verification & Test Results

```bash
mix test test/controlkeel_web/live/findings_live_test.exs test/controlkeel/mission_test.exs
```

**Result:**
```text
Running ExUnit with seed: 268848, max_cases: 1
Excluding tags: [:performance]

.......................................................................
Finished in 1.7 seconds (0.00s async, 1.7s sync)

Result: 71 passed, 0 failures
```
