### PR TITLE
⚡ Bolt: [performance improvement] Elixir Enum.uniq length optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-08-19 - Elixir List Allocation Overhead
 **Learning:** Chaining `Enum.map/2` into `Enum.uniq/1` then `length/1` (or `Enum.filter/2` into `length/1`) forces unnecessary intermediate list allocations in Elixir, adding hidden overhead.
 **Action:** Use `MapSet.new/2 |> MapSet.size()` and `Enum.count/2` to skip intermediate lists and reduce GC pressure.
+## 2024-10-24 - Elixir Unique Count Optimization
+**Learning:** In Elixir, using length(Enum.uniq(list)) creates an intermediate list allocation which adds overhead.
+**Action:** Use MapSet.new(list) |> MapSet.size() instead for better performance when only the count of unique items is needed.

--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -270,7 +270,8 @@ defmodule ControlKeel.Benchmark do
   # itself), so we skip the recompute and keep the export payload lean. The
   # explicit `benchmark compare <id>` command always computes a comparison.
   defp maybe_comparison(%Run{subjects: subjects} = run) when is_list(subjects) do
-    if length(Enum.uniq(subjects)) >= 2, do: compare_run(run), else: nil
+    # Optimized: Use MapSet for unique count to avoid intermediate list allocation
+    if MapSet.new(subjects) |> MapSet.size() >= 2, do: compare_run(run), else: nil
   end
 
   defp maybe_comparison(_run), do: nil


### PR DESCRIPTION
## What
Replaced `length(Enum.uniq(subjects))` with `MapSet.new(subjects) |> MapSet.size()` in `ControlKeel.Benchmark.maybe_comparison/1`.

## Why
Using `Enum.uniq/1` followed by `length/1` creates an unnecessary intermediate list allocation. Using `MapSet` directly counts unique elements more efficiently without the extra list allocation.

## Impact
Minor reduction in memory allocation overhead and slightly faster execution for benchmark comparisons, particularly when subjects lists are large.

## Measurement
Verified visually and conceptually that the optimization is correct and safe, avoiding the extra `Enum.uniq` list creation.

---
*PR created automatically by Jules for task [5825626068929524481](https://jules.google.com/task/5825626068929524481) started by @aryaminus*