### PR TITLE
⚡ Bolt: [performance improvement] Reduce intermediate list allocations in counts

### DIFF
--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -270,7 +270,8 @@ defmodule ControlKeel.Benchmark do
   # itself), so we skip the recompute and keep the export payload lean. The
   # explicit `benchmark compare <id>` command always computes a comparison.
   defp maybe_comparison(%Run{subjects: subjects} = run) when is_list(subjects) do
-    if length(Enum.uniq(subjects)) >= 2, do: compare_run(run), else: nil
+    # Bolt: Using MapSet avoids intermediate list allocation
+    if MapSet.new(subjects) |> MapSet.size() >= 2, do: compare_run(run), else: nil
   end
 
   defp maybe_comparison(_run), do: nil

--- a/test/controlkeel/budget/cost_optimizer_test.exs
+++ b/test/controlkeel/budget/cost_optimizer_test.exs
@@ -30,7 +30,8 @@ defmodule ControlKeel.Budget.CostOptimizerTest do
       end
 
     assert {:ok, suggestions} = CostOptimizer.suggest("session_3", spending: spending)
-    cache_count = length(Enum.filter(suggestions, &(&1.type == :caching)))
+    # Bolt: Enum.count avoids intermediate list allocation
+    cache_count = Enum.count(suggestions, &(&1.type == :caching))
     assert cache_count >= 0
   end
 
@@ -41,7 +42,8 @@ defmodule ControlKeel.Budget.CostOptimizerTest do
       end
 
     assert {:ok, suggestions} = CostOptimizer.suggest("session_4", spending: spending)
-    local_count = length(Enum.filter(suggestions, &(&1.type == :local_model)))
+    # Bolt: Enum.count avoids intermediate list allocation
+    local_count = Enum.count(suggestions, &(&1.type == :local_model))
     assert local_count >= 0
   end
 


### PR DESCRIPTION
💡 **What:**
Replaced inefficient list aggregations with optimized functional equivalents:
1. Replaced `length(Enum.uniq(subjects))` with `MapSet.new(subjects) |> MapSet.size()` in `lib/controlkeel/benchmark.ex`.
2. Replaced `length(Enum.filter(suggestions, fn))` with `Enum.count(suggestions, fn)` in `test/controlkeel/budget/cost_optimizer_test.exs`.

🎯 **Why:**
Chaining operations like `Enum.filter` into `length` or `Enum.uniq` into `length` forces Elixir to allocate memory for an intermediate list only to immediately throw it away after counting its elements. Using `Enum.count/2` and `MapSet` skips this allocation entirely, reducing GC pressure and overhead.

📊 **Impact:**
Reduces GC overhead and memory allocations for hot loops, particularly when dealing with long lists, ensuring a smaller memory footprint with O(n) traversal.

🔬 **Measurement:**
Run `mix test test/controlkeel/budget/cost_optimizer_test.exs` and `mix test test/controlkeel/benchmark_test.exs` to verify that functionality remains exactly identical while the intermediate list allocations are eliminated.

---
*PR created automatically by Jules for task [3502468900793094289](https://jules.google.com/task/3502468900793094289) started by @aryaminus*