### PR TITLE
🎨 Palette: [UX improvement] add ARIA attributes and focus styles to user menu

### DIFF
--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -265,9 +265,15 @@ defmodule ControlKeelWeb.Layouts do
     <div {@rest} class={"relative #{@class}"} id={@id}>
       <button
         type="button"
-        phx-click={JS.toggle(to: "##{@id}-popover")}
+        phx-click={
+          JS.toggle(to: "##{@id}-popover")
+          |> JS.toggle_attribute({"aria-expanded", "true", "false"})
+        }
+        aria-haspopup="menu"
+        aria-expanded="false"
+        aria-label="User menu"
         class={[
-          "transition hover:bg-muted",
+          "transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded",
           if(@compact,
             do:
               "flex items-center gap-2 rounded-full px-1 py-1 text-sm font-semibold text-muted-foreground hover:text-foreground",
@@ -292,7 +298,10 @@ defmodule ControlKeelWeb.Layouts do
       </button>
       <div
         id={"#{@id}-popover"}
-        phx-click-away={JS.hide(to: "##{@id}-popover")}
+        phx-click-away={
+          JS.hide(to: "##{@id}-popover")
+          |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id} button")
+        }
         class={"hidden absolute #{@popover_class} z-50 w-56 rounded-xl border bg-card p-3 shadow-2xl shadow-black/50 backdrop-blur-md"}
       >
         <p class="text-sm font-semibold text-foreground">
@@ -303,7 +312,10 @@ defmodule ControlKeelWeb.Layouts do
         <%= if @show_dashboard do %>
           <a
             href={~p"/dashboard"}
-            phx-click={JS.hide(to: "##{@id}-popover")}
+            phx-click={
+              JS.hide(to: "##{@id}-popover")
+              |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id} button")
+            }
             class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
           >
             <.icon name="hero-squares-2x2" class="size-4" /> Dashboard


### PR DESCRIPTION
### 💡 What
Added `aria-haspopup`, dynamic `aria-expanded` state tracking, and a descriptive `aria-label` to the main user menu component in `layouts.ex`. Also added explicit keyboard focus styles for better visibility during tab navigation.

### 🎯 Why
The user menu previously had no indication for screen readers that it was a menu, what its current open/close state was, or what the toggle actually controlled. In addition, its keyboard focus ring was missing/subtle, making it difficult for keyboard-only users to see when the menu toggle had focus.

### 📸 Before/After
**Before:**
Menu toggle button had no ARIA metadata, meaning screen readers would just read "button", with no context about it opening a dropdown. 

**After:**
Menu toggle is properly announced as a menu button with dynamic expanded/collapsed state, allowing users to understand its function and state without visual cues. Focus ring explicitly shows when navigating via keyboard.

### ♿ Accessibility
- Added `aria-haspopup="menu"` to indicate the toggle opens a menu.
- Added `aria-label="User menu"` to describe the button's purpose.
- Used Phoenix LiveView `JS.toggle_attribute({"aria-expanded", "true", "false"})` and `JS.set_attribute({"aria-expanded", "false"}, ...)` to dynamically sync the ARIA state with the popover's visual visibility in real-time, purely on the client side without needing a server roundtrip.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded` to explicitly style the focus ring for keyboard users.

---
*PR created automatically by Jules for task [3214239397582901631](https://jules.google.com/task/3214239397582901631) started by @aryaminus*