### PR TITLE
🎨 Palette: Add explicit focus-visible states to buttons for keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-23 - Consistent Keyboard Navigation
+**Learning:** Custom interactive elements like sidebar buttons and specialized panel buttons often lack default focus states, making them inaccessible via keyboard. Relying on default browser outlines is insufficient when custom styles mask them.
+**Action:** Always verify keyboard focus visibility for custom buttons and explicitly add Tailwind focus-visible classes like 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary'.

--- a/lib/controlkeel_web/components/finding_components.ex
+++ b/lib/controlkeel_web/components/finding_components.ex
@@ -63,7 +63,7 @@ defmodule ControlKeelWeb.FindingComponents do
         <button
           :if={@copy_event && @fix["agent_prompt"]}
           type="button"
-          class="inline-flex items-center justify-center gap-[0.4rem] px-[1.25rem] py-[0.95rem] rounded-full bg-primary text-[#11170d] font-bold transition-[transform,box-shadow] duration-[160ms] ease-out hover:-translate-y-px hover:shadow-[0_12px_24px_rgba(196,240,66,0.24)]"
+          class="inline-flex items-center justify-center gap-[0.4rem] px-[1.25rem] py-[0.95rem] rounded-full bg-primary text-[#11170d] font-bold transition-[transform,box-shadow] duration-[160ms] ease-out hover:-translate-y-px hover:shadow-[0_12px_24px_rgba(196,240,66,0.24)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
           phx-click={@copy_event}
           phx-value-id={@finding.id}
         >
@@ -72,7 +72,7 @@ defmodule ControlKeelWeb.FindingComponents do
         <button
           :if={@close_event}
           type="button"
-          class="uppercase tracking-[0.14em] text-xs text-primary font-semibold"
+          class="uppercase tracking-[0.14em] text-xs text-primary font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded px-2 py-1"
           phx-click={@close_event}
         >
           Close

--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -202,11 +202,11 @@ defmodule ControlKeelWeb.Layouts do
   defp nav_active?(_current_path, _path, _exact), do: false
 
   defp sidebar_link_class(true) do
-    "group flex items-center gap-3 rounded-xl bg-muted px-3 py-2.5 font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted"
+    "group flex items-center gap-3 rounded-xl bg-muted px-3 py-2.5 font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
   end
 
   defp sidebar_link_class(false) do
-    "group flex items-center gap-3 rounded-xl px-3 py-2.5 font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+    "group flex items-center gap-3 rounded-xl px-3 py-2.5 font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
   end
 
   defp sidebar_icon_class(true), do: "size-4 text-primary"


### PR DESCRIPTION
## 💡 What
Added explicit `focus-visible` Tailwind classes to custom interactive elements that were missing them. Specifically:
- The "Copy fix prompt" and "Close" buttons in the finding autofix panel (`finding_components.ex`).
- The sidebar toggle buttons (`layouts.ex`).

## 🎯 Why
Custom interactive elements, especially those with specialized styling, often lose the default browser focus ring. This makes the application difficult or impossible to navigate for users who rely on keyboard navigation, as they cannot tell which element currently has focus.

## 📸 Before/After
*(Visual change only visible when tabbing via keyboard)*
**Before:** Tabbing to the "Copy fix prompt", "Close" buttons, or sidebar items provided no visible indicator of focus.
**After:** Tabbing to these elements now displays a clear, primary-colored focus ring (e.g., `ring-2 ring-primary`). The text-only "Close" button also gained slight padding to ensure the focus ring doesn't clip the text.

## ♿ Accessibility
- **Keyboard Navigation:** Users can now visibly track their focus when navigating through the sidebar and finding autofix panels using the `Tab` key. This satisfies WCAG 2.1 Success Criterion 2.4.7 Focus Visible.

---
*PR created automatically by Jules for task [16618406643934302623](https://jules.google.com/task/16618406643934302623) started by @aryaminus*