### PR TITLE
⚡ Bolt: Optimize list operations to reduce intermediate allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Elixir list operations optimization
+**Learning:** Chaining `Enum.map |> Enum.uniq |> length` and `Enum.filter |> length` creates unnecessary intermediate list allocations, adding performance overhead.
+**Action:** Prefer `Enum.count/2` over `length(Enum.filter/2)`, and `MapSet.new/2 |> MapSet.size()` over `Enum.map/2 |> Enum.uniq/1 |> length/1` to avoid intermediate list allocations and improve performance overhead.

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -524,7 +524,8 @@ defmodule ControlKeel.Observability do
       benchmark_drafts: drafts.count,
       approved_drafts: approved_drafts,
       materialized_scenarios: length(scenario_ids),
-      covered_scenarios: length(Enum.filter(scenario_ids, &(&1 in covered_ids))),
+      # Optimized: using Enum.count/2 to avoid intermediate list allocations
+      covered_scenarios: Enum.count(scenario_ids, &(&1 in covered_ids)),
       benchmark_runs: length(runs)
     }
 
@@ -1698,7 +1699,8 @@ defmodule ControlKeel.Observability do
       input_tokens: sum_invocation_field(invocations, :input_tokens),
       cached_input_tokens: sum_invocation_field(invocations, :cached_input_tokens),
       output_tokens: sum_invocation_field(invocations, :output_tokens),
-      sessions: invocations |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+      # Optimized: using MapSet.new/2 |> MapSet.size() to avoid intermediate list allocations
+      sessions: invocations |> MapSet.new(& &1.session_id) |> MapSet.size()
     }
   end
 
@@ -1713,7 +1715,8 @@ defmodule ControlKeel.Observability do
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
         output_tokens: sum_invocation_field(group, :output_tokens),
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length()
+        # Optimized: using MapSet.new/2 |> MapSet.size() to avoid intermediate list allocations
+        sessions: group |> MapSet.new(& &1.session_id) |> MapSet.size()
       }
     end)
     |> Enum.sort_by(&{&1.estimated_cost_cents, &1.invocations}, :desc)
@@ -1730,7 +1733,8 @@ defmodule ControlKeel.Observability do
       %{
         name: name,
         invocations: invocation_count,
-        sessions: group |> Enum.map(& &1.session_id) |> Enum.uniq() |> length(),
+        # Optimized: using MapSet.new/2 |> MapSet.size() to avoid intermediate list allocations
+        sessions: group |> MapSet.new(& &1.session_id) |> MapSet.size(),
         estimated_cost_cents: total_cost,
         input_tokens: sum_invocation_field(group, :input_tokens),
         cached_input_tokens: sum_invocation_field(group, :cached_input_tokens),
@@ -2194,7 +2198,8 @@ defmodule ControlKeel.Observability do
       suite: benchmark_run_suite_slug(run),
       subjects: run.subjects || [],
       total_scenarios: run.total_scenarios,
-      observed_scenarios: run.results |> Enum.map(& &1.scenario_id) |> Enum.uniq() |> length(),
+      # Optimized: using MapSet.new/2 |> MapSet.size() to avoid intermediate list allocations
+      observed_scenarios: run.results |> MapSet.new(& &1.scenario_id) |> MapSet.size(),
       caught_count: run.caught_count,
       blocked_count: run.blocked_count,
       catch_rate: run.catch_rate || 0.0,


### PR DESCRIPTION
**What:** Replaced `length(Enum.filter(...))` with `Enum.count(...)` and `Enum.map(...) |> Enum.uniq() |> length()` with `MapSet.new(...) |> MapSet.size()` in `lib/controlkeel/observability.ex`.

**Why:** To reduce intermediate list allocations and improve performance overhead during data transformations.

**Impact:** Reduces memory allocation overhead and slightly improves execution time for these functions.

**Measurement:** Verify that the test suite still passes successfully and functionality remains unchanged.

---
*PR created automatically by Jules for task [12552922429203645285](https://jules.google.com/task/12552922429203645285) started by @aryaminus*