### PR TITLE
🎨 Palette: Add accessibility to findings modal close button

### DIFF
--- a/lib/controlkeel_web/live/findings_live.ex
+++ b/lib/controlkeel_web/live/findings_live.ex
@@ -591,8 +591,9 @@ defmodule ControlKeelWeb.FindingsLive do
         <div class="relative rounded-2xl border bg-card shadow-card p-8 w-full max-w-2xl mx-4 space-y-4">
           <button
             type="button"
-            class="absolute top-2 right-2 text-muted-foreground hover:text-foreground transition"
+            class="absolute top-2 right-2 text-muted-foreground hover:text-foreground transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded"
             phx-click="close_fix"
+            aria-label="Close guided fix"
           >
             <.icon name="hero-x-mark" class="w-5 h-5" />
           </button>


### PR DESCRIPTION
## 💡 What
Added `aria-label="Close guided fix"` and explicit keyboard focus styles (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded`) to the icon-only Close button in the findings guided fix modal (`findings_live.ex`).

## 🎯 Why
Icon-only buttons without accessible names are invisible to screen readers, making it difficult for visually impaired users to understand the button's function. Furthermore, missing focus states make keyboard navigation unpredictable.

## 📸 Before/After
**Before:**
The close button in the top right of the modal lacked an `aria-label` and `focus-visible` styling, hindering a11y.

**After:**
The close button now announces "Close guided fix" to screen readers and visually indicates focus when navigating via keyboard.

## ♿ Accessibility
- Added `aria-label` for screen reader support.
- Added `focus-visible` Tailwind classes for explicit keyboard focus indication.

---
*PR created automatically by Jules for task [5169660049073178568](https://jules.google.com/task/5169660049073178568) started by @aryaminus*