### PR TITLE
🎨 Palette: [UX improvement] Breadcrumb accessibility and focus states

### DIFF
--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -410,7 +410,8 @@ defmodule ControlKeelWeb.Layouts do
           <li>
             <.link
               navigate={~p"/dashboard"}
-              class="flex items-center gap-1 text-muted-foreground transition hover:text-muted-foreground"
+              aria-label="Dashboard home"
+              class="flex items-center gap-1 text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-sm"
             >
               <.icon name="hero-home" class="size-3.5" />
             </.link>
@@ -423,7 +424,7 @@ defmodule ControlKeelWeb.Layouts do
               <% else %>
                 <.link
                   navigate={path}
-                  class="text-muted-foreground transition hover:text-muted-foreground"
+                  class="text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-sm"
                 >
                   {label}
                 </.link>


### PR DESCRIPTION
💡 **What:** Enhanced the accessibility and interaction states of the breadcrumb navigation in the main layout component.
🎯 **Why:** To improve keyboard navigation and screen reader support, as the home link was missing an ARIA label and breadcrumb links lacked visible focus states. Also fixed the hover state so it actually provides visual feedback (previously `text-muted-foreground` hovered to `text-muted-foreground`).
📸 **Before/After:** No major layout changes, but hover and focus interactions are now distinct.
♿ **Accessibility:** Added an `aria-label` to the icon-only home link. Added `focus-visible` styles to all breadcrumb links to ensure clear visual focus indicators for keyboard users.

---
*PR created automatically by Jules for task [18124881698972629899](https://jules.google.com/task/18124881698972629899) started by @aryaminus*