### PR TITLE
⚡ Bolt: Optimize intermediate list allocations in Observability aggregates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-08-19 - Elixir List Allocation Overhead
+**Learning:** Chaining `Enum.map/2` into `Enum.uniq/1` then `length/1` (or `Enum.filter/2` into `length/1`) forces unnecessary intermediate list allocations in Elixir, adding hidden overhead.
+**Action:** Use `MapSet.new/2 |> MapSet.size()` and `Enum.count/2` to skip intermediate lists and reduce GC pressure.

--- a/lib/controlkeel/cloud/baseline_analyzer.ex
+++ b/lib/controlkeel/cloud/baseline_analyzer.ex
@@ -94,7 +94,8 @@ defmodule ControlKeel.Cloud.BaselineAnalyzer do
       )
       |> Repo.all()
 
-    sample_sessions = rows |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+    # Bolt: MapSet avoids intermediate list allocations for uniqueness
+    sample_sessions = rows |> MapSet.new(& &1.session_id) |> MapSet.size()
 
     baseline =
       rows

--- a/lib/controlkeel/governance.ex
+++ b/lib/controlkeel/governance.ex
@@ -555,7 +555,8 @@ defmodule ControlKeel.Governance do
   end
 
   defp review_summary(decision, findings, fragments) do
-    files_reviewed = fragments |> Enum.map(& &1.path) |> Enum.uniq() |> length()
+    # Bolt: MapSet avoids intermediate list allocations for uniqueness
+    files_reviewed = fragments |> MapSet.new(& &1.path) |> MapSet.size()
     chunks_reviewed = length(fragments)
     added_lines_reviewed = Enum.reduce(fragments, 0, &(&1.added_line_count + &2))
 

--- a/lib/controlkeel/mcp/tool_group_tracker.ex
+++ b/lib/controlkeel/mcp/tool_group_tracker.ex
@@ -162,8 +162,9 @@ defmodule ControlKeel.MCP.ToolGroupTracker do
     else
       total_calls = entries |> Enum.map(fn {_key, _ts, count} -> count end) |> Enum.sum()
 
+      # Bolt: MapSet avoids intermediate list allocations for uniqueness
       unique_tools =
-        entries |> Enum.map(fn {key, _ts, _count} -> key end) |> Enum.uniq() |> length()
+        entries |> MapSet.new(fn {key, _ts, _count} -> key end) |> MapSet.size()
 
       %{total_calls: total_calls, unique_tools: unique_tools}
     end

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -524,7 +524,8 @@ defmodule ControlKeel.Observability do
       benchmark_drafts: drafts.count,
       approved_drafts: approved_drafts,
       materialized_scenarios: length(scenario_ids),
-      covered_scenarios: length(Enum.filter(scenario_ids, &(&1 in covered_ids))),
+      # Bolt: Using Enum.count/2 avoids intermediate list allocation
+      covered_scenarios: Enum.count(scenario_ids, &(&1 in covered_ids)),
       benchmark_runs: length(runs)
     }
 
@@ -1698,7 +1699,8 @@ defmodule ControlKeel.Observability do
       input_tokens: sum_invocation_field(invocations, :input_tokens),
       cached_input_tokens: sum_invocation_field(invocations, :cached_input_tokens),
       output_tokens: sum_invocation_field(invocations, :output_tokens),
-      sessions: invocations |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+      # Bolt: MapSet avoids intermediate list allocations for uniqueness
+      sessions: invocations |> MapSet.new(& &1.session_id) |> MapSet.size()
     }
   end
 
@@ -1713,7 +1715,8 @@ defmodule ControlKeel.Observability do
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
         output_tokens: sum_invocation_field(group, :output_tokens),
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+        # Bolt: MapSet avoids intermediate list allocations for uniqueness
+        sessions: group |> MapSet.new(& &1.session_id) |> MapSet.size()
       }
     end)
     |> Enum.sort_by(&{&1.estimated_cost_cents, &1.invocations}, :desc)
@@ -1730,7 +1733,8 @@ defmodule ControlKeel.Observability do
       %{
         name: name,
         invocations: invocation_count,
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length(),
+        # Bolt: MapSet avoids intermediate list allocations for uniqueness
+        sessions: group |> MapSet.new(& &1.session_id) |> MapSet.size(),
         estimated_cost_cents: total_cost,
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
@@ -2194,7 +2198,8 @@ defmodule ControlKeel.Observability do
       suite: benchmark_run_suite_slug(run),
       subjects: run.subjects || [],
       total_scenarios: run.total_scenarios,
-      observed_scenarios: run.results |> Enum.map(& &1.scenario_id) |> Enum.uniq() |> length(),
+      # Bolt: MapSet avoids intermediate list allocations for uniqueness
+      observed_scenarios: run.results |> MapSet.new(& &1.scenario_id) |> MapSet.size(),
       caught_count: run.caught_count,
       blocked_count: run.blocked_count,
       catch_rate: run.catch_rate || 0.0,


### PR DESCRIPTION
💡 **What**: Replaced intermediate list-generating pipelines with more direct counting primitives in `ControlKeel.Observability`, `ControlKeel.Governance`, `ControlKeel.MCP.ToolGroupTracker`, and `ControlKeel.Cloud.BaselineAnalyzer`. specifically `length(Enum.filter(...))` was changed to `Enum.count(...)` and `Enum.map(...) |> Enum.uniq() |> length()` was changed to `MapSet.new(...) |> MapSet.size()`.

🎯 **Why**: In Elixir, piping operations over `Enum` often allocates an entire new list at each stage. Operations like mapping IDs just to find unique ones and count them can quickly become inefficient for large collections because of memory allocations and garbage collector pressure. `MapSet` ensures uniqueness natively and calculates size in `O(1)` time without maintaining an intermediate sequence of items.

📊 **Impact**: Reduces GC pressure and memory consumption during analytics/aggregation routines, saving `O(N)` list construction per replaced pipeline sequence.

🔬 **Measurement**: Profiling the specific module functions via `:eprof` during dense scenario reporting before/after patch. Memory usage on the Erlang VM heap during telemetry ingestion will be noticeably flatter over time.

---
*PR created automatically by Jules for task [16861620328743561073](https://jules.google.com/task/16861620328743561073) started by @aryaminus*