### PR TITLE
⚡ Bolt: Optimize uniqueness check in benchmark comparison

### DIFF
--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -270,7 +270,8 @@ defmodule ControlKeel.Benchmark do
   # itself), so we skip the recompute and keep the export payload lean. The
   # explicit `benchmark compare <id>` command always computes a comparison.
   defp maybe_comparison(%Run{subjects: subjects} = run) when is_list(subjects) do
-    if length(Enum.uniq(subjects)) >= 2, do: compare_run(run), else: nil
+    # Bolt: MapSet avoids intermediate list allocations for uniqueness
+    if MapSet.new(subjects) |> MapSet.size() >= 2, do: compare_run(run), else: nil
   end
 
   defp maybe_comparison(_run), do: nil


### PR DESCRIPTION
💡 **What:** 
Replaced `length(Enum.uniq(subjects))` with `MapSet.new(subjects) |> MapSet.size()` in `lib/controlkeel/benchmark.ex`. Added a comment explaining the optimization.

🎯 **Why:** 
In Elixir, `Enum.uniq/1` builds an internal map to track seen elements and a new list to return them. Calling `length/1` on the result then requires a subsequent O(N) traversal of that newly allocated list. `MapSet.new/1` only allocates the underlying map, and `MapSet.size/1` delegates to `map_size/1`, which operates in O(1) time. This optimization avoids intermediate list allocations and unnecessary O(N) traversals.

📊 **Impact:** 
Reduces intermediate GC allocations and improves execution time from O(N) to O(1) for the size calculation step, particularly noticeable if subject lists grow large.

🔬 **Measurement:** 
Verification involves running the benchmark comparison flows. Correctness is maintained as the equality semantics remain identical.

---
*PR created automatically by Jules for task [12795883411217879931](https://jules.google.com/task/12795883411217879931) started by @aryaminus*