### PR TITLE
🎨 Palette: Add missing keyboard focus styles to page actions and findings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Focus States on Custom Interactive Elements
+**Learning:** Custom interactive elements (like the "Copy fix prompt" button in finding components or inline action elements in layout dashboards) frequently lack default keyboard focus styles (`focus-visible:outline-none focus-visible:ring-2`) and basic cursor/hover states in this app's components, making them inaccessible to keyboard users and less discoverable.
+**Action:** Always verify keyboard accessibility (tabbing through) and add appropriate Tailwind focus ring utilities (`focus-visible:ring-primary` or similar) to any interactive element not using the core `<.button>` component.

--- a/lib/controlkeel_web/components/finding_components.ex
+++ b/lib/controlkeel_web/components/finding_components.ex
@@ -63,7 +63,7 @@ defmodule ControlKeelWeb.FindingComponents do
         <button
           :if={@copy_event && @fix["agent_prompt"]}
           type="button"
-          class="inline-flex items-center justify-center gap-[0.4rem] px-[1.25rem] py-[0.95rem] rounded-full bg-primary text-[#11170d] font-bold transition-[transform,box-shadow] duration-[160ms] ease-out hover:-translate-y-px hover:shadow-[0_12px_24px_rgba(196,240,66,0.24)]"
+          class="inline-flex items-center justify-center gap-[0.4rem] px-[1.25rem] py-[0.95rem] rounded-full bg-primary text-[#11170d] font-bold transition-[transform,box-shadow] duration-[160ms] ease-out hover:-translate-y-px hover:shadow-[0_12px_24px_rgba(196,240,66,0.24)] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
           phx-click={@copy_event}
           phx-value-id={@finding.id}
         >
@@ -72,7 +72,7 @@ defmodule ControlKeelWeb.FindingComponents do
         <button
           :if={@close_event}
           type="button"
-          class="uppercase tracking-[0.14em] text-xs text-primary font-semibold"
+          class="uppercase tracking-[0.14em] text-xs text-primary font-semibold hover:opacity-80 transition-opacity cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
           phx-click={@close_event}
         >
           Close

--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -316,7 +316,7 @@ defmodule ControlKeelWeb.Layouts do
               JS.hide(to: "##{@id}-popover")
               |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id} button")
             }
-            class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
+            class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
           >
             <.icon name="hero-squares-2x2" class="size-4" /> Dashboard
           </a>
@@ -334,7 +334,7 @@ defmodule ControlKeelWeb.Layouts do
         --%>
         <a
           href={~p"/auth/logout"}
-          class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-[var(--ck-danger)]"
+          class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-[var(--ck-danger)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
         >
           <.icon name="hero-arrow-right-on-rectangle" class="size-4" /> Sign out
         </a>
@@ -450,7 +450,7 @@ defmodule ControlKeelWeb.Layouts do
           <a
             :if={action[:to]}
             href={action.to}
-            class="inline-flex items-center gap-2 rounded-3xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 cursor-pointer"
+            class="inline-flex items-center gap-2 rounded-3xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
           >
             <.icon :if={action[:icon]} name={action.icon} class="size-4" /> {action.label}
           </a>
@@ -459,7 +459,7 @@ defmodule ControlKeelWeb.Layouts do
             :if={action[:form]}
             type="submit"
             form={action.form}
-            class="inline-flex items-center gap-2 rounded-3xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 cursor-pointer"
+            class="inline-flex items-center gap-2 rounded-3xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
           >
             <.icon :if={action[:icon]} name={action.icon} class="size-4" /> {action.label}
           </button>
@@ -468,7 +468,7 @@ defmodule ControlKeelWeb.Layouts do
             :if={action[:event]}
             type="button"
             phx-click={action.event}
-            class="inline-flex items-center gap-2 rounded-3xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 cursor-pointer"
+            class="inline-flex items-center gap-2 rounded-3xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
           >
             <.icon :if={action[:icon]} name={action.icon} class="size-4" /> {action.label}
           </button>


### PR DESCRIPTION
**What:**
Added missing `focus-visible` Tailwind classes to custom interactive elements, including the dashboard breadcrumb link, user menu sign-out link, page action buttons in the layout dashboard, and the "Copy fix prompt" and "Close" buttons in the finding panel.

**Why:**
Custom elements that do not use standard component helpers (like `<.button>`) were lacking default focus ring styles, making them invisible to keyboard users navigating via Tab. This change ensures a consistent and accessible focus outline appears when these elements receive keyboard focus. Additionally, a missing hover state was added to the finding close button.

**Before/After:**
*   **Before:** Tabbing to the aforementioned elements resulted in no visual indication of focus.
*   **After:** Tabbing to the elements displays a primary-colored focus ring (`focus-visible:ring-2 focus-visible:ring-primary` or `focus-visible:ring-primary/50`), providing clear visual feedback.

**Accessibility:**
*   Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary` and `focus-visible:ring-primary/50` to interactive elements.
*   Ensured keyboard focus states are visible for screen readers and keyboard-only users navigating the interface.

---
*PR created automatically by Jules for task [1685603281514619690](https://jules.google.com/task/1685603281514619690) started by @aryaminus*