### PR TITLE
Enhance Policy Studio UI and functionality for better usability

### DIFF
--- a/lib/controlkeel/accounts.ex
+++ b/lib/controlkeel/accounts.ex
@@ -1100,7 +1100,7 @@ defmodule ControlKeel.Accounts do
       when is_integer(workspace_id) and is_binary(mode) and is_list(tools) do
     existing = Repo.get_by(WorkspaceToolPolicy, workspace_id: workspace_id)
 
-    attrs = %{workspace_id: workspace_id, mode: mode, tools: tools}
+    attrs = %{workspace_id: workspace_id, mode: mode, tools: tools_for_mode(mode, tools)}
 
     changeset =
       case existing do
@@ -1110,6 +1110,10 @@ defmodule ControlKeel.Accounts do
 
     Repo.insert_or_update(changeset)
   end
+
+  # Under `inherit` the tools list is inert — never store stale selections.
+  defp tools_for_mode("inherit", _tools), do: []
+  defp tools_for_mode(_mode, tools), do: tools
 
   @doc """
   Checks `tool_name` against the workspace's tool policy. Returns `:ok` to

--- a/lib/controlkeel/platform.ex
+++ b/lib/controlkeel/platform.ex
@@ -186,6 +186,17 @@ defmodule ControlKeel.Platform do
     )
   end
 
+  def remove_workspace_policy_set(workspace_id, policy_set_id)
+      when is_integer(workspace_id) and is_integer(policy_set_id) do
+    case Repo.get_by(WorkspacePolicySet, workspace_id: workspace_id, policy_set_id: policy_set_id) do
+      nil ->
+        {:error, :not_found}
+
+      assignment ->
+        Repo.delete(assignment)
+    end
+  end
+
   def workspace_policy_rules(workspace_id) when is_integer(workspace_id) do
     workspace_id
     |> list_workspace_policy_sets()

--- a/lib/controlkeel/platform.ex
+++ b/lib/controlkeel/platform.ex
@@ -149,7 +149,17 @@ defmodule ControlKeel.Platform do
     |> Repo.insert()
   end
 
-  def list_workspace_policy_sets(workspace_id) do
+  def list_workspace_policy_sets(workspace_id \\ nil)
+
+  def list_workspace_policy_sets(nil) do
+    WorkspacePolicySet
+    |> where([assignment], assignment.enabled == true)
+    |> order_by([assignment], asc: assignment.precedence, asc: assignment.id)
+    |> preload(:policy_set)
+    |> Repo.all()
+  end
+
+  def list_workspace_policy_sets(workspace_id) when is_integer(workspace_id) do
     WorkspacePolicySet
     |> where(
       [assignment],

--- a/lib/controlkeel/platform.ex
+++ b/lib/controlkeel/platform.ex
@@ -149,26 +149,44 @@ defmodule ControlKeel.Platform do
     |> Repo.insert()
   end
 
+  @doc """
+  Enabled assignments for `workspace_id` (every workspace when `nil`), ordered
+  by precedence. Rule evaluation path — disabled assignments never run.
+  """
   def list_workspace_policy_sets(workspace_id \\ nil)
 
-  def list_workspace_policy_sets(nil) do
-    WorkspacePolicySet
+  def list_workspace_policy_sets(workspace_id)
+      when is_nil(workspace_id) or is_integer(workspace_id) do
+    workspace_id
+    |> workspace_policy_set_query()
     |> where([assignment], assignment.enabled == true)
-    |> order_by([assignment], asc: assignment.precedence, asc: assignment.id)
-    |> preload(:policy_set)
     |> Repo.all()
   end
 
-  def list_workspace_policy_sets(workspace_id) when is_integer(workspace_id) do
-    WorkspacePolicySet
-    |> where(
-      [assignment],
-      assignment.workspace_id == ^workspace_id and assignment.enabled == true
-    )
-    |> order_by([assignment], asc: assignment.precedence, asc: assignment.id)
-    |> preload(:policy_set)
+  @doc """
+  All assignments for `workspace_id` (every workspace when `nil`), including
+  disabled ones. Display counterpart to `list_workspace_policy_sets/1`.
+  """
+  def list_workspace_policy_assignments(workspace_id \\ nil)
+
+  def list_workspace_policy_assignments(workspace_id)
+      when is_nil(workspace_id) or is_integer(workspace_id) do
+    workspace_id
+    |> workspace_policy_set_query()
     |> Repo.all()
   end
+
+  defp workspace_policy_set_query(workspace_id) do
+    WorkspacePolicySet
+    |> maybe_where_workspace(workspace_id)
+    |> order_by([assignment], asc: assignment.precedence, asc: assignment.id)
+    |> preload(:policy_set)
+  end
+
+  defp maybe_where_workspace(query, nil), do: query
+
+  defp maybe_where_workspace(query, workspace_id) when is_integer(workspace_id),
+    do: where(query, [assignment], assignment.workspace_id == ^workspace_id)
 
   def apply_policy_set(workspace_id, policy_set_id, attrs \\ %{}) do
     attrs =

--- a/lib/controlkeel/platform/workspace_policy_set.ex
+++ b/lib/controlkeel/platform/workspace_policy_set.ex
@@ -19,7 +19,10 @@ defmodule ControlKeel.Platform.WorkspacePolicySet do
     workspace_policy_set
     |> cast(attrs, [:workspace_id, :policy_set_id, :precedence, :enabled])
     |> validate_required([:workspace_id, :policy_set_id, :precedence, :enabled])
-    |> validate_number(:precedence, greater_than_or_equal_to: 0)
+    |> validate_number(:precedence,
+      greater_than_or_equal_to: 0,
+      less_than_or_equal_to: 2_147_483_647
+    )
     |> assoc_constraint(:workspace)
     |> assoc_constraint(:policy_set)
     |> unique_constraint([:workspace_id, :policy_set_id])

--- a/lib/controlkeel_web/components/core_components.ex
+++ b/lib/controlkeel_web/components/core_components.ex
@@ -353,6 +353,7 @@ defmodule ControlKeelWeb.CoreComponents do
   attr :value, :any
   attr :type, :string, default: "text"
   attr :field, Phoenix.HTML.FormField
+  attr :errors, :list, default: [], doc: "error messages rendered below the input"
   attr :hint, :string, default: nil
   attr :icon, :string, default: nil
   attr :class, :any, default: nil, doc: "additional classes appended to the default styling"
@@ -372,9 +373,11 @@ defmodule ControlKeelWeb.CoreComponents do
         id={@id}
         name={@name}
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+        aria-invalid={@errors != [] || nil}
         class={[input_component_field_class(), @class]}
         {@rest}
       />
+      <.component_field_error :for={msg <- @errors} message={msg} />
       <.component_field_hint :if={@hint} hint={@hint} />
     </div>
     """
@@ -399,6 +402,7 @@ defmodule ControlKeelWeb.CoreComponents do
   attr :label, :string, required: true
   attr :value, :any
   attr :field, Phoenix.HTML.FormField
+  attr :errors, :list, default: [], doc: "error messages rendered below the textarea"
   attr :hint, :string, default: nil
   attr :icon, :string, default: nil
   attr :class, :any, default: nil, doc: "additional classes appended to the default styling"
@@ -416,9 +420,11 @@ defmodule ControlKeelWeb.CoreComponents do
       <textarea
         id={@id}
         name={@name}
+        aria-invalid={@errors != [] || nil}
         class={[textarea_component_field_class(), @class]}
         {@rest}
       >{Phoenix.HTML.Form.normalize_value("textarea", @value)}</textarea>
+      <.component_field_error :for={msg <- @errors} message={msg} />
       <.component_field_hint :if={@hint} hint={@hint} />
     </div>
     """
@@ -443,11 +449,20 @@ defmodule ControlKeelWeb.CoreComponents do
     """
   end
 
+  attr :message, :string, required: true
+
+  defp component_field_error(assigns) do
+    ~H"""
+    <p class="mt-1.5 text-xs font-medium text-destructive">{@message}</p>
+    """
+  end
+
   defp assign_component_field(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
     assigns
     |> assign(field: nil, id: assigns.id || field.id)
     |> assign_new(:name, fn -> field.name end)
     |> assign_new(:value, fn -> field.value end)
+    |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
   end
 
   defp assign_component_field(assigns), do: assigns

--- a/lib/controlkeel_web/components/core_components.ex
+++ b/lib/controlkeel_web/components/core_components.ex
@@ -620,6 +620,63 @@ defmodule ControlKeelWeb.CoreComponents do
   end
 
   @doc """
+  Renders a modal dialog shell: overlay, Escape-to-close, close button, and
+  focus-on-open. Content goes in the inner block; the LiveView owning the
+  modal handles the `on_close` event by toggling its open assign.
+
+  ## Examples
+
+      <.modal id="my-modal" title="Title" on_close="close_modal">
+        body
+      </.modal>
+  """
+  attr :id, :string, required: true
+  attr :title, :string, required: true
+  attr :on_close, :string, required: true, doc: "event pushed on backdrop click, X, or Escape"
+  attr :width, :string, default: "max-w-2xl"
+  slot :inner_block, required: true
+
+  def modal(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      class="relative z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={"#{@id}-title"}
+      phx-mounted={JS.show(to: "##{@id}") |> JS.focus_first(to: "##{@id}")}
+      phx-remove={JS.hide(to: "##{@id}")}
+      phx-window-keydown={JS.push(@on_close)}
+      phx-key="escape"
+    >
+      <div
+        class="fixed inset-0 bg-overlay/70 backdrop-blur-sm transition-opacity"
+        phx-click={@on_close}
+        aria-hidden="true"
+      />
+      <div class="fixed inset-0 flex items-center justify-center p-4">
+        <div class={"max-h-[90vh] w-full overflow-y-auto rounded-2xl border bg-card p-6 shadow-card #{@width}"}>
+          <div class="mb-5 flex items-center justify-between">
+            <h2 id={"#{@id}-title"} class="text-lg font-semibold text-foreground">
+              {@title}
+            </h2>
+            <button
+              type="button"
+              phx-click={@on_close}
+              class="rounded-md text-muted-foreground transition hover:text-foreground"
+              aria-label="Close"
+            >
+              <.icon name="hero-x-mark" class="size-5" />
+            </button>
+          </div>
+          {render_slot(@inner_block)}
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
   Translates an error message using gettext.
   """
   def translate_error({msg, opts}) do

--- a/lib/controlkeel_web/components/core_components.ex
+++ b/lib/controlkeel_web/components/core_components.ex
@@ -567,6 +567,35 @@ defmodule ControlKeelWeb.CoreComponents do
     """
   end
 
+  @doc """
+  Renders a policy rule pill. Color reflects `action` (`block` / `warn` /
+  `escalate_to_human`); the label content goes in the inner block.
+
+  ## Examples
+
+      <.rule_tag action="block" class="px-2.5 py-1 text-xs font-medium">no rm rf</.rule_tag>
+  """
+  attr :action, :string, required: true
+  attr :title, :string, default: nil
+  attr :class, :any, default: nil, doc: "spacing/typography classes appended to the pill"
+  slot :inner_block, required: true, doc: "rule label"
+
+  def rule_tag(assigns) do
+    ~H"""
+    <span
+      title={@title}
+      class={["inline-flex rounded-full ring-1", rule_tag_class(@action), @class]}
+    >
+      {render_slot(@inner_block)}
+    </span>
+    """
+  end
+
+  defp rule_tag_class("block"), do: "bg-destructive/10 text-destructive ring-destructive/20"
+  defp rule_tag_class("warn"), do: "bg-warning/10 text-warning ring-warning/20"
+  defp rule_tag_class("escalate_to_human"), do: "bg-info/10 text-info ring-info/20"
+  defp rule_tag_class(_), do: "bg-muted text-muted-foreground ring-border"
+
   ## JS Commands
 
   def show(js \\ %JS{}, selector) do

--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -391,6 +391,13 @@ defmodule ControlKeelWeb.Layouts do
   """
   attr :current_path, :string, default: nil
   attr :page_action, :any, default: nil
+  attr :breadcrumbs, :list,
+    default: nil,
+    doc: """
+    Explicit crumbs (`%{label: ..., to: ...}`, `to: nil` renders plain text).
+    Overrides the path-derived trail — use when path segments are opaque ids
+    or have no route.
+    """
 
   def dashboard_header(assigns) do
     actions =
@@ -400,7 +407,10 @@ defmodule ControlKeelWeb.Layouts do
         true -> [assigns.page_action]
       end
 
-    assigns = assign(assigns, :actions, actions)
+    assigns =
+      assigns
+      |> assign(:actions, actions)
+      |> assign(:trail, breadcrumb_items(assigns))
 
     ~H"""
     <div class="flex w-full items-center justify-between border-b p-4">
@@ -414,18 +424,18 @@ defmodule ControlKeelWeb.Layouts do
               <.icon name="hero-home" class="size-3.5" />
             </.link>
           </li>
-          <%= for {label, path, final} <- breadcrumb_trail(@current_path) do %>
+          <%= for {label, path} <- @trail do %>
             <li class="flex items-center gap-1.5">
               <.icon name="hero-chevron-right" class="size-3 text-muted-foreground" />
-              <%= if final do %>
-                <span class="font-medium text-muted-foreground">{label}</span>
-              <% else %>
+              <%= if path do %>
                 <.link
                   navigate={path}
                   class="text-muted-foreground transition hover:text-muted-foreground"
                 >
                   {label}
                 </.link>
+              <% else %>
+                <span class="font-medium text-muted-foreground">{label}</span>
               <% end %>
             </li>
           <% end %>
@@ -486,6 +496,20 @@ defmodule ControlKeelWeb.Layouts do
     "telemetry" => "Telemetry",
     "projects" => "Projects"
   }
+
+  defp breadcrumb_items(%{breadcrumbs: [_ | _] = crumbs}) do
+    Enum.map(crumbs, fn
+      %{label: label, to: to} -> {label, to}
+      %{label: label} -> {label, nil}
+    end)
+  end
+
+  defp breadcrumb_items(assigns) do
+    Enum.map(breadcrumb_trail(assigns.current_path), fn
+      {label, _path, true} -> {label, nil}
+      {label, path, false} -> {label, path}
+    end)
+  end
 
   defp breadcrumb_trail(current_path) do
     segments = String.split(current_path, "/", trim: true)

--- a/lib/controlkeel_web/components/layouts/dashboard.html.heex
+++ b/lib/controlkeel_web/components/layouts/dashboard.html.heex
@@ -2,7 +2,11 @@
   <.sidebar current_user={@current_user} current_path={@current_path} />
 
   <div class="flex flex-1 flex-col overflow-hidden">
-    <.dashboard_header current_path={@current_path} page_action={@page_action} breadcrumbs={@breadcrumbs} />
+    <.dashboard_header
+      current_path={@current_path}
+      page_action={@page_action}
+      breadcrumbs={@breadcrumbs}
+    />
 
     <main class="flex-1 overflow-y-auto">
       <div class="px-4 pt-6 pb-12 sm:px-8 lg:px-8 container mx-auto">

--- a/lib/controlkeel_web/components/layouts/dashboard.html.heex
+++ b/lib/controlkeel_web/components/layouts/dashboard.html.heex
@@ -2,7 +2,7 @@
   <.sidebar current_user={@current_user} current_path={@current_path} />
 
   <div class="flex flex-1 flex-col overflow-hidden">
-    <.dashboard_header current_path={@current_path} page_action={@page_action} />
+    <.dashboard_header current_path={@current_path} page_action={@page_action} breadcrumbs={@breadcrumbs} />
 
     <main class="flex-1 overflow-y-auto">
       <div class="px-4 pt-6 pb-12 sm:px-8 lg:px-8 container mx-auto">

--- a/lib/controlkeel_web/live/layout_defaults.ex
+++ b/lib/controlkeel_web/live/layout_defaults.ex
@@ -10,6 +10,9 @@ defmodule ControlKeelWeb.LayoutDefaults do
     - `%{label: ..., event: ..., icon: ...}` — a `phx-click` button
     - `%{label: ..., form: ..., icon: ...}` — a `type="submit"` button that
       submits the form with the given DOM id (e.g. `"benchmark-runner"`)
+  - `@breadcrumbs` — defaults to `nil`; a LiveView overrides it with explicit
+    breadcrumb crumbs (`%{label: ..., to: ...}` where `to: nil` renders plain
+    text) when the path-derived trail would show opaque ids or dead segments.
 
   Attached as an `on_mount` hook on the live_sessions whose layout needs these,
   so individual LiveViews don't have to set them manually.
@@ -23,6 +26,7 @@ defmodule ControlKeelWeb.LayoutDefaults do
       socket
       |> assign(:current_path, nil)
       |> assign_new(:page_action, fn -> nil end)
+      |> assign_new(:breadcrumbs, fn -> nil end)
       |> attach_hook(:__current_path__, :handle_params, fn _params, uri, socket ->
         {:cont, assign(socket, :current_path, URI.parse(uri).path)}
       end)

--- a/lib/controlkeel_web/live/policy_studio_live.ex
+++ b/lib/controlkeel_web/live/policy_studio_live.ex
@@ -432,7 +432,7 @@ defmodule ControlKeelWeb.PolicyStudioLive do
 
   defp assign_policy_sets(socket) do
     assignments_by_set =
-      Platform.list_workspace_policy_sets()
+      Platform.list_workspace_policy_assignments()
       |> Enum.group_by(& &1.policy_set_id)
 
     policy_sets =

--- a/lib/controlkeel_web/live/policy_studio_live.ex
+++ b/lib/controlkeel_web/live/policy_studio_live.ex
@@ -3,6 +3,7 @@ defmodule ControlKeelWeb.PolicyStudioLive do
 
   alias ControlKeel.Intent
   alias ControlKeel.Platform
+  alias ControlKeel.Platform.PolicySet
   alias ControlKeel.Policy.PackLoader
 
   @impl true
@@ -136,15 +137,11 @@ defmodule ControlKeelWeb.PolicyStudioLive do
                   </p>
                   <%= if set.workspace_policy_sets != [] do %>
                     <p class="mt-1 text-xs text-muted-foreground">
-                      Applied to:
-                      <%= for assignment <- set.workspace_policy_sets do %>
-                        workspace #{assignment.workspace_id} (precedence {assignment.precedence}
-                        <%= unless assignment.enabled do %>
-                          , disabled
-                        <% end %>)<%= if assignment != List.last(set.workspace_policy_sets) do %>
-                          ,
-                        <% end %>
-                      <% end %>
+                      Applied to: {Enum.map_join(
+                        set.workspace_policy_sets,
+                        ", ",
+                        &assignment_summary/1
+                      )}
                     </p>
                   <% else %>
                     <p class="mt-1 text-xs text-muted-foreground">
@@ -219,97 +216,65 @@ defmodule ControlKeelWeb.PolicyStudioLive do
 
   defp create_policy_set_modal(assigns) do
     ~H"""
-    <div
-      id="policy-set-create-modal"
-      class="relative z-50"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="policy-set-create-modal-title"
-      phx-mounted={Phoenix.LiveView.JS.show(to: "#policy-set-create-modal")}
-      phx-remove={Phoenix.LiveView.JS.hide(to: "#policy-set-create-modal")}
-    >
-      <div
-        class="fixed inset-0 bg-overlay/70 backdrop-blur-sm transition-opacity"
-        phx-click="close_create_modal"
-        aria-label="Close modal"
-      />
+    <.modal id="policy-set-create-modal" title="New policy set" on_close="close_create_modal">
+      <.form
+        for={@form}
+        phx-change="validate_policy_set"
+        phx-submit="save_policy_set"
+        id="policy-set-form"
+        class="space-y-4"
+      >
+        <.input_component
+          field={@form[:name]}
+          label="Name"
+          placeholder="no-rm-rf"
+          required
+        />
 
-      <div class="fixed inset-0 flex items-center justify-center p-4">
-        <div class="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl border bg-card p-6 shadow-card">
-          <div class="mb-5 flex items-center justify-between">
-            <h2 id="policy-set-create-modal-title" class="text-lg font-semibold text-foreground">
-              New policy set
-            </h2>
-            <button
-              type="button"
-              phx-click="close_create_modal"
-              class="rounded-md text-muted-foreground transition hover:text-foreground"
-              aria-label="Close"
-            >
-              <.icon name="hero-x-mark" class="size-5" />
-            </button>
-          </div>
-
-          <.form
-            for={@form}
-            phx-change="validate_policy_set"
-            phx-submit="save_policy_set"
-            id="policy-set-form"
-            class="space-y-4"
+        <div>
+          <label
+            for="policy-set-scope"
+            class="mb-1.5 flex items-center gap-1.5 text-sm font-medium text-foreground/90"
           >
-            <.input_component
-              field={@form[:name]}
-              label="Name"
-              placeholder="no-rm-rf"
-              required
-            />
-
-            <div>
-              <label
-                for="policy-set-scope"
-                class="mb-1.5 flex items-center gap-1.5 text-sm font-medium text-foreground/90"
-              >
-                Scope
-              </label>
-              <select
-                id="policy-set-scope"
-                name="policy_set[scope]"
-                class="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 md:text-sm"
-              >
-                <option value="workspace" selected={@form[:scope].value in [nil, "workspace"]}>
-                  Workspace
-                </option>
-                <option value="global" selected={@form[:scope].value == "global"}>
-                  Global
-                </option>
-              </select>
-            </div>
-
-            <.input_component
-              field={@form[:description]}
-              label="Description"
-              placeholder="Example: no rm -rf rules"
-              required
-            />
-
-            <.textarea
-              name="policy_set[rules_json]"
-              value={@rules_json}
-              label="Rules JSON (optional)"
-              placeholder={rules_json_placeholder()}
-              spellcheck="false"
-              class="min-h-40 font-mono text-xs"
-              errors={if @rules_error, do: [@rules_error], else: []}
-            />
-
-            <div class="flex items-center justify-end gap-3 border-t pt-4">
-              <.button variant="outline" phx-click="close_create_modal">Cancel</.button>
-              <.button type="submit">Create policy set</.button>
-            </div>
-          </.form>
+            Scope
+          </label>
+          <select
+            id="policy-set-scope"
+            name="policy_set[scope]"
+            class="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 md:text-sm"
+          >
+            <option value="workspace" selected={@form[:scope].value in [nil, "workspace"]}>
+              Workspace
+            </option>
+            <option value="global" selected={@form[:scope].value == "global"}>
+              Global
+            </option>
+          </select>
         </div>
-      </div>
-    </div>
+
+        <.input_component
+          field={@form[:description]}
+          label="Description"
+          placeholder="Example: no rm -rf rules"
+          required
+        />
+
+        <.textarea
+          name="policy_set[rules_json]"
+          value={@rules_json}
+          label="Rules JSON (optional)"
+          placeholder={rules_json_placeholder()}
+          spellcheck="false"
+          class="min-h-40 font-mono text-xs"
+          errors={if @rules_error, do: [@rules_error], else: []}
+        />
+
+        <div class="flex items-center justify-end gap-3 border-t pt-4">
+          <.button variant="outline" phx-click="close_create_modal">Cancel</.button>
+          <.button type="submit">Create policy set</.button>
+        </div>
+      </.form>
+    </.modal>
     """
   end
 
@@ -318,98 +283,71 @@ defmodule ControlKeelWeb.PolicyStudioLive do
 
   defp packs_dialog(assigns) do
     ~H"""
-    <div
+    <.modal
       id="packs-dialog"
-      class="relative z-50"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="packs-dialog-title"
-      phx-mounted={Phoenix.LiveView.JS.show(to: "#packs-dialog")}
-      phx-remove={Phoenix.LiveView.JS.hide(to: "#packs-dialog")}
+      title="Built-in policy packs"
+      on_close="close_packs_dialog"
+      width="max-w-3xl"
     >
-      <div
-        class="fixed inset-0 bg-overlay/70 backdrop-blur-sm transition-opacity"
-        phx-click="close_packs_dialog"
-        aria-label="Close dialog"
-      />
-
-      <div class="fixed inset-0 flex items-center justify-center p-4">
-        <div class="max-h-[85vh] w-full max-w-3xl overflow-hidden rounded-2xl border bg-card shadow-card">
-          <div class="flex items-center justify-between border-b p-5">
-            <h2 id="packs-dialog-title" class="text-lg font-semibold text-foreground">
-              Built-in policy packs
-            </h2>
-            <button
-              type="button"
-              phx-click="close_packs_dialog"
-              class="rounded-md text-muted-foreground transition hover:text-foreground"
-              aria-label="Close"
-            >
-              <.icon name="hero-x-mark" class="size-5" />
-            </button>
-          </div>
-
-          <div class="max-h-[70vh] divide-y divide-border overflow-y-auto p-5">
-            <%= for {name, rules} <- @packs do %>
-              <% open? = MapSet.member?(@open_packs, name) %>
-              <% panel_id = "pack-panel-#{name}"
-              label_id = "#{panel_id}-label" %>
-              <article class="py-2 first:pt-0 last:pb-0">
-                <h3 class="m-0">
-                  <button
-                    type="button"
-                    phx-click="toggle_pack"
-                    phx-value-name={name}
-                    aria-expanded={open?}
-                    aria-controls={panel_id}
-                    class="flex w-full cursor-pointer select-none items-center justify-between gap-4 py-2 text-left"
+      <div class="divide-y divide-border">
+        <%= for {name, rules} <- @packs do %>
+          <% open? = MapSet.member?(@open_packs, name) %>
+          <% panel_id = "pack-panel-#{name}"
+          label_id = "#{panel_id}-label" %>
+          <article class="py-2 first:pt-0 last:pb-0">
+            <h3 class="m-0">
+              <button
+                type="button"
+                phx-click="toggle_pack"
+                phx-value-name={name}
+                aria-expanded={open?}
+                aria-controls={panel_id}
+                class="flex w-full cursor-pointer select-none items-center justify-between gap-4 py-2 text-left"
+              >
+                <span id={label_id} class="text-base font-semibold text-foreground">
+                  {pack_label(name)}
+                </span>
+                <span class="flex items-center gap-2">
+                  <span class="text-xs text-muted-foreground">
+                    {length(rules)} rules
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class={"size-4 text-muted-foreground transition-transform duration-200 #{if open?, do: "rotate-180", else: ""}"}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
                   >
-                    <span id={label_id} class="text-base font-semibold text-foreground">
-                      {pack_label(name)}
-                    </span>
-                    <span class="flex items-center gap-2">
-                      <span class="text-xs text-muted-foreground">
-                        {length(rules)} rules
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        class={"size-4 text-muted-foreground transition-transform duration-200 #{if open?, do: "rotate-180", else: ""}"}
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M19 9l-7 7-7-7"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </h3>
-                <%= if open? do %>
-                  <div id={panel_id} role="region" aria-labelledby={label_id} class="pb-2 pl-1">
-                    <p class="text-sm text-muted-foreground">{pack_description(name)}</p>
-                    <div class="mt-3 flex flex-wrap gap-2">
-                      <%= for rule <- rules do %>
-                        <.rule_tag
-                          action={rule.action}
-                          title={rule.action <> ", " <> rule.category}
-                          class="px-2.5 py-1 text-xs font-medium"
-                        >
-                          {rule_name(rule.id)}
-                        </.rule_tag>
-                      <% end %>
-                    </div>
-                  </div>
-                <% end %>
-              </article>
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </h3>
+            <%= if open? do %>
+              <div id={panel_id} role="region" aria-labelledby={label_id} class="pb-2 pl-1">
+                <p class="text-sm text-muted-foreground">{pack_description(name)}</p>
+                <div class="mt-3 flex flex-wrap gap-2">
+                  <%= for rule <- rules do %>
+                    <.rule_tag
+                      action={rule.action}
+                      title={rule.action <> ", " <> rule.category}
+                      class="px-2.5 py-1 text-xs font-medium"
+                    >
+                      {rule_name(rule.id)}
+                    </.rule_tag>
+                  <% end %>
+                </div>
+              </div>
             <% end %>
-          </div>
-        </div>
+          </article>
+        <% end %>
       </div>
-    </div>
+    </.modal>
     """
   end
 
@@ -446,8 +384,13 @@ defmodule ControlKeelWeb.PolicyStudioLive do
     assign(socket, :policy_sets, policy_sets)
   end
 
+  defp assignment_summary(assignment) do
+    suffix = if assignment.enabled, do: "", else: ", disabled"
+    "workspace ##{assignment.workspace_id} (precedence #{assignment.precedence}#{suffix})"
+  end
+
   defp empty_policy_set_changeset do
-    ControlKeel.Platform.PolicySet.changeset(%ControlKeel.Platform.PolicySet{}, %{})
+    PolicySet.changeset(%PolicySet{}, %{})
   end
 
   defp assign_policy_set_form(socket, changeset, raw_rules_json, rules_error) do
@@ -469,11 +412,8 @@ defmodule ControlKeelWeb.PolicyStudioLive do
       end
 
     changeset =
-      %ControlKeel.Platform.PolicySet{}
-      |> ControlKeel.Platform.PolicySet.changeset(attrs)
-      |> then(fn changeset ->
-        if ui_error, do: Ecto.Changeset.add_error(changeset, :rules, ui_error), else: changeset
-      end)
+      %PolicySet{}
+      |> PolicySet.changeset(attrs)
       |> Map.put(:action, action)
 
     {attrs, changeset, raw, ui_error}

--- a/lib/controlkeel_web/live/policy_studio_live.ex
+++ b/lib/controlkeel_web/live/policy_studio_live.ex
@@ -371,6 +371,10 @@ defmodule ControlKeelWeb.PolicyStudioLive do
   end
 
   defp assign_policy_sets(socket) do
+    # Operator ruling (issue #117 review): creating policy sets here is
+    # intentionally open to all members — no role gate, regardless of the
+    # set's intended use. Cross-org visibility of assignments below is also
+    # accepted for now; tighten both in a future auth pass.
     assignments_by_set =
       Platform.list_workspace_policy_assignments()
       |> Enum.group_by(& &1.policy_set_id)

--- a/lib/controlkeel_web/live/policy_studio_live.ex
+++ b/lib/controlkeel_web/live/policy_studio_live.ex
@@ -155,12 +155,13 @@ defmodule ControlKeelWeb.PolicyStudioLive do
                   <%= if entries != [] do %>
                     <div class="mt-2 flex flex-wrap gap-2">
                       <%= for rule <- entries do %>
-                        <span
+                        <.rule_tag
+                          action={rule["action"]}
                           title={"#{rule["action"]}, #{rule["category"]}"}
-                          class={"inline-flex rounded-full px-2.5 py-1 text-xs font-medium ring-1 #{rule_tag_class(rule["action"])}"}
+                          class="px-2.5 py-1 text-xs font-medium"
                         >
                           {rule_name(rule["id"])}
-                        </span>
+                        </.rule_tag>
                       <% end %>
                     </div>
                   <% end %>
@@ -392,12 +393,13 @@ defmodule ControlKeelWeb.PolicyStudioLive do
                     <p class="text-sm text-muted-foreground">{pack_description(name)}</p>
                     <div class="mt-3 flex flex-wrap gap-2">
                       <%= for rule <- rules do %>
-                        <span
+                        <.rule_tag
+                          action={rule.action}
                           title={rule.action <> ", " <> rule.category}
-                          class={"inline-flex rounded-full px-2.5 py-1 text-xs font-medium ring-1 #{rule_tag_class(rule.action)}"}
+                          class="px-2.5 py-1 text-xs font-medium"
                         >
                           {rule_name(rule.id)}
-                        </span>
+                        </.rule_tag>
                       <% end %>
                     </div>
                   </div>
@@ -581,11 +583,4 @@ defmodule ControlKeelWeb.PolicyStudioLive do
   defp rule_name(id) do
     id |> String.split(".") |> List.last() |> String.replace("_", " ")
   end
-
-  defp rule_tag_class("block"), do: "bg-destructive/10 text-destructive ring-destructive/20"
-  defp rule_tag_class("warn"), do: "bg-warning/10 text-warning ring-warning/20"
-
-  defp rule_tag_class("escalate_to_human"), do: "bg-info/10 text-info ring-info/20"
-
-  defp rule_tag_class(_), do: "bg-muted text-muted-foreground ring-border"
 end

--- a/lib/controlkeel_web/live/policy_studio_live.ex
+++ b/lib/controlkeel_web/live/policy_studio_live.ex
@@ -12,7 +12,13 @@ defmodule ControlKeelWeb.PolicyStudioLive do
      |> assign(:page_title, "Policy Studio")
      |> assign(:open_packs, MapSet.new())
      |> assign_packs()
-     |> assign_policy_sets()}
+     |> assign_policy_sets()
+     |> assign(
+       :page_action,
+       %{label: "New policy set", event: "open_create_modal", icon: "hero-plus"}
+     )
+     |> assign(:show_create_modal, false)
+     |> assign_policy_set_form(empty_policy_set_changeset(), "", nil)}
   end
 
   @impl true
@@ -30,6 +36,52 @@ defmodule ControlKeelWeb.PolicyStudioLive do
       {:noreply, assign(socket, :open_packs, open_packs)}
     else
       {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("open_create_modal", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:show_create_modal, true)
+     |> assign_policy_set_form(empty_policy_set_changeset(), "", nil)}
+  end
+
+  @impl true
+  def handle_event("close_create_modal", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:show_create_modal, false)
+     |> assign_policy_set_form(empty_policy_set_changeset(), "", nil)}
+  end
+
+  @impl true
+  def handle_event("validate_policy_set", %{"policy_set" => params}, socket) do
+    {_attrs, changeset, raw, ui_error} = prepare_policy_set(params, :validate)
+
+    {:noreply, assign_policy_set_form(socket, changeset, raw, ui_error)}
+  end
+
+  @impl true
+  def handle_event("save_policy_set", %{"policy_set" => params}, socket) do
+    {attrs, changeset, raw, ui_error} = prepare_policy_set(params, :insert)
+
+    if ui_error do
+      {:noreply, assign_policy_set_form(socket, changeset, raw, ui_error)}
+    else
+      case Platform.create_policy_set(attrs) do
+        {:ok, set} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, "Created policy set ##{set.id}.")
+           |> assign(:show_create_modal, false)
+           |> assign_policy_set_form(empty_policy_set_changeset(), "", nil)
+           |> assign_policy_sets()}
+
+        {:error, %Ecto.Changeset{} = changeset} ->
+          {:noreply,
+           assign_policy_set_form(socket, Map.put(changeset, :action, :insert), raw, nil)}
+      end
     end
   end
 
@@ -184,6 +236,134 @@ defmodule ControlKeelWeb.PolicyStudioLive do
         </div>
       </div>
     </section>
+
+    <.create_policy_set_modal
+      :if={@show_create_modal}
+      form={@form}
+      rules_json={@rules_json}
+      rules_error={@rules_error}
+    />
+    """
+  end
+
+  defp rules_json_placeholder do
+    ~S([
+  {
+    "id": "shell.destructive_rm_rf",
+    "category": "security",
+    "severity": "critical",
+    "action": "block",
+    "plain_message": "Recursive force-delete commands are blocked in this workspace.",
+    "matcher": { "type": "regex", "patterns": ["rm\\s+-rf\\s+/"] }
+  }
+])
+  end
+
+  attr :form, :map, required: true
+  attr :rules_json, :string, default: ""
+  attr :rules_error, :string, default: nil
+
+  defp create_policy_set_modal(assigns) do
+    ~H"""
+    <div
+      id="policy-set-create-modal"
+      class="relative z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="policy-set-create-modal-title"
+      phx-mounted={Phoenix.LiveView.JS.show(to: "#policy-set-create-modal")}
+      phx-remove={Phoenix.LiveView.JS.hide(to: "#policy-set-create-modal")}
+    >
+      <div
+        class="fixed inset-0 bg-overlay/70 backdrop-blur-sm transition-opacity"
+        phx-click="close_create_modal"
+        aria-label="Close modal"
+      />
+
+      <div class="fixed inset-0 flex items-center justify-center p-4">
+        <div class="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl border bg-card/95 p-6 shadow-card">
+          <div class="mb-5 flex items-center justify-between">
+            <h2 id="policy-set-create-modal-title" class="text-lg font-semibold text-foreground">
+              New policy set
+            </h2>
+            <button
+              type="button"
+              phx-click="close_create_modal"
+              class="rounded-md text-muted-foreground transition hover:text-foreground"
+              aria-label="Close"
+            >
+              <.icon name="hero-x-mark" class="size-5" />
+            </button>
+          </div>
+
+          <.form
+            for={@form}
+            phx-change="validate_policy_set"
+            phx-submit="save_policy_set"
+            id="policy-set-form"
+            class="space-y-4"
+          >
+            <.input
+              field={@form[:name]}
+              type="text"
+              label="Name"
+              placeholder="no-rm-rf"
+              required
+              class="w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+
+            <.input
+              field={@form[:scope]}
+              type="select"
+              label="Scope"
+              options={[{"Workspace", "workspace"}, {"Global", "global"}]}
+              class="w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+
+            <.input
+              field={@form[:description]}
+              type="text"
+              label="Description"
+              placeholder="Block destructive deletes"
+              class="w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+
+            <div>
+              <label for="policy-set-rules-json" class="label mb-1 block">
+                Rules JSON <span class="font-normal text-muted-foreground">(optional)</span>
+              </label>
+              <textarea
+                id="policy-set-rules-json"
+                name="policy_set[rules_json]"
+                rows="10"
+                spellcheck="false"
+                placeholder={rules_json_placeholder()}
+                class="w-full rounded-xl border border-input bg-background px-3 py-2 font-mono text-xs text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              ><%= @rules_json %></textarea>
+              <p :if={@rules_error} class="mt-1 text-sm text-destructive">
+                {@rules_error}
+              </p>
+            </div>
+
+            <div class="flex items-center justify-end gap-3 border-t pt-4">
+              <button
+                type="button"
+                phx-click="close_create_modal"
+                class="rounded-full px-4 py-2 text-sm font-medium text-muted-foreground transition hover:text-foreground"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                class="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground shadow-lg shadow-primary/20 transition hover:-translate-y-0.5 hover:bg-primary"
+              >
+                Create policy set
+              </button>
+            </div>
+          </.form>
+        </div>
+      </div>
+    </div>
     """
   end
 
@@ -218,6 +398,57 @@ defmodule ControlKeelWeb.PolicyStudioLive do
       end)
 
     assign(socket, :policy_sets, policy_sets)
+  end
+
+  defp empty_policy_set_changeset do
+    ControlKeel.Platform.PolicySet.changeset(%ControlKeel.Platform.PolicySet{}, %{})
+  end
+
+  defp assign_policy_set_form(socket, changeset, raw_rules_json, rules_error) do
+    socket
+    |> assign(:changeset, changeset)
+    |> assign(:form, to_form(changeset, as: :policy_set))
+    |> assign(:rules_json, raw_rules_json)
+    |> assign(:rules_error, rules_error)
+  end
+
+  defp prepare_policy_set(params, action) do
+    {raw, attrs} = Map.pop(params, "rules_json")
+    raw = raw || ""
+
+    {attrs, ui_error} =
+      case decode_rule_entries(raw) do
+        {:ok, rules} -> {Map.put(attrs, "rules", rules), nil}
+        {:error, message} -> {Map.put(attrs, "rules", %{"entries" => []}), message}
+      end
+
+    changeset =
+      %ControlKeel.Platform.PolicySet{}
+      |> ControlKeel.Platform.PolicySet.changeset(attrs)
+      |> then(fn changeset ->
+        if ui_error, do: Ecto.Changeset.add_error(changeset, :rules, ui_error), else: changeset
+      end)
+      |> Map.put(:action, action)
+
+    {attrs, changeset, raw, ui_error}
+  end
+
+  defp decode_rule_entries(""), do: {:ok, %{"entries" => []}}
+
+  defp decode_rule_entries(raw) do
+    case Jason.decode(raw) do
+      {:ok, %{"entries" => _entries} = wrapped} ->
+        {:ok, wrapped}
+
+      {:ok, entries} when is_list(entries) ->
+        {:ok, %{"entries" => entries}}
+
+      {:ok, _other} ->
+        {:error, ~s(must be an array of rule entries or {"entries": [...]})}
+
+      {:error, %Jason.DecodeError{} = error} ->
+        {:error, "invalid JSON: " <> Exception.message(error)}
+    end
   end
 
   defp pack_label("baseline"), do: "Baseline — Secrets & OWASP"

--- a/lib/controlkeel_web/live/policy_studio_live.ex
+++ b/lib/controlkeel_web/live/policy_studio_live.ex
@@ -13,10 +13,6 @@ defmodule ControlKeelWeb.PolicyStudioLive do
      |> assign(:open_packs, MapSet.new())
      |> assign_packs()
      |> assign_policy_sets()
-     |> assign(
-       :page_action,
-       %{label: "New policy set", event: "open_create_modal", icon: "hero-plus"}
-     )
      |> assign(:show_create_modal, false)
      |> assign_policy_set_form(empty_policy_set_changeset(), "", nil)}
   end
@@ -88,67 +84,45 @@ defmodule ControlKeelWeb.PolicyStudioLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <section class="mx-auto max-w-[1180px] px-4 py-12 pb-16 pt-8">
-      <div class="space-y-1 mb-12">
-        <h2 class="text-2xl font-semibold text-primary leading-6 tracking-wide uppercase">
-          Policy Studio
-        </h2>
-        <p class="text-muted-foreground">
-          Every agent action passes through these policy packs before it executes. Rules that block are enforced automatically — no action required from you.
-        </p>
+    <section>
+      <div class="flex items-start justify-between gap-3 mb-8">
+        <.page_title
+          title="Policy Studio"
+          subtitle="Every agent action passes through these policy packs before it executes."
+        />
+        <.button phx-click="open_create_modal">
+          <.icon name="hero-plus" class="size-3.5" /> New policy set
+        </.button>
       </div>
 
-      <div class="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-4 mt-5">
-        <div class="border bg-card rounded-2xl backdrop-blur-lg shadow-2xl p-6">
-          <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-            Active packs
-          </p>
-          <strong>{@pack_count}</strong>
-        </div>
-        <div class="border bg-card rounded-2xl backdrop-blur-lg shadow-2xl p-6">
-          <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-            Total rules
-          </p>
-          <strong>{@rule_count}</strong>
-        </div>
-        <div class="border bg-card rounded-2xl backdrop-blur-lg shadow-2xl p-6">
-          <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-            Blocking rules
-          </p>
-          <strong>{@block_count}</strong>
-        </div>
-      </div>
-
-      <div class="border bg-card rounded-2xl backdrop-blur-lg shadow-2xl p-6 my-4">
-        <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-          Policy sets
-        </p>
+      <section class="rounded-2xl border bg-card p-5 shadow-card">
+        <.section_title>Custom policy sets</.section_title>
 
         <%= if @policy_sets == [] do %>
-          <p class="text-muted-foreground">
+          <p class="mt-4 text-sm text-muted-foreground">
             No custom policy sets yet. Create one with <code>controlkeel policy-set create</code>.
           </p>
         <% else %>
-          <div class="grid gap-4 list-none m-0 p-0">
+          <ul class="mt-4 divide-y divide-border">
             <%= for set <- @policy_sets do %>
-              <article class="grid gap-[0.55rem] border border-[rgba(255,255,255,0.07)] rounded-[1.1rem] p-4 bg-[rgba(255,255,255,0.03)]">
+              <li class="py-4 first:pt-0 last:pb-0">
                 <div class="flex items-center justify-between gap-4">
-                  <h3>#{set.id} {set.name}</h3>
+                  <h3 class="text-base font-semibold text-foreground">#{set.id} {set.name}</h3>
                   <span
                     title={set.status}
-                    class={"border rounded-full px-3 py-[0.45rem] text-[0.8rem] #{status_pill_class(set.status)}"}
+                    class={"inline-flex rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1 #{status_pill_class(set.status)}"}
                   >
                     {set.status}
                   </span>
                 </div>
-                <p class="text-muted-foreground mt-1">
+                <p class="mt-1 text-sm text-muted-foreground">
                   {length(Platform.PolicySet.rule_entries(set))} rules · scope: {set.scope}
                   <%= if set.description not in [nil, ""] do %>
                     · {set.description}
                   <% end %>
                 </p>
                 <%= if set.workspace_policy_sets != [] do %>
-                  <p class="text-muted-foreground text-sm">
+                  <p class="mt-1 text-xs text-muted-foreground">
                     Applied to:
                     <%= for assignment <- set.workspace_policy_sets do %>
                       workspace #{assignment.workspace_id} (precedence {assignment.precedence}
@@ -160,31 +134,33 @@ defmodule ControlKeelWeb.PolicyStudioLive do
                     <% end %>
                   </p>
                 <% else %>
-                  <p class="text-muted-foreground text-sm">Not applied to any workspace yet.</p>
+                  <p class="mt-1 text-xs text-muted-foreground">
+                    Not applied to any workspace yet.
+                  </p>
                 <% end %>
-              </article>
+              </li>
             <% end %>
-          </div>
+          </ul>
         <% end %>
-      </div>
+      </section>
 
-      <div class="border bg-card rounded-2xl backdrop-blur-lg shadow-2xl p-6">
-        <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-          Policy packs
-        </p>
-        <p class="text-muted-foreground text-sm mt-4 mb-4">
-          <span class="rounded-full p-2 text-xs bg-destructive/15 text-destructive border border-destructive/15 mr-1 font-bold uppercase">
+      <section class="mt-6 rounded-2xl border bg-card p-5 shadow-card">
+        <div class="flex items-center justify-between gap-3">
+          <.section_title>Built-in policy packs</.section_title>
+        </div>
+        <p class="mt-2 text-sm text-muted-foreground">
+          <span class="mr-1 inline-flex rounded-full bg-destructive/10 px-2.5 py-1 align-middle text-xs font-semibold text-destructive ring-1 ring-destructive/20">
             {@block_count} rules
           </span>
           block agent actions when violated. Other rules only generate warnings.
         </p>
 
-        <div class="grid gap-2 list-none m-0 p-0 max-h-[48rem] overflow-y-auto pr-1">
+        <div class="mt-4 max-h-[48rem] divide-y divide-border overflow-y-auto pr-1">
           <%= for {name, rules} <- @packs do %>
             <% open? = MapSet.member?(@open_packs, name) %>
-            <article class="border border-[rgba(255,255,255,0.07)] rounded-[1.1rem] bg-[rgba(255,255,255,0.03)]">
-              <% panel_id = "pack-panel-#{name}"
-              label_id = "#{panel_id}-label" %>
+            <% panel_id = "pack-panel-#{name}"
+            label_id = "#{panel_id}-label" %>
+            <article class="py-2 first:pt-0 last:pb-0">
               <h3 class="m-0">
                 <button
                   type="button"
@@ -192,16 +168,18 @@ defmodule ControlKeelWeb.PolicyStudioLive do
                   phx-value-name={name}
                   aria-expanded={open?}
                   aria-controls={panel_id}
-                  class="flex w-full items-center justify-between gap-4 p-4 cursor-pointer select-none text-left"
+                  class="flex w-full cursor-pointer select-none items-center justify-between gap-4 py-2 text-left"
                 >
-                  <span id={label_id}>{pack_label(name)}</span>
+                  <span id={label_id} class="text-base font-semibold text-foreground">
+                    {pack_label(name)}
+                  </span>
                   <span class="flex items-center gap-2">
                     <span class="text-xs text-muted-foreground">
                       {length(rules)} rules
                     </span>
                     <svg
                       aria-hidden="true"
-                      class={"w-4 h-4 text-muted-foreground transition-transform duration-200 #{if open?, do: "rotate-180", else: ""}"}
+                      class={"size-4 text-muted-foreground transition-transform duration-200 #{if open?, do: "rotate-180", else: ""}"}
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -217,13 +195,13 @@ defmodule ControlKeelWeb.PolicyStudioLive do
                 </button>
               </h3>
               <%= if open? do %>
-                <div id={panel_id} role="region" aria-labelledby={label_id} class="px-4 pb-4">
-                  <p class="text-muted-foreground text-sm">{pack_description(name)}</p>
-                  <div class="flex flex-wrap gap-2 mt-3">
+                <div id={panel_id} role="region" aria-labelledby={label_id} class="pb-2 pl-1">
+                  <p class="text-sm text-muted-foreground">{pack_description(name)}</p>
+                  <div class="mt-3 flex flex-wrap gap-2">
                     <%= for rule <- rules do %>
                       <span
                         title={rule.action <> ", " <> rule.category}
-                        class={"border rounded-full px-3 py-[0.45rem] text-[0.8rem] #{rule_tag_class(rule.action)}"}
+                        class={"inline-flex rounded-full px-2.5 py-1 text-xs font-medium ring-1 #{rule_tag_class(rule.action)}"}
                       >
                         {rule_name(rule.id)}
                       </span>
@@ -234,7 +212,7 @@ defmodule ControlKeelWeb.PolicyStudioLive do
             </article>
           <% end %>
         </div>
-      </div>
+      </section>
     </section>
 
     <.create_policy_set_modal
@@ -281,7 +259,7 @@ defmodule ControlKeelWeb.PolicyStudioLive do
       />
 
       <div class="fixed inset-0 flex items-center justify-center p-4">
-        <div class="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl border bg-card/95 p-6 shadow-card">
+        <div class="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl border bg-card p-6 shadow-card">
           <div class="mb-5 flex items-center justify-between">
             <h2 id="policy-set-create-modal-title" class="text-lg font-semibold text-foreground">
               New policy set
@@ -303,62 +281,54 @@ defmodule ControlKeelWeb.PolicyStudioLive do
             id="policy-set-form"
             class="space-y-4"
           >
-            <.input
+            <.input_component
               field={@form[:name]}
-              type="text"
               label="Name"
               placeholder="no-rm-rf"
               required
-              class="w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-            />
-
-            <.input
-              field={@form[:scope]}
-              type="select"
-              label="Scope"
-              options={[{"Workspace", "workspace"}, {"Global", "global"}]}
-              class="w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-            />
-
-            <.input
-              field={@form[:description]}
-              type="text"
-              label="Description"
-              placeholder="Block destructive deletes"
-              class="w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
             />
 
             <div>
-              <label for="policy-set-rules-json" class="label mb-1 block">
-                Rules JSON <span class="font-normal text-muted-foreground">(optional)</span>
+              <label
+                for="policy-set-scope"
+                class="mb-1.5 flex items-center gap-1.5 text-sm font-medium text-foreground/90"
+              >
+                Scope
               </label>
-              <textarea
-                id="policy-set-rules-json"
-                name="policy_set[rules_json]"
-                rows="10"
-                spellcheck="false"
-                placeholder={rules_json_placeholder()}
-                class="w-full rounded-xl border border-input bg-background px-3 py-2 font-mono text-xs text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-              ><%= @rules_json %></textarea>
-              <p :if={@rules_error} class="mt-1 text-sm text-destructive">
-                {@rules_error}
-              </p>
+              <select
+                id="policy-set-scope"
+                name="policy_set[scope]"
+                class="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 md:text-sm"
+              >
+                <option value="workspace" selected={@form[:scope].value in [nil, "workspace"]}>
+                  Workspace
+                </option>
+                <option value="global" selected={@form[:scope].value == "global"}>
+                  Global
+                </option>
+              </select>
             </div>
 
+            <.input_component
+              field={@form[:description]}
+              label="Description"
+              placeholder="Example: no rm -rf rules"
+              required
+            />
+
+            <.textarea
+              name="policy_set[rules_json]"
+              value={@rules_json}
+              label="Rules JSON (optional)"
+              placeholder={rules_json_placeholder()}
+              spellcheck="false"
+              class="min-h-40 font-mono text-xs"
+              errors={if @rules_error, do: [@rules_error], else: []}
+            />
+
             <div class="flex items-center justify-end gap-3 border-t pt-4">
-              <button
-                type="button"
-                phx-click="close_create_modal"
-                class="rounded-full px-4 py-2 text-sm font-medium text-muted-foreground transition hover:text-foreground"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                class="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground shadow-lg shadow-primary/20 transition hover:-translate-y-0.5 hover:bg-primary"
-              >
-                Create policy set
-              </button>
+              <.button variant="outline" phx-click="close_create_modal">Cancel</.button>
+              <.button type="submit">Create policy set</.button>
             </div>
           </.form>
         </div>
@@ -380,8 +350,6 @@ defmodule ControlKeelWeb.PolicyStudioLive do
     socket
     |> assign(:packs, Enum.sort_by(packs, fn {name, _} -> pack_sort_order(name) end))
     |> assign(:pack_names, MapSet.new(Map.keys(packs)))
-    |> assign(:pack_count, map_size(packs))
-    |> assign(:rule_count, length(all_rules))
     |> assign(:block_count, Enum.count(all_rules, &(&1.action == "block")))
     |> assign(:blocked_rules, blocked_rules)
   end
@@ -529,17 +497,19 @@ defmodule ControlKeelWeb.PolicyStudioLive do
   defp pack_sort_order("software"), do: 2
   defp pack_sort_order(_), do: 3
 
-  defp status_pill_class("active"), do: "bg-[rgba(125,226,174,0.12)] text-[#7de2ae]"
-  defp status_pill_class("disabled"), do: "bg-[rgba(255,143,107,0.12)] text-[#ffd6cb]"
-  defp status_pill_class("archived"), do: "bg-muted text-muted-foreground"
-  defp status_pill_class(_), do: "bg-muted text-muted-foreground"
+  defp status_pill_class("active"), do: "bg-success/10 text-success ring-success/20"
+  defp status_pill_class("disabled"), do: "bg-warning/10 text-warning ring-warning/20"
+
+  defp status_pill_class(_), do: "bg-muted text-muted-foreground ring-border"
 
   defp rule_name(id) do
     id |> String.split(".") |> List.last() |> String.replace("_", " ")
   end
 
-  defp rule_tag_class("block"), do: "bg-destructive/15 text-destructive border-destructive/15"
+  defp rule_tag_class("block"), do: "bg-destructive/10 text-destructive ring-destructive/20"
+  defp rule_tag_class("warn"), do: "bg-warning/10 text-warning ring-warning/20"
 
-  defp rule_tag_class("warn"),
-    do: "bg-[var(--ck-warning)]/15 text-[var(--ck-warning)] border-[var(--ck-warning)]/15"
+  defp rule_tag_class("escalate_to_human"), do: "bg-info/10 text-info ring-info/20"
+
+  defp rule_tag_class(_), do: "bg-muted text-muted-foreground ring-border"
 end

--- a/lib/controlkeel_web/live/policy_studio_live.ex
+++ b/lib/controlkeel_web/live/policy_studio_live.ex
@@ -1,25 +1,18 @@
 defmodule ControlKeelWeb.PolicyStudioLive do
   use ControlKeelWeb, :live_view
 
-  alias ControlKeel.Accounts
-  alias ControlKeel.Accounts.WorkspaceToolPolicy
   alias ControlKeel.Intent
+  alias ControlKeel.Platform
   alias ControlKeel.Policy.PackLoader
 
   @impl true
-  def mount(_params, session, socket) do
-    org_id =
-      socket.assigns[:current_org_id] ||
-        Map.get(session, "current_org_id") ||
-        Map.get(session, :current_org_id)
-
+  def mount(_params, _session, socket) do
     {:ok,
      socket
      |> assign(:page_title, "Policy Studio")
-     |> assign(:current_org_id, org_id)
      |> assign(:open_packs, MapSet.new())
      |> assign_packs()
-     |> assign_tool_policies(org_id)}
+     |> assign_policy_sets()}
   end
 
   @impl true
@@ -74,107 +67,120 @@ defmodule ControlKeelWeb.PolicyStudioLive do
         </div>
       </div>
 
-      <div class="grid gap-6 mt-6 max-[900px]:grid-cols-1 min-[901px]:grid-cols-[1.35fr_0.75fr]">
-        <div>
-          <div class="border bg-card rounded-2xl backdrop-blur-lg shadow-2xl p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-              Policy packs
-            </p>
-            <p class="text-muted-foreground text-sm mt-4 mb-4">
-              <span class="rounded-full p-2 text-xs bg-destructive/15 text-destructive border border-destructive/15 mr-1 font-bold uppercase">
-                {@block_count} rules
-              </span>
-              block agent actions when violated. Other rules only generate warnings.
-            </p>
+      <div class="border bg-card rounded-2xl backdrop-blur-lg shadow-2xl p-6 my-4">
+        <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
+          Policy sets
+        </p>
 
-            <div class="grid gap-2 list-none m-0 p-0 max-h-[48rem] overflow-y-auto pr-1">
-              <%= for {name, rules} <- @packs do %>
-                <% open? = MapSet.member?(@open_packs, name) %>
-                <article class="border border-[rgba(255,255,255,0.07)] rounded-[1.1rem] bg-[rgba(255,255,255,0.03)]">
-                  <% panel_id = "pack-panel-#{name}"
-                  label_id = "#{panel_id}-label" %>
-                  <h3 class="m-0">
-                    <button
-                      type="button"
-                      phx-click="toggle_pack"
-                      phx-value-name={name}
-                      aria-expanded={open?}
-                      aria-controls={panel_id}
-                      class="flex w-full items-center justify-between gap-4 p-4 cursor-pointer select-none text-left"
-                    >
-                      <span id={label_id}>{pack_label(name)}</span>
-                      <span class="flex items-center gap-2">
-                        <span class="text-xs text-muted-foreground">
-                          {length(rules)} rules
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          class={"w-4 h-4 text-muted-foreground transition-transform duration-200 #{if open?, do: "rotate-180", else: ""}"}
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M19 9l-7 7-7-7"
-                          />
-                        </svg>
-                      </span>
-                    </button>
-                  </h3>
-                  <%= if open? do %>
-                    <div id={panel_id} role="region" aria-labelledby={label_id} class="px-4 pb-4">
-                      <p class="text-muted-foreground text-sm">{pack_description(name)}</p>
-                      <div class="flex flex-wrap gap-2 mt-3">
-                        <%= for rule <- rules do %>
-                          <span
-                            title={rule.action <> ", " <> rule.category}
-                            class={"border rounded-full px-3 py-[0.45rem] text-[0.8rem] #{rule_tag_class(rule.action)}"}
-                          >
-                            {rule_name(rule.id)}
-                          </span>
-                        <% end %>
-                      </div>
-                    </div>
+        <%= if @policy_sets == [] do %>
+          <p class="text-muted-foreground">
+            No custom policy sets yet. Create one with <code>controlkeel policy-set create</code>.
+          </p>
+        <% else %>
+          <div class="grid gap-4 list-none m-0 p-0">
+            <%= for set <- @policy_sets do %>
+              <article class="grid gap-[0.55rem] border border-[rgba(255,255,255,0.07)] rounded-[1.1rem] p-4 bg-[rgba(255,255,255,0.03)]">
+                <div class="flex items-center justify-between gap-4">
+                  <h3>#{set.id} {set.name}</h3>
+                  <span
+                    title={set.status}
+                    class={"border rounded-full px-3 py-[0.45rem] text-[0.8rem] #{status_pill_class(set.status)}"}
+                  >
+                    {set.status}
+                  </span>
+                </div>
+                <p class="text-muted-foreground mt-1">
+                  {length(Platform.PolicySet.rule_entries(set))} rules · scope: {set.scope}
+                  <%= if set.description not in [nil, ""] do %>
+                    · {set.description}
                   <% end %>
-                </article>
-              <% end %>
-            </div>
-          </div>
-        </div>
-
-        <div>
-          <div class="border bg-card rounded-2xl backdrop-blur-lg shadow-2xl p-6">
-            <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
-              Workspace tool policies
-            </p>
-            <%= if @tool_policies == [] do %>
-              <p class="text-muted-foreground">
-                All workspaces inherit global tool access. Set a workspace policy with <code>controlkeel workspace tool-policy set</code>.
-              </p>
-            <% else %>
-              <div class="grid gap-4 list-none m-0 p-0">
-                <%= for {ws, policy} <- @tool_policies do %>
-                  <article class="grid gap-[0.55rem] border border-[rgba(255,255,255,0.07)] rounded-[1.1rem] p-4 bg-[rgba(255,255,255,0.03)]">
-                    <div class="flex items-center justify-between gap-4">
-                      <h3>{ws.name}</h3>
-                      <span class={"border rounded-full px-3 py-[0.45rem] text-[0.8rem] #{tool_policy_pill_class(policy.mode)}"}>
-                        {policy.mode}
-                      </span>
-                    </div>
-                    <% tools = WorkspaceToolPolicy.decode_tools(policy) %>
-                    <%= if tools != [] do %>
-                      <p class="text-muted-foreground mt-1">
-                        Tools: {Enum.join(tools, ", ")}
-                      </p>
+                </p>
+                <%= if set.workspace_policy_sets != [] do %>
+                  <p class="text-muted-foreground text-sm">
+                    Applied to:
+                    <%= for assignment <- set.workspace_policy_sets do %>
+                      workspace #{assignment.workspace_id} (precedence {assignment.precedence}
+                      <%= unless assignment.enabled do %>
+                        , disabled
+                      <% end %>)<%= if assignment != List.last(set.workspace_policy_sets) do %>
+                        ,
+                      <% end %>
                     <% end %>
-                  </article>
+                  </p>
+                <% else %>
+                  <p class="text-muted-foreground text-sm">Not applied to any workspace yet.</p>
                 <% end %>
-              </div>
+              </article>
             <% end %>
           </div>
+        <% end %>
+      </div>
+
+      <div class="border bg-card rounded-2xl backdrop-blur-lg shadow-2xl p-6">
+        <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
+          Policy packs
+        </p>
+        <p class="text-muted-foreground text-sm mt-4 mb-4">
+          <span class="rounded-full p-2 text-xs bg-destructive/15 text-destructive border border-destructive/15 mr-1 font-bold uppercase">
+            {@block_count} rules
+          </span>
+          block agent actions when violated. Other rules only generate warnings.
+        </p>
+
+        <div class="grid gap-2 list-none m-0 p-0 max-h-[48rem] overflow-y-auto pr-1">
+          <%= for {name, rules} <- @packs do %>
+            <% open? = MapSet.member?(@open_packs, name) %>
+            <article class="border border-[rgba(255,255,255,0.07)] rounded-[1.1rem] bg-[rgba(255,255,255,0.03)]">
+              <% panel_id = "pack-panel-#{name}"
+              label_id = "#{panel_id}-label" %>
+              <h3 class="m-0">
+                <button
+                  type="button"
+                  phx-click="toggle_pack"
+                  phx-value-name={name}
+                  aria-expanded={open?}
+                  aria-controls={panel_id}
+                  class="flex w-full items-center justify-between gap-4 p-4 cursor-pointer select-none text-left"
+                >
+                  <span id={label_id}>{pack_label(name)}</span>
+                  <span class="flex items-center gap-2">
+                    <span class="text-xs text-muted-foreground">
+                      {length(rules)} rules
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      class={"w-4 h-4 text-muted-foreground transition-transform duration-200 #{if open?, do: "rotate-180", else: ""}"}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M19 9l-7 7-7-7"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </h3>
+              <%= if open? do %>
+                <div id={panel_id} role="region" aria-labelledby={label_id} class="px-4 pb-4">
+                  <p class="text-muted-foreground text-sm">{pack_description(name)}</p>
+                  <div class="flex flex-wrap gap-2 mt-3">
+                    <%= for rule <- rules do %>
+                      <span
+                        title={rule.action <> ", " <> rule.category}
+                        class={"border rounded-full px-3 py-[0.45rem] text-[0.8rem] #{rule_tag_class(rule.action)}"}
+                      >
+                        {rule_name(rule.id)}
+                      </span>
+                    <% end %>
+                  </div>
+                </div>
+              <% end %>
+            </article>
+          <% end %>
         </div>
       </div>
     </section>
@@ -200,22 +206,18 @@ defmodule ControlKeelWeb.PolicyStudioLive do
     |> assign(:blocked_rules, blocked_rules)
   end
 
-  defp assign_tool_policies(socket, nil) do
-    assign(socket, :tool_policies, [])
-  end
+  defp assign_policy_sets(socket) do
+    assignments_by_set =
+      Platform.list_workspace_policy_sets()
+      |> Enum.group_by(& &1.policy_set_id)
 
-  defp assign_tool_policies(socket, org_id) when is_integer(org_id) do
-    workspaces = Accounts.list_workspaces_for_org(org_id)
-
-    policies =
-      workspaces
-      |> Enum.map(fn ws ->
-        policy = Accounts.get_workspace_tool_policy(ws.id)
-        {ws, policy}
+    policy_sets =
+      Platform.list_policy_sets()
+      |> Enum.map(fn set ->
+        Map.put(set, :workspace_policy_sets, Map.get(assignments_by_set, set.id, []))
       end)
-      |> Enum.reject(fn {_ws, policy} -> is_nil(policy) || policy.mode == "inherit" end)
 
-    assign(socket, :tool_policies, policies)
+    assign(socket, :policy_sets, policy_sets)
   end
 
   defp pack_label("baseline"), do: "Baseline — Secrets & OWASP"
@@ -296,9 +298,10 @@ defmodule ControlKeelWeb.PolicyStudioLive do
   defp pack_sort_order("software"), do: 2
   defp pack_sort_order(_), do: 3
 
-  defp tool_policy_pill_class("allowlist"), do: "bg-[rgba(125,226,174,0.12)] text-[#7de2ae]"
-  defp tool_policy_pill_class("denylist"), do: "bg-[rgba(255,143,107,0.12)] text-[#ffd6cb]"
-  defp tool_policy_pill_class(_), do: "bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]"
+  defp status_pill_class("active"), do: "bg-[rgba(125,226,174,0.12)] text-[#7de2ae]"
+  defp status_pill_class("disabled"), do: "bg-[rgba(255,143,107,0.12)] text-[#ffd6cb]"
+  defp status_pill_class("archived"), do: "bg-muted text-muted-foreground"
+  defp status_pill_class(_), do: "bg-muted text-muted-foreground"
 
   defp rule_name(id) do
     id |> String.split(".") |> List.last() |> String.replace("_", " ")

--- a/lib/controlkeel_web/live/policy_studio_live.ex
+++ b/lib/controlkeel_web/live/policy_studio_live.ex
@@ -85,29 +85,30 @@ defmodule ControlKeelWeb.PolicyStudioLive do
   def render(assigns) do
     ~H"""
     <section>
-      <div class="flex items-start justify-between gap-3 mb-8">
-        <.page_title
-          title="Policy Studio"
-          subtitle="Every agent action passes through these policy packs before it executes."
-        />
-        <.button phx-click="open_create_modal">
-          <.icon name="hero-plus" class="size-3.5" /> New policy set
-        </.button>
-      </div>
+      <.page_title
+        title="Policy Studio"
+        subtitle="Every agent action passes through these policy packs before it executes."
+        class="mb-8"
+      />
 
-      <section class="rounded-2xl border bg-card p-5 shadow-card">
-        <.section_title>Custom policy sets</.section_title>
+      <section class="mb-6">
+        <div class="flex items-center justify-between mb-4">
+          <.section_title>Custom policy sets</.section_title>
+          <.button phx-click="open_create_modal">
+            <.icon name="hero-plus" class="size-3.5" /> New policy set
+          </.button>
+        </div>
 
         <%= if @policy_sets == [] do %>
           <p class="mt-4 text-sm text-muted-foreground">
-            No custom policy sets yet. Create one with <code>controlkeel policy-set create</code>.
+            No custom policy sets yet. Use the New policy set button to create one.
           </p>
         <% else %>
-          <ul class="mt-4 divide-y divide-border">
+          <ul class="mt-4 divide-y divide-border bg-card p-5 rounded-2xl shadow-card">
             <%= for set <- @policy_sets do %>
               <li class="py-4 first:pt-0 last:pb-0">
                 <div class="flex items-center justify-between gap-4">
-                  <h3 class="text-base font-semibold text-foreground">#{set.id} {set.name}</h3>
+                  <h3 class="text-base font-semibold text-foreground">{set.name}</h3>
                   <span
                     title={set.status}
                     class={"inline-flex rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1 #{status_pill_class(set.status)}"}
@@ -144,18 +145,19 @@ defmodule ControlKeelWeb.PolicyStudioLive do
         <% end %>
       </section>
 
-      <section class="mt-6 rounded-2xl border bg-card p-5 shadow-card">
-        <div class="flex items-center justify-between gap-3">
+      <section>
+        <div class="flex items-center justify-between gap-3 mb-4">
           <.section_title>Built-in policy packs</.section_title>
-        </div>
-        <p class="mt-2 text-sm text-muted-foreground">
-          <span class="mr-1 inline-flex rounded-full bg-destructive/10 px-2.5 py-1 align-middle text-xs font-semibold text-destructive ring-1 ring-destructive/20">
-            {@block_count} rules
-          </span>
-          block agent actions when violated. Other rules only generate warnings.
-        </p>
 
-        <div class="mt-4 max-h-[48rem] divide-y divide-border overflow-y-auto pr-1">
+          <p class="mt-2 text-sm text-muted-foreground">
+            <span class="mr-1 inline-flex rounded-full bg-destructive/10 px-2.5 py-1 align-middle text-xs font-semibold text-destructive ring-1 ring-destructive/20">
+              {@block_count} rules
+            </span>
+            block agent actions when violated. Other rules only generate warnings.
+          </p>
+        </div>
+
+        <div class="rounded-2xl border bg-card p-5 shadow-card max-h-[48rem] divide-y divide-border overflow-y-auto pr-1">
           <%= for {name, rules} <- @packs do %>
             <% open? = MapSet.member?(@open_packs, name) %>
             <% panel_id = "pack-panel-#{name}"

--- a/lib/controlkeel_web/live/policy_studio_live.ex
+++ b/lib/controlkeel_web/live/policy_studio_live.ex
@@ -11,10 +11,21 @@ defmodule ControlKeelWeb.PolicyStudioLive do
      socket
      |> assign(:page_title, "Policy Studio")
      |> assign(:open_packs, MapSet.new())
+     |> assign(:show_packs_dialog, false)
      |> assign_packs()
      |> assign_policy_sets()
      |> assign(:show_create_modal, false)
      |> assign_policy_set_form(empty_policy_set_changeset(), "", nil)}
+  end
+
+  @impl true
+  def handle_event("open_packs_dialog", _params, socket) do
+    {:noreply, assign(socket, :show_packs_dialog, true)}
+  end
+
+  @impl true
+  def handle_event("close_packs_dialog", _params, socket) do
+    {:noreply, assign(socket, :show_packs_dialog, false)}
   end
 
   @impl true
@@ -91,131 +102,93 @@ defmodule ControlKeelWeb.PolicyStudioLive do
         class="mb-8"
       />
 
-      <section class="mb-6">
-        <div class="flex items-center justify-between mb-4">
-          <.section_title>Custom policy sets</.section_title>
-          <.button phx-click="open_create_modal">
-            <.icon name="hero-plus" class="size-3.5" /> New policy set
-          </.button>
-        </div>
+      <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_260px]">
+        <section>
+          <div class="flex items-center justify-between mb-4">
+            <.section_title>Custom policy sets</.section_title>
+            <.button phx-click="open_create_modal">
+              <.icon name="hero-plus" class="size-3.5" /> New policy set
+            </.button>
+          </div>
 
-        <%= if @policy_sets == [] do %>
-          <p class="mt-4 text-sm text-muted-foreground">
-            No custom policy sets yet. Use the New policy set button to create one.
-          </p>
-        <% else %>
-          <ul class="mt-4 divide-y divide-border bg-card p-5 rounded-2xl shadow-card">
-            <%= for set <- @policy_sets do %>
-              <li class="py-4 first:pt-0 last:pb-0">
-                <div class="flex items-center justify-between gap-4">
-                  <h3 class="text-base font-semibold text-foreground">{set.name}</h3>
-                  <span
-                    title={set.status}
-                    class={"inline-flex rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1 #{status_pill_class(set.status)}"}
-                  >
-                    {set.status}
-                  </span>
-                </div>
-                <p class="mt-1 text-sm text-muted-foreground">
-                  {length(Platform.PolicySet.rule_entries(set))} rules · scope: {set.scope}
-                  <%= if set.description not in [nil, ""] do %>
-                    · {set.description}
-                  <% end %>
-                </p>
-                <%= if set.workspace_policy_sets != [] do %>
-                  <p class="mt-1 text-xs text-muted-foreground">
-                    Applied to:
-                    <%= for assignment <- set.workspace_policy_sets do %>
-                      workspace #{assignment.workspace_id} (precedence {assignment.precedence}
-                      <%= unless assignment.enabled do %>
-                        , disabled
-                      <% end %>)<%= if assignment != List.last(set.workspace_policy_sets) do %>
-                        ,
-                      <% end %>
+          <%= if @policy_sets == [] do %>
+            <p class="mt-4 text-sm text-muted-foreground">
+              No custom policy sets yet. Use the New policy set button to create one.
+            </p>
+          <% else %>
+            <ul class="mt-4 divide-y divide-border bg-card p-5 rounded-2xl shadow-card">
+              <%= for set <- @policy_sets do %>
+                <li class="py-4 first:pt-0 last:pb-0">
+                  <div class="flex items-center justify-between gap-4">
+                    <h3 class="text-base font-semibold text-foreground">{set.name}</h3>
+                    <span
+                      title={set.status}
+                      class={"inline-flex rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1 #{status_pill_class(set.status)}"}
+                    >
+                      {set.status}
+                    </span>
+                  </div>
+                  <p class="mt-1 text-sm text-muted-foreground">
+                    {length(Platform.PolicySet.rule_entries(set))} rules · scope: {set.scope}
+                    <%= if set.description not in [nil, ""] do %>
+                      · {set.description}
                     <% end %>
                   </p>
-                <% else %>
-                  <p class="mt-1 text-xs text-muted-foreground">
-                    Not applied to any workspace yet.
-                  </p>
-                <% end %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
-      </section>
+                  <%= if set.workspace_policy_sets != [] do %>
+                    <p class="mt-1 text-xs text-muted-foreground">
+                      Applied to:
+                      <%= for assignment <- set.workspace_policy_sets do %>
+                        workspace #{assignment.workspace_id} (precedence {assignment.precedence}
+                        <%= unless assignment.enabled do %>
+                          , disabled
+                        <% end %>)<%= if assignment != List.last(set.workspace_policy_sets) do %>
+                          ,
+                        <% end %>
+                      <% end %>
+                    </p>
+                  <% else %>
+                    <p class="mt-1 text-xs text-muted-foreground">
+                      Not applied to any workspace yet.
+                    </p>
+                  <% end %>
+                  <% entries = Enum.filter(Platform.PolicySet.rule_entries(set), &is_binary(&1["id"])) %>
+                  <%= if entries != [] do %>
+                    <div class="mt-2 flex flex-wrap gap-2">
+                      <%= for rule <- entries do %>
+                        <span
+                          title={"#{rule["action"]}, #{rule["category"]}"}
+                          class={"inline-flex rounded-full px-2.5 py-1 text-xs font-medium ring-1 #{rule_tag_class(rule["action"])}"}
+                        >
+                          {rule_name(rule["id"])}
+                        </span>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+        </section>
 
-      <section>
-        <div class="flex items-center justify-between gap-3 mb-4">
-          <.section_title>Built-in policy packs</.section_title>
-
+        <aside class="self-start rounded-2xl border bg-card p-5 shadow-card">
+          <h3 class="text-base font-semibold text-foreground">Built-in policy packs</h3>
           <p class="mt-2 text-sm text-muted-foreground">
             <span class="mr-1 inline-flex rounded-full bg-destructive/10 px-2.5 py-1 align-middle text-xs font-semibold text-destructive ring-1 ring-destructive/20">
               {@block_count} rules
             </span>
-            block agent actions when violated. Other rules only generate warnings.
+            block agent actions when violated; other rules only warn.
           </p>
-        </div>
-
-        <div class="rounded-2xl border bg-card p-5 shadow-card max-h-[48rem] divide-y divide-border overflow-y-auto pr-1">
-          <%= for {name, rules} <- @packs do %>
-            <% open? = MapSet.member?(@open_packs, name) %>
-            <% panel_id = "pack-panel-#{name}"
-            label_id = "#{panel_id}-label" %>
-            <article class="py-2 first:pt-0 last:pb-0">
-              <h3 class="m-0">
-                <button
-                  type="button"
-                  phx-click="toggle_pack"
-                  phx-value-name={name}
-                  aria-expanded={open?}
-                  aria-controls={panel_id}
-                  class="flex w-full cursor-pointer select-none items-center justify-between gap-4 py-2 text-left"
-                >
-                  <span id={label_id} class="text-base font-semibold text-foreground">
-                    {pack_label(name)}
-                  </span>
-                  <span class="flex items-center gap-2">
-                    <span class="text-xs text-muted-foreground">
-                      {length(rules)} rules
-                    </span>
-                    <svg
-                      aria-hidden="true"
-                      class={"size-4 text-muted-foreground transition-transform duration-200 #{if open?, do: "rotate-180", else: ""}"}
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M19 9l-7 7-7-7"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </h3>
-              <%= if open? do %>
-                <div id={panel_id} role="region" aria-labelledby={label_id} class="pb-2 pl-1">
-                  <p class="text-sm text-muted-foreground">{pack_description(name)}</p>
-                  <div class="mt-3 flex flex-wrap gap-2">
-                    <%= for rule <- rules do %>
-                      <span
-                        title={rule.action <> ", " <> rule.category}
-                        class={"inline-flex rounded-full px-2.5 py-1 text-xs font-medium ring-1 #{rule_tag_class(rule.action)}"}
-                      >
-                        {rule_name(rule.id)}
-                      </span>
-                    <% end %>
-                  </div>
-                </div>
-              <% end %>
-            </article>
-          <% end %>
-        </div>
-      </section>
+          <p class="mt-2 text-xs text-muted-foreground">
+            {@pack_count} packs · {@rule_count} rules total, shipped with ControlKeel.
+          </p>
+          <.button variant="outline" phx-click="open_packs_dialog" class="mt-4 w-full">
+            View packs
+          </.button>
+        </aside>
+      </div>
     </section>
+
+    <.packs_dialog :if={@show_packs_dialog} packs={@packs} open_packs={@open_packs} />
 
     <.create_policy_set_modal
       :if={@show_create_modal}
@@ -339,6 +312,105 @@ defmodule ControlKeelWeb.PolicyStudioLive do
     """
   end
 
+  attr :packs, :list, required: true
+  attr :open_packs, :any, required: true
+
+  defp packs_dialog(assigns) do
+    ~H"""
+    <div
+      id="packs-dialog"
+      class="relative z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="packs-dialog-title"
+      phx-mounted={Phoenix.LiveView.JS.show(to: "#packs-dialog")}
+      phx-remove={Phoenix.LiveView.JS.hide(to: "#packs-dialog")}
+    >
+      <div
+        class="fixed inset-0 bg-overlay/70 backdrop-blur-sm transition-opacity"
+        phx-click="close_packs_dialog"
+        aria-label="Close dialog"
+      />
+
+      <div class="fixed inset-0 flex items-center justify-center p-4">
+        <div class="max-h-[85vh] w-full max-w-3xl overflow-hidden rounded-2xl border bg-card shadow-card">
+          <div class="flex items-center justify-between border-b p-5">
+            <h2 id="packs-dialog-title" class="text-lg font-semibold text-foreground">
+              Built-in policy packs
+            </h2>
+            <button
+              type="button"
+              phx-click="close_packs_dialog"
+              class="rounded-md text-muted-foreground transition hover:text-foreground"
+              aria-label="Close"
+            >
+              <.icon name="hero-x-mark" class="size-5" />
+            </button>
+          </div>
+
+          <div class="max-h-[70vh] divide-y divide-border overflow-y-auto p-5">
+            <%= for {name, rules} <- @packs do %>
+              <% open? = MapSet.member?(@open_packs, name) %>
+              <% panel_id = "pack-panel-#{name}"
+              label_id = "#{panel_id}-label" %>
+              <article class="py-2 first:pt-0 last:pb-0">
+                <h3 class="m-0">
+                  <button
+                    type="button"
+                    phx-click="toggle_pack"
+                    phx-value-name={name}
+                    aria-expanded={open?}
+                    aria-controls={panel_id}
+                    class="flex w-full cursor-pointer select-none items-center justify-between gap-4 py-2 text-left"
+                  >
+                    <span id={label_id} class="text-base font-semibold text-foreground">
+                      {pack_label(name)}
+                    </span>
+                    <span class="flex items-center gap-2">
+                      <span class="text-xs text-muted-foreground">
+                        {length(rules)} rules
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        class={"size-4 text-muted-foreground transition-transform duration-200 #{if open?, do: "rotate-180", else: ""}"}
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M19 9l-7 7-7-7"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </h3>
+                <%= if open? do %>
+                  <div id={panel_id} role="region" aria-labelledby={label_id} class="pb-2 pl-1">
+                    <p class="text-sm text-muted-foreground">{pack_description(name)}</p>
+                    <div class="mt-3 flex flex-wrap gap-2">
+                      <%= for rule <- rules do %>
+                        <span
+                          title={rule.action <> ", " <> rule.category}
+                          class={"inline-flex rounded-full px-2.5 py-1 text-xs font-medium ring-1 #{rule_tag_class(rule.action)}"}
+                        >
+                          {rule_name(rule.id)}
+                        </span>
+                      <% end %>
+                    </div>
+                  </div>
+                <% end %>
+              </article>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
   defp assign_packs(socket) do
     packs = PackLoader.all_packs()
     all_rules = packs |> Map.values() |> List.flatten()
@@ -352,6 +424,8 @@ defmodule ControlKeelWeb.PolicyStudioLive do
     socket
     |> assign(:packs, Enum.sort_by(packs, fn {name, _} -> pack_sort_order(name) end))
     |> assign(:pack_names, MapSet.new(Map.keys(packs)))
+    |> assign(:pack_count, map_size(packs))
+    |> assign(:rule_count, length(all_rules))
     |> assign(:block_count, Enum.count(all_rules, &(&1.action == "block")))
     |> assign(:blocked_rules, blocked_rules)
   end

--- a/lib/controlkeel_web/live/workspace_detail_live.ex
+++ b/lib/controlkeel_web/live/workspace_detail_live.ex
@@ -18,6 +18,7 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
   alias ControlKeel.Mission.Workspace
   alias ControlKeel.Platform
   alias ControlKeel.Repo
+  alias ControlKeel.Runtime.Mode
 
   @impl true
   def mount(%{"id" => id, "slug" => slug} = _params, _session, socket) do
@@ -213,7 +214,7 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
 
                 <.link
                   navigate={
-                    ~p"/organizations/#{@workspace.org.slug}/workspaces/#{@workspace.id}/settings?tab=tool_policy"
+                    ~p"/organizations/#{@workspace.org.slug}/workspaces/#{@workspace.id}/settings?tab=agent_tools"
                   }
                   class="text-xs font-medium text-primary transition hover:text-primary/80"
                 >
@@ -337,21 +338,28 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
     """
   end
 
-  # TODO(auth): the workspace lookup + org-relation checks below are duplicated
+  # TODO(auth): the workspace lookup + access checks below are duplicated
   # across workspace LiveViews. Extract into a shared on_mount hook when
   # centralized auth lands (CLI/web parity PR).
-  defp check_workspace_access(%Workspace{org_id: ws_org_id}, assigns) do
-    case assigns[:current_org_id] do
-      nil ->
-        :ok
-
-      org_id when is_integer(org_id) and org_id == ws_org_id ->
-        :ok
-
-      _ ->
-        {:error, "Workspace belongs to a different organization."}
+  # View access: local mode is open; cloud mode requires membership of the
+  # workspace's org (no role requirement — role gates live on write surfaces).
+  defp check_workspace_access(workspace, assigns) do
+    if Mode.current() == :local do
+      :ok
+    else
+      check_cloud_workspace_access(workspace, assigns)
     end
   end
+
+  defp check_cloud_workspace_access(%Workspace{org_id: nil}, _),
+    do: {:error, "Workspace is not bound to an org."}
+
+  defp check_cloud_workspace_access(%Workspace{org_id: ws_org}, %{current_org_id: org_id})
+       when is_integer(ws_org) and ws_org == org_id,
+       do: :ok
+
+  defp check_cloud_workspace_access(_, _),
+    do: {:error, "Workspace belongs to a different organization."}
 
   defp redirect_with_flash(socket, kind, msg, path) do
     socket

--- a/lib/controlkeel_web/live/workspace_detail_live.ex
+++ b/lib/controlkeel_web/live/workspace_detail_live.ex
@@ -65,13 +65,6 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
 
   defp check_org_slug(_, _), do: {:error, "Workspace does not belong to this organization."}
 
-  defp rule_tag_class("block"), do: "bg-destructive/10 text-destructive ring-destructive/20"
-  defp rule_tag_class("warn"), do: "bg-warning/10 text-warning ring-warning/20"
-
-  defp rule_tag_class("escalate_to_human"), do: "bg-info/10 text-info ring-info/20"
-
-  defp rule_tag_class(_), do: "bg-muted text-muted-foreground ring-border"
-
   @impl true
   def render(assigns) do
     ~H"""
@@ -183,12 +176,13 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
                       <div class="mt-2 space-y-1.5">
                         <%= for rule <- entries do %>
                           <div class="flex flex-wrap items-center gap-2">
-                            <span
+                            <.rule_tag
+                              action={rule["action"]}
                               title={rule["action"]}
-                              class={"inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase ring-1 #{rule_tag_class(rule["action"])}"}
+                              class="px-2 py-0.5 text-[10px] font-semibold uppercase"
                             >
                               {rule["action"]}
-                            </span>
+                            </.rule_tag>
                             <span class="font-mono text-xs text-foreground">{rule["id"]}</span>
                             <span class="text-xs text-muted-foreground">{rule["plain_message"]}</span>
                           </div>

--- a/lib/controlkeel_web/live/workspace_detail_live.ex
+++ b/lib/controlkeel_web/live/workspace_detail_live.ex
@@ -41,7 +41,7 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
          ]
        )
        |> assign(:sessions, sessions)
-       |> assign(:policy_assignments, Platform.list_workspace_policy_sets(ws_id))
+       |> assign(:policy_assignments, Platform.list_workspace_policy_assignments(ws_id))
        |> assign(:tool_policy_mode, tool_policy.mode)
        |> assign(:tool_policy_tools, WorkspaceToolPolicy.decode_tools(tool_policy))}
     else

--- a/lib/controlkeel_web/live/workspace_detail_live.ex
+++ b/lib/controlkeel_web/live/workspace_detail_live.ex
@@ -343,6 +343,9 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
     """
   end
 
+  # TODO(auth): the workspace lookup + org-relation checks below are duplicated
+  # across workspace LiveViews. Extract into a shared on_mount hook when
+  # centralized auth lands (CLI/web parity PR).
   defp check_workspace_access(%Workspace{org_id: ws_org_id}, assigns) do
     case assigns[:current_org_id] do
       nil ->

--- a/lib/controlkeel_web/live/workspace_detail_live.ex
+++ b/lib/controlkeel_web/live/workspace_detail_live.ex
@@ -32,6 +32,14 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
        socket
        |> assign(:page_title, workspace.name)
        |> assign(:workspace, workspace)
+       |> assign(
+         :breadcrumbs,
+         [
+           %{label: "Organizations", to: ~p"/organizations"},
+           %{label: workspace.org.name, to: ~p"/organizations/#{workspace.org.slug}"},
+           %{label: workspace.name, to: nil}
+         ]
+       )
        |> assign(:sessions, sessions)
        |> assign(:policy_assignments, Platform.list_workspace_policy_sets(ws_id))
        |> assign(:tool_policy_mode, tool_policy.mode)
@@ -158,9 +166,6 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
                     <div class="flex flex-wrap items-center justify-between gap-2">
                       <p class="text-sm font-semibold text-foreground">
                         {a.policy_set.name}
-                        <span class="ml-1 font-mono text-xs font-normal text-muted-foreground">
-                          #{a.policy_set.id}
-                        </span>
                       </p>
                       <span class="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground ring-1 ring-border">
                         precedence {a.precedence}
@@ -200,11 +205,11 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
 
           <section class="rounded-2xl border bg-card p-5 shadow-card">
             <div class="flex items-center justify-between gap-3">
-              <p class="text-sm font-semibold text-muted-foreground">Tool policy</p>
+              <p class="text-sm font-semibold text-muted-foreground">Agent tools</p>
               <div class="flex items-center gap-3">
                 <span class={[
                   "inline-flex rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1",
-                  @tool_policy_mode == "allowlist" && "bg-primary/10 text-primary ring-primary/20",
+                  @tool_policy_mode == "allowlist" && "bg-info/10 text-info ring-info/20",
                   @tool_policy_mode == "denylist" &&
                     "bg-destructive/10 text-destructive ring-destructive/20",
                   @tool_policy_mode == "inherit" && "bg-muted text-muted-foreground ring-border"
@@ -213,7 +218,9 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
                 </span>
 
                 <.link
-                  navigate={~p"/organizations/#{@workspace.org.slug}/workspaces/#{@workspace.id}/settings?tab=tool_policy"}
+                  navigate={
+                    ~p"/organizations/#{@workspace.org.slug}/workspaces/#{@workspace.id}/settings?tab=tool_policy"
+                  }
                   class="text-xs font-medium text-primary transition hover:text-primary/80"
                 >
                   Manage tools

--- a/lib/controlkeel_web/live/workspace_detail_live.ex
+++ b/lib/controlkeel_web/live/workspace_detail_live.ex
@@ -12,23 +12,30 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
 
   alias ControlKeel.Accounts
   alias ControlKeel.Accounts.Org
+  alias ControlKeel.Accounts.WorkspaceToolPolicy
+  alias ControlKeel.MCP.ToolGroups
   alias ControlKeel.Mission
   alias ControlKeel.Mission.Workspace
+  alias ControlKeel.Platform
   alias ControlKeel.Repo
 
   @impl true
   def mount(%{"id" => id, "slug" => slug} = _params, _session, socket) do
     with {ws_id, ""} <- Integer.parse(id),
-         %Workspace{} = workspace <- Repo.get(Workspace, ws_id),
+         %Workspace{} = workspace <- Repo.get(Workspace, ws_id) |> Repo.preload(:org),
          :ok <- check_org_slug(workspace, %{slug: slug}),
          :ok <- check_workspace_access(workspace, socket.assigns) do
       sessions = Mission.list_all_sessions(ws_id)
+      tool_policy = Accounts.get_workspace_tool_policy(ws_id)
 
       {:ok,
        socket
        |> assign(:page_title, workspace.name)
        |> assign(:workspace, workspace)
-       |> assign(:sessions, sessions)}
+       |> assign(:sessions, sessions)
+       |> assign(:policy_assignments, Platform.list_workspace_policy_sets(ws_id))
+       |> assign(:tool_policy_mode, tool_policy.mode)
+       |> assign(:tool_policy_tools, WorkspaceToolPolicy.decode_tools(tool_policy))}
     else
       :error ->
         {:ok, redirect_with_flash(socket, :error, "Invalid workspace id.", ~p"/organizations")}
@@ -50,11 +57,18 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
 
   defp check_org_slug(_, _), do: {:error, "Workspace does not belong to this organization."}
 
+  defp rule_tag_class("block"), do: "bg-destructive/10 text-destructive ring-destructive/20"
+  defp rule_tag_class("warn"), do: "bg-warning/10 text-warning ring-warning/20"
+
+  defp rule_tag_class("escalate_to_human"), do: "bg-info/10 text-info ring-info/20"
+
+  defp rule_tag_class(_), do: "bg-muted text-muted-foreground ring-border"
+
   @impl true
   def render(assigns) do
     ~H"""
-    <section class="w-full space-y-12">
-      <div class="flex flex-col justify-between gap-4 lg:flex-row lg:items-end">
+    <section class="w-full space-y-10">
+      <div class="flex flex-col md:flex-row justify-between gap-6">
         <div class="space-y-2">
           <div class="flex flex-wrap items-center gap-3">
             <h1 class="text-xl font-semibold tracking-tight sm:text-2xl text-foreground">
@@ -70,53 +84,37 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
             </span>
           </div>
 
-          <p class="text-sm text-muted-foreground">
-            Sessions launched under this workspace are indexed here.
+          <p class="flex flex-wrap items-center gap-x-2 gap-y-1 pt-1 text-xs text-muted-foreground">
+            <span class="font-mono">{@workspace.slug}</span>
+
+            <button
+              type="button"
+              aria-label="Copy workspace slug"
+              title="Copy slug"
+              phx-click={JS.dispatch("phx:copy-to-clipboard", detail: %{text: @workspace.slug})}
+              class="inline-flex items-center rounded p-0.5 text-muted-foreground transition hover:text-primary"
+            >
+              <.icon name="hero-clipboard" class="size-3.5" />
+            </button>
+
+            <span aria-hidden="true">·</span>
+            <span>
+              <%= if @workspace.budget_cents > 0 do %>
+                {"$#{Float.round(@workspace.budget_cents / 100, 2)}/mo budget"}
+              <% else %>
+                No monthly budget
+              <% end %>
+            </span>
           </p>
         </div>
 
-        <div class="flex flex-wrap gap-x-8 gap-y-3">
-          <div class="flex flex-col gap-1">
-            <span class="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-              Slug
-            </span>
-            <span class="font-mono text-sm text-foreground">{@workspace.slug}</span>
-          </div>
-
-          <div class="flex flex-col gap-1">
-            <span class="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-              Sessions
-            </span>
-            <span class="text-sm font-semibold text-foreground">{length(@sessions)}</span>
-          </div>
-
-          <div class="flex flex-col gap-1">
-            <span class="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-              Monthly budget
-            </span>
-            <span class="text-sm font-semibold text-foreground">
-              <%= if @workspace.budget_cents > 0 do %>
-                {"$#{Float.round(@workspace.budget_cents / 100, 2)}"}
-              <% else %>
-                <span class="text-muted-foreground">—</span>
-              <% end %>
-            </span>
-          </div>
-
-          <div class="flex flex-col gap-1">
-            <span class="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-              Created
-            </span>
-            <span class="text-sm text-foreground">
-              {Calendar.strftime(@workspace.inserted_at, "%b %d, %Y")}
-            </span>
-          </div>
-        </div>
-      </div>
-
-      <div>
-        <div class="flex items-center justify-between gap-3 mb-4">
-          <.section_title>Sessions</.section_title>
+        <div>
+          <.link
+            navigate={~p"/organizations/#{@workspace.org.slug}/workspaces/#{@workspace.id}/settings"}
+            class="inline-flex shrink-0 items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium text-muted-foreground transition hover:border-primary/40 hover:text-primary"
+          >
+            <.icon name="hero-cog-6-tooth" class="size-4" /> Settings
+          </.link>
 
           <.link
             navigate={~p"/sessions/start"}
@@ -125,8 +123,144 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
             <.icon name="hero-plus" class="size-4" /> New Session
           </.link>
         </div>
+      </div>
 
-        <div class="bg-card border rounded-2xl shadow-card overflow-clip">
+      <div class="space-y-4">
+        <div class="space-y-1">
+          <.section_title>Governance</.section_title>
+          <p class="text-sm text-muted-foreground">
+            Controls currently applied to this workspace
+          </p>
+        </div>
+
+        <div class="grid gap-6 lg:grid-cols-2">
+          <section class="rounded-2xl border bg-card p-5 shadow-card">
+            <div class="flex items-center justify-between gap-3">
+              <p class="text-sm font-semibold text-muted-foreground">Applied policies</p>
+              <span class="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+                {length(@policy_assignments)} applied
+              </span>
+            </div>
+
+            <%= if @policy_assignments == [] do %>
+              <p class="mt-4 text-sm text-muted-foreground">
+                No policy sets applied to this workspace. Go to settings to apply policy sets to
+                this workspace.
+              </p>
+            <% else %>
+              <ul class="mt-4 max-h-96 divide-y divide-border overflow-y-auto">
+                <%= for a <- @policy_assignments do %>
+                  <% entries =
+                    a.policy_set
+                    |> Platform.PolicySet.rule_entries()
+                    |> Enum.filter(&is_binary(&1["id"])) %>
+                  <li class="py-3 first:pt-0 last:pb-0">
+                    <div class="flex flex-wrap items-center justify-between gap-2">
+                      <p class="text-sm font-semibold text-foreground">
+                        {a.policy_set.name}
+                        <span class="ml-1 font-mono text-xs font-normal text-muted-foreground">
+                          #{a.policy_set.id}
+                        </span>
+                      </p>
+                      <span class="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground ring-1 ring-border">
+                        precedence {a.precedence}
+                        <%= unless a.enabled do %>
+                          , disabled
+                        <% end %>
+                      </span>
+                    </div>
+
+                    <%= if a.policy_set.description not in [nil, ""] do %>
+                      <p class="mt-0.5 text-xs text-muted-foreground">{a.policy_set.description}</p>
+                    <% end %>
+
+                    <%= if entries != [] do %>
+                      <div class="mt-2 space-y-1.5">
+                        <%= for rule <- entries do %>
+                          <div class="flex flex-wrap items-center gap-2">
+                            <span
+                              title={rule["action"]}
+                              class={"inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase ring-1 #{rule_tag_class(rule["action"])}"}
+                            >
+                              {rule["action"]}
+                            </span>
+                            <span class="font-mono text-xs text-foreground">{rule["id"]}</span>
+                            <span class="text-xs text-muted-foreground">{rule["plain_message"]}</span>
+                          </div>
+                        <% end %>
+                      </div>
+                    <% else %>
+                      <p class="mt-1 text-xs text-muted-foreground">No rules in this set.</p>
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
+          </section>
+
+          <section class="rounded-2xl border bg-card p-5 shadow-card">
+            <div class="flex items-center justify-between gap-3">
+              <p class="text-sm font-semibold text-muted-foreground">Tool policy</p>
+              <div class="flex items-center gap-3">
+                <span class={[
+                  "inline-flex rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1",
+                  @tool_policy_mode == "allowlist" && "bg-primary/10 text-primary ring-primary/20",
+                  @tool_policy_mode == "denylist" &&
+                    "bg-destructive/10 text-destructive ring-destructive/20",
+                  @tool_policy_mode == "inherit" && "bg-muted text-muted-foreground ring-border"
+                ]}>
+                  {@tool_policy_mode}
+                </span>
+
+                <.link
+                  navigate={~p"/organizations/#{@workspace.org.slug}/workspaces/#{@workspace.id}/settings?tab=tool_policy"}
+                  class="text-xs font-medium text-primary transition hover:text-primary/80"
+                >
+                  Manage tools
+                </.link>
+              </div>
+            </div>
+
+            <%= cond do %>
+              <% @tool_policy_mode == "inherit" -> %>
+                <p class="mt-4 text-sm text-muted-foreground">
+                  Falls back to the global allowlist — no workspace override is set.
+                </p>
+              <% @tool_policy_tools == [] -> %>
+                <p class="mt-4 text-sm font-medium text-warning">
+                  No tools listed — every call is rejected.
+                </p>
+              <% true -> %>
+                <p class="mt-4 text-xs text-muted-foreground">
+                  {length(@tool_policy_tools)} tools governed by this workspace's gate.
+                </p>
+
+                <ul class="mt-2 max-h-96 divide-y divide-border overflow-y-auto">
+                  <%= for tool <- @tool_policy_tools do %>
+                    <li class="flex items-center justify-between gap-3 py-2 first:pt-0 last:pb-0">
+                      <span class="font-mono text-xs text-foreground">{tool}</span>
+                      <%= if tool not in ToolGroups.all_tools() do %>
+                        <span class="rounded-full bg-warning/10 px-2 py-0.5 text-[10px] font-medium text-warning ring-1 ring-warning/20">
+                          not in catalog
+                        </span>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+            <% end %>
+          </section>
+        </div>
+      </div>
+
+      <div>
+        <div class="flex items-center gap-2 mb-4">
+          <.section_title>Sessions</.section_title>
+          <span class="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+            {length(@sessions)} total
+          </span>
+        </div>
+
+        <div class="bg-card border rounded-2xl shadow-card max-h-[32rem] overflow-y-auto">
           <table class="min-w-full divide-y divide-border text-left text-sm">
             <thead class="bg-muted text-xs uppercase tracking-[0.14em] text-muted-foreground sticky top-0 z-10">
               <tr>
@@ -135,13 +269,12 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
                 <th class="px-5 py-3 font-semibold">Workload</th>
                 <th class="px-5 py-3 font-semibold">Findings</th>
                 <th class="px-5 py-3 font-semibold">Budget</th>
-                <th class="px-5 py-3 font-semibold w-px whitespace-nowrap"></th>
               </tr>
             </thead>
             <tbody class="divide-y divide-border">
               <%= if @sessions == [] do %>
                 <tr>
-                  <td colspan="6" class="px-5 py-12 text-center">
+                  <td colspan="5" class="px-5 py-12 text-center">
                     <p class="text-base font-medium text-foreground">No sessions yet.</p>
                     <p class="mt-1 text-sm text-muted-foreground">
                       Sessions launched under this workspace will appear here.
@@ -152,7 +285,12 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
                 <%= for session <- @sessions do %>
                   <tr class="transition hover:bg-muted/30">
                     <td class="max-w-sm px-5 py-4">
-                      <p class="font-medium text-foreground">{session.title}</p>
+                      <.link
+                        navigate={~p"/sessions/#{session.id}"}
+                        class="font-medium text-foreground hover:underline"
+                      >
+                        {session.title}
+                      </.link>
                       <p class="mt-1 line-clamp-1 text-xs text-muted-foreground">
                         {session.objective}
                       </p>
@@ -186,14 +324,6 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
                     </td>
                     <td class="px-5 py-4 text-muted-foreground">
                       ${session.budget_cents |> Kernel./(100) |> trunc()}
-                    </td>
-                    <td class="px-4 text-right whitespace-nowrap w-px">
-                      <.link
-                        navigate={~p"/sessions/#{session.id}"}
-                        class="inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-xs font-semibold text-muted-foreground transition hover:border-primary/40 hover:bg-primary/10 hover:text-foreground"
-                      >
-                        Inspect <.icon name="hero-arrow-right" class="size-3" />
-                      </.link>
                     </td>
                   </tr>
                 <% end %>

--- a/lib/controlkeel_web/live/workspace_settings_live.ex
+++ b/lib/controlkeel_web/live/workspace_settings_live.ex
@@ -139,6 +139,41 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
   end
 
   @impl true
+  def handle_event("toggle_assignment", %{"policy-set-id" => id}, socket) do
+    with {:ok, set_id} <- parse_int(id),
+         %{} = assignment <- find_assignment(socket.assigns.policy_assignments, set_id) do
+      # Re-apply flips the enabled flag via the upsert while keeping precedence.
+      case Platform.apply_policy_set(socket.assigns.workspace.id, set_id, %{
+             "precedence" => assignment.precedence,
+             "enabled" => not assignment.enabled
+           }) do
+        {:ok, assignment} ->
+          {:noreply,
+           socket
+           |> put_flash(
+             :info,
+             "Policy set #{if assignment.enabled, do: "enabled", else: "disabled"}."
+           )
+           |> refresh_policy_assigns()}
+
+        {:error, %Ecto.Changeset{} = changeset} ->
+          msg = Enum.map_join(changeset.errors, ", ", fn {f, {m, _}} -> "#{f}: #{m}" end)
+          {:noreply, put_flash(socket, :error, msg)}
+      end
+    else
+      :error ->
+        {:noreply, put_flash(socket, :error, "Invalid policy set id.")}
+
+      {:error, :not_found} ->
+        {:noreply, put_flash(socket, :error, "Policy set assignment not found.")}
+    end
+  end
+
+  defp find_assignment(assignments, set_id) do
+    Enum.find(assignments, &(&1.policy_set_id == set_id)) || {:error, :not_found}
+  end
+
+  @impl true
   def handle_event("mode_changed", %{"policy" => %{"mode" => mode}}, socket) do
     {:noreply, assign(socket, :live_mode, mode)}
   end
@@ -271,14 +306,28 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
                   <% end %>
                 </p>
               </div>
-              <button
-                type="button"
-                phx-click="remove_policy_set"
-                phx-value-policy-set-id={a.policy_set_id}
-                class="inline-flex items-center rounded-lg px-3 py-1.5 text-xs font-medium text-destructive transition hover:bg-destructive/10"
-              >
-                Remove
-              </button>
+              <div class="flex shrink-0 items-center gap-2">
+                <button
+                  type="button"
+                  phx-click="toggle_assignment"
+                  phx-value-policy-set-id={a.policy_set_id}
+                  class="inline-flex items-center rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+                >
+                  <%= if a.enabled do %>
+                    Disable
+                  <% else %>
+                    Enable
+                  <% end %>
+                </button>
+                <button
+                  type="button"
+                  phx-click="remove_policy_set"
+                  phx-value-policy-set-id={a.policy_set_id}
+                  class="inline-flex items-center rounded-lg px-3 py-1.5 text-xs font-medium text-destructive transition hover:bg-destructive/10"
+                >
+                  Remove
+                </button>
+              </div>
             </li>
           <% end %>
         </ul>
@@ -446,7 +495,10 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
   end
 
   defp refresh_policy_assigns(socket) do
-    assignments = Platform.list_workspace_policy_sets(socket.assigns.workspace.id)
+    # Display list includes disabled assignments; the dropdown excludes any
+    # set with an assignment row so re-applying never silently flips a
+    # disabled assignment back to enabled via the upsert.
+    assignments = Platform.list_workspace_policy_assignments(socket.assigns.workspace.id)
     assigned_ids = Enum.map(assignments, & &1.policy_set_id)
 
     available_sets =

--- a/lib/controlkeel_web/live/workspace_settings_live.ex
+++ b/lib/controlkeel_web/live/workspace_settings_live.ex
@@ -53,10 +53,6 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
        |> assign(:tool_options, ToolGroups.all_tools())
        |> assign(:live_mode, tool_policy.mode)
        |> assign(
-         :form,
-         to_form(%{"mode" => tool_policy.mode, "tools" => Enum.join(tools, "\n")}, as: :policy)
-       )
-       |> assign(
          :apply_form,
          to_form(%{"policy_set_id" => "", "precedence" => "100"}, as: :assignment)
        )
@@ -168,10 +164,6 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
     end
   end
 
-  defp find_assignment(assignments, set_id) do
-    Enum.find(assignments, &(&1.policy_set_id == set_id)) || {:error, :not_found}
-  end
-
   @impl true
   def handle_event("mode_changed", %{"policy" => %{"mode" => mode}}, socket) do
     {:noreply, assign(socket, :live_mode, mode)}
@@ -200,7 +192,6 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
 
         {:noreply,
          socket
-         |> assign(:policy, policy)
          |> assign(:selected_tools, saved_tools)
          |> assign(:unknown_tools, saved_tools -- ToolGroups.all_tools())
          |> assign(:live_mode, policy.mode)
@@ -256,7 +247,6 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
           <% "tool_policy" -> %>
             <.tool_policy_panel
               workspace={@workspace}
-              form={@form}
               modes={@modes}
               tool_options={@tool_options}
               selected_tools={@selected_tools}
@@ -390,7 +380,6 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
   end
 
   attr :workspace, :map, required: true
-  attr :form, :map, required: true
   attr :modes, :list, required: true
   attr :tool_options, :list, required: true
   attr :selected_tools, :list, required: true
@@ -408,7 +397,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
         override it.
       </p>
 
-      <.form for={@form} phx-submit="submit" id="workspace-tool-policy-form" class="mt-4 space-y-4">
+      <form id="workspace-tool-policy-form" phx-submit="submit" class="mt-4 space-y-4">
         <div>
           <label
             for="tool-policy-mode"
@@ -428,67 +417,67 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
           </select>
         </div>
 
-        <div>
-          <%= if @selected_tools == [] do %>
-            <p class="text-xs text-muted-foreground">No tools selected.</p>
-          <% else %>
-            <ul class="flex list-none flex-wrap gap-1.5 m-0 p-0">
-              <%= for tool <- @selected_tools do %>
-                <li class={[
-                  "inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-medium ring-1",
-                  tool in @tool_options &&
-                    "bg-primary/10 text-primary ring-primary/20",
-                  tool not in @tool_options && "bg-warning/10 text-warning ring-warning/20",
-                  @live_mode == "inherit" && "opacity-50"
-                ]}>
-                  {tool}
-                  <button
-                    type="button"
-                    phx-click="remove_tool"
-                    phx-value-tool={tool}
-                    disabled={@live_mode == "inherit" || nil}
-                    aria-label={"Remove #{tool}"}
-                    class={[
-                      "transition",
-                      @live_mode == "inherit" &&
-                        "cursor-not-allowed opacity-60 hover:text-current",
-                      @live_mode != "inherit" && "cursor-pointer hover:text-destructive"
-                    ]}
-                  >
-                    <.icon name="hero-x-mark" class="size-3.5" />
-                  </button>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
-
-          <select
-            id="tool-policy-picker"
-            name="tool_picker"
-            phx-change="pick_tool"
-            disabled={@live_mode == "inherit" || nil}
-            class={[
-              "mt-2 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 md:text-sm",
-              @live_mode == "inherit" && "cursor-not-allowed opacity-50"
-            ]}
-          >
-            <option value="">Add a tool…</option>
-            <%= for tool <- @tool_options do %>
-              <%= unless tool in @selected_tools do %>
-                <option value={tool}>{tool}</option>
-              <% end %>
-            <% end %>
-          </select>
-
-          <p class="mt-1.5 text-xs text-muted-foreground">
-            Used by <code>allowlist</code>
-            and <code>denylist</code>
-            modes. Ignored under <code>inherit</code>.
-          </p>
-        </div>
-
         <.button type="submit">Save policy</.button>
-      </.form>
+      </form>
+
+      <div>
+        <%= if @selected_tools == [] do %>
+          <p class="text-xs text-muted-foreground">No tools selected.</p>
+        <% else %>
+          <ul class="flex list-none flex-wrap gap-1.5 m-0 p-0">
+            <%= for tool <- @selected_tools do %>
+              <li class={[
+                "inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-medium ring-1",
+                tool in @tool_options &&
+                  "bg-primary/10 text-primary ring-primary/20",
+                tool not in @tool_options && "bg-warning/10 text-warning ring-warning/20",
+                @live_mode == "inherit" && "opacity-50"
+              ]}>
+                {tool}
+                <button
+                  type="button"
+                  phx-click="remove_tool"
+                  phx-value-tool={tool}
+                  disabled={@live_mode == "inherit" || nil}
+                  aria-label={"Remove #{tool}"}
+                  class={[
+                    "transition",
+                    @live_mode == "inherit" &&
+                      "cursor-not-allowed opacity-60 hover:text-current",
+                    @live_mode != "inherit" && "cursor-pointer hover:text-destructive"
+                  ]}
+                >
+                  <.icon name="hero-x-mark" class="size-3.5" />
+                </button>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+
+        <select
+          id="tool-policy-picker"
+          name="tool_picker"
+          phx-change="pick_tool"
+          disabled={@live_mode == "inherit" || nil}
+          class={[
+            "mt-2 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 md:text-sm",
+            @live_mode == "inherit" && "cursor-not-allowed opacity-50"
+          ]}
+        >
+          <option value="">Add a tool…</option>
+          <%= for tool <- @tool_options do %>
+            <%= unless tool in @selected_tools do %>
+              <option value={tool}>{tool}</option>
+            <% end %>
+          <% end %>
+        </select>
+
+        <p class="mt-1.5 text-xs text-muted-foreground">
+          Used by <code>allowlist</code>
+          and <code>denylist</code>
+          modes. Ignored under <code>inherit</code>.
+        </p>
+      </div>
     </section>
     """
   end
@@ -511,6 +500,10 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
 
   defp tab_label("policies"), do: "Policies"
   defp tab_label("tool_policy"), do: "Agent tools"
+
+  defp find_assignment(assignments, set_id) do
+    Enum.find(assignments, &(&1.policy_set_id == set_id)) || {:error, :not_found}
+  end
 
   defp parse_int(value) when is_binary(value) do
     case Integer.parse(value) do

--- a/lib/controlkeel_web/live/workspace_settings_live.ex
+++ b/lib/controlkeel_web/live/workspace_settings_live.ex
@@ -34,6 +34,18 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
        socket
        |> assign(:page_title, "Settings — #{workspace.name}")
        |> assign(:workspace, workspace)
+       |> assign(
+         :breadcrumbs,
+         [
+           %{label: "Organizations", to: ~p"/organizations"},
+           %{label: workspace.org.name, to: ~p"/organizations/#{workspace.org.slug}"},
+           %{
+             label: workspace.name,
+             to: ~p"/organizations/#{workspace.org.slug}/workspaces/#{workspace.id}"
+           },
+           %{label: "Settings", to: nil}
+         ]
+       )
        |> assign(:active_tab, "policies")
        |> assign(:tabs, @tabs)
        |> assign(:modes, WorkspaceToolPolicy.modes())
@@ -157,7 +169,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
          |> assign(:selected_tools, saved_tools)
          |> assign(:unknown_tools, saved_tools -- ToolGroups.all_tools())
          |> assign(:live_mode, policy.mode)
-         |> put_flash(:info, "Tool policy saved (#{policy.mode}).")}
+         |> put_flash(:info, "Agent tools policy saved (#{policy.mode}).")}
 
       {:error, %Ecto.Changeset{} = cs} ->
         msg = Enum.map_join(cs.errors, ", ", fn {f, {m, _}} -> "#{f}: #{m}" end)
@@ -172,12 +184,6 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
     <section class="w-full space-y-8">
       <div class="flex flex-col justify-between gap-4 lg:flex-row lg:items-end">
         <div class="space-y-2">
-          <p class="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-            <.link navigate={~p"/organizations/#{@workspace.org.slug}/workspaces/#{@workspace.id}"}>
-              {@workspace.name}
-            </.link>
-            · Settings
-          </p>
           <h1 class="text-xl font-semibold tracking-tight sm:text-2xl text-foreground">
             Workspace settings
           </h1>
@@ -255,7 +261,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
             <li class="flex items-center justify-between gap-3 py-3 first:pt-0 last:pb-0">
               <div>
                 <p class="text-sm font-semibold text-foreground">
-                  #{a.policy_set.id} {a.policy_set.name}
+                  {a.policy_set.name}
                 </p>
                 <p class="mt-0.5 text-xs text-muted-foreground">
                   precedence {a.precedence}
@@ -345,7 +351,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
   defp tool_policy_panel(assigns) do
     ~H"""
     <section class="rounded-2xl border bg-card p-5 shadow-card">
-      <.section_title>Tool policy</.section_title>
+      <.section_title>Agent tools</.section_title>
       <p class="mt-1 text-xs text-muted-foreground">
         Restrict which MCP tools agents in this workspace may invoke. <code>inherit</code>
         falls back to the global allowlist; <code>allowlist</code>
@@ -383,15 +389,22 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
                   "inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-medium ring-1",
                   tool in @tool_options &&
                     "bg-primary/10 text-primary ring-primary/20",
-                  tool not in @tool_options && "bg-warning/10 text-warning ring-warning/20"
+                  tool not in @tool_options && "bg-warning/10 text-warning ring-warning/20",
+                  @live_mode == "inherit" && "opacity-50"
                 ]}>
                   {tool}
                   <button
                     type="button"
                     phx-click="remove_tool"
                     phx-value-tool={tool}
+                    disabled={@live_mode == "inherit" || nil}
                     aria-label={"Remove #{tool}"}
-                    class="cursor-pointer transition hover:text-destructive"
+                    class={[
+                      "transition",
+                      @live_mode == "inherit" &&
+                        "cursor-not-allowed opacity-60 hover:text-current",
+                      @live_mode != "inherit" && "cursor-pointer hover:text-destructive"
+                    ]}
                   >
                     <.icon name="hero-x-mark" class="size-3.5" />
                   </button>
@@ -445,7 +458,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
   end
 
   defp tab_label("policies"), do: "Policies"
-  defp tab_label("tool_policy"), do: "Tool policy"
+  defp tab_label("tool_policy"), do: "Agent tools"
 
   defp parse_int(value) when is_binary(value) do
     case Integer.parse(value) do

--- a/lib/controlkeel_web/live/workspace_settings_live.ex
+++ b/lib/controlkeel_web/live/workspace_settings_live.ex
@@ -107,8 +107,9 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
            |> put_flash(:info, "Policy set applied.")
            |> refresh_policy_assigns()}
 
-        {:error, _changeset} ->
-          {:noreply, put_flash(socket, :error, "Failed to apply policy set.")}
+        {:error, %Ecto.Changeset{} = changeset} ->
+          msg = Enum.map_join(changeset.errors, ", ", fn {f, {m, _}} -> "#{f}: #{m}" end)
+          {:noreply, put_flash(socket, :error, msg)}
       end
     else
       :error ->

--- a/lib/controlkeel_web/live/workspace_settings_live.ex
+++ b/lib/controlkeel_web/live/workspace_settings_live.ex
@@ -17,7 +17,6 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
   alias ControlKeel.Mission.Workspace
   alias ControlKeel.Platform
   alias ControlKeel.Repo
-  alias ControlKeel.Runtime.Mode
 
   @tabs ["policies", "tool_policy"]
 
@@ -538,29 +537,21 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
 
   defp check_org_slug(_, _), do: {:error, "Workspace does not belong to this organization."}
 
-  defp check_workspace_access(workspace, assigns) do
-    if Mode.current() == :local do
-      :ok
-    else
-      check_cloud_workspace_access(workspace, assigns)
+  # TODO(auth): the workspace lookup + org-relation checks below are duplicated
+  # across workspace LiveViews. Extract into a shared on_mount hook and restore
+  # role enforcement when centralized auth lands (CLI/web parity PR).
+  defp check_workspace_access(%Workspace{org_id: ws_org_id}, assigns) do
+    case assigns[:current_org_id] do
+      nil ->
+        :ok
+
+      org_id when is_integer(org_id) and org_id == ws_org_id ->
+        :ok
+
+      _ ->
+        {:error, "Workspace belongs to a different organization."}
     end
   end
-
-  defp check_cloud_workspace_access(%Workspace{org_id: nil}, _),
-    do: {:error, "Workspace is not bound to an org."}
-
-  defp check_cloud_workspace_access(%Workspace{org_id: ws_org}, %{
-         current_org_id: org_id,
-         current_membership: m
-       })
-       when is_integer(ws_org) and ws_org == org_id do
-    if m && Accounts.role_at_least?(m.role, "admin"),
-      do: :ok,
-      else: {:error, "Admin or owner role required."}
-  end
-
-  defp check_cloud_workspace_access(_, _),
-    do: {:error, "Workspace belongs to a different organization."}
 
   defp redirect_with_flash(socket, kind, msg, path) do
     socket

--- a/lib/controlkeel_web/live/workspace_settings_live.ex
+++ b/lib/controlkeel_web/live/workspace_settings_live.ex
@@ -17,8 +17,9 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
   alias ControlKeel.Mission.Workspace
   alias ControlKeel.Platform
   alias ControlKeel.Repo
+  alias ControlKeel.Runtime.Mode
 
-  @tabs ["policies", "tool_policy"]
+  @tabs ["policies", "agent_tools"]
 
   @impl true
   def mount(%{"id" => id, "slug" => slug} = _params, _session, socket) do
@@ -74,7 +75,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
     {:noreply, assign(socket, :active_tab, normalize_tab(params["tab"]))}
   end
 
-  defp normalize_tab("tool_policy"), do: "tool_policy"
+  defp normalize_tab("agent_tools"), do: "agent_tools"
   defp normalize_tab(_tab), do: "policies"
 
   @impl true
@@ -244,7 +245,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
         </nav>
 
         <%= case @active_tab do %>
-          <% "tool_policy" -> %>
+          <% "agent_tools" -> %>
             <.tool_policy_panel
               workspace={@workspace}
               modes={@modes}
@@ -499,7 +500,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
   end
 
   defp tab_label("policies"), do: "Policies"
-  defp tab_label("tool_policy"), do: "Agent tools"
+  defp tab_label("agent_tools"), do: "Agent tools"
 
   defp find_assignment(assignments, set_id) do
     Enum.find(assignments, &(&1.policy_set_id == set_id)) || {:error, :not_found}
@@ -530,21 +531,32 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
 
   defp check_org_slug(_, _), do: {:error, "Workspace does not belong to this organization."}
 
-  # TODO(auth): the workspace lookup + org-relation checks below are duplicated
-  # across workspace LiveViews. Extract into a shared on_mount hook and restore
-  # role enforcement when centralized auth lands (CLI/web parity PR).
-  defp check_workspace_access(%Workspace{org_id: ws_org_id}, assigns) do
-    case assigns[:current_org_id] do
-      nil ->
-        :ok
-
-      org_id when is_integer(org_id) and org_id == ws_org_id ->
-        :ok
-
-      _ ->
-        {:error, "Workspace belongs to a different organization."}
+  # TODO(auth): the workspace lookup + access checks below are duplicated
+  # across workspace LiveViews. Extract into a shared on_mount hook when
+  # centralized auth lands (CLI/web parity PR).
+  defp check_workspace_access(workspace, assigns) do
+    if Mode.current() == :local do
+      :ok
+    else
+      check_cloud_workspace_access(workspace, assigns)
     end
   end
+
+  defp check_cloud_workspace_access(%Workspace{org_id: nil}, _),
+    do: {:error, "Workspace is not bound to an org."}
+
+  defp check_cloud_workspace_access(%Workspace{org_id: ws_org}, %{
+         current_org_id: org_id,
+         current_membership: m
+       })
+       when is_integer(ws_org) and ws_org == org_id do
+    if m && Accounts.role_at_least?(m.role, "admin"),
+      do: :ok,
+      else: {:error, "Admin or owner role required."}
+  end
+
+  defp check_cloud_workspace_access(_, _),
+    do: {:error, "Workspace belongs to a different organization."}
 
   defp redirect_with_flash(socket, kind, msg, path) do
     socket

--- a/lib/controlkeel_web/live/workspace_settings_live.ex
+++ b/lib/controlkeel_web/live/workspace_settings_live.ex
@@ -1,0 +1,504 @@
+defmodule ControlKeelWeb.WorkspaceSettingsLive do
+  @moduledoc """
+  Workspace settings at `/organizations/:slug/workspaces/:id/settings`.
+
+  Secondary navigation over setting groups. Two groups today: Policies
+  (rule-set assignments, parity with `controlkeel policy-set apply`) and
+  Tool policy (the MCP gate editor also available standalone at
+  `/workspaces/:id/tool-policy`).
+  """
+
+  use ControlKeelWeb, :live_view
+
+  alias ControlKeel.Accounts
+  alias ControlKeel.Accounts.Org
+  alias ControlKeel.Accounts.WorkspaceToolPolicy
+  alias ControlKeel.MCP.ToolGroups
+  alias ControlKeel.Mission.Workspace
+  alias ControlKeel.Platform
+  alias ControlKeel.Repo
+  alias ControlKeel.Runtime.Mode
+
+  @tabs ["policies", "tool_policy"]
+
+  @impl true
+  def mount(%{"id" => id, "slug" => slug} = _params, _session, socket) do
+    with {ws_id, ""} <- Integer.parse(id),
+         %Workspace{} = workspace <- Repo.get(Workspace, ws_id) |> Repo.preload(:org),
+         :ok <- check_org_slug(workspace, %{slug: slug}),
+         :ok <- check_workspace_access(workspace, socket.assigns) do
+      tool_policy = Accounts.get_workspace_tool_policy(workspace.id)
+      tools = WorkspaceToolPolicy.decode_tools(tool_policy)
+
+      {:ok,
+       socket
+       |> assign(:page_title, "Settings — #{workspace.name}")
+       |> assign(:workspace, workspace)
+       |> assign(:active_tab, "policies")
+       |> assign(:tabs, @tabs)
+       |> assign(:modes, WorkspaceToolPolicy.modes())
+       |> assign(:selected_tools, tools)
+       |> assign(:unknown_tools, tools -- ToolGroups.all_tools())
+       |> assign(:tool_options, ToolGroups.all_tools())
+       |> assign(:live_mode, tool_policy.mode)
+       |> assign(
+         :form,
+         to_form(%{"mode" => tool_policy.mode, "tools" => Enum.join(tools, "\n")}, as: :policy)
+       )
+       |> assign(
+         :apply_form,
+         to_form(%{"policy_set_id" => "", "precedence" => "100"}, as: :assignment)
+       )
+       |> refresh_policy_assigns()}
+    else
+      :error ->
+        {:ok, redirect_with_flash(socket, :error, "Invalid workspace id.", ~p"/organizations")}
+
+      nil ->
+        {:ok, redirect_with_flash(socket, :error, "Workspace not found.", ~p"/organizations")}
+
+      {:error, reason} ->
+        {:ok, redirect_with_flash(socket, :error, reason, ~p"/organizations")}
+    end
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    {:noreply, assign(socket, :active_tab, normalize_tab(params["tab"]))}
+  end
+
+  defp normalize_tab("tool_policy"), do: "tool_policy"
+  defp normalize_tab(_tab), do: "policies"
+
+  @impl true
+  def handle_event("set_tab", %{"tab" => tab}, socket) when tab in @tabs do
+    {:noreply,
+     push_patch(socket,
+       to:
+         ~p"/organizations/#{socket.assigns.workspace.org.slug}/workspaces/#{socket.assigns.workspace.id}/settings?tab=#{tab}"
+     )}
+  end
+
+  def handle_event("set_tab", _params, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_event("apply_policy_set", %{"assignment" => params}, socket) do
+    with {:ok, set_id} <- parse_int(params["policy_set_id"]),
+         {:ok, precedence} <- parse_precedence(params["precedence"]) do
+      case Platform.apply_policy_set(socket.assigns.workspace.id, set_id, %{
+             "precedence" => precedence,
+             "enabled" => true
+           }) do
+        {:ok, _assignment} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, "Policy set applied.")
+           |> refresh_policy_assigns()}
+
+        {:error, _changeset} ->
+          {:noreply, put_flash(socket, :error, "Failed to apply policy set.")}
+      end
+    else
+      :error ->
+        {:noreply,
+         put_flash(socket, :error, "Choose a policy set and a non-negative precedence.")}
+    end
+  end
+
+  @impl true
+  def handle_event("remove_policy_set", %{"policy-set-id" => id}, socket) do
+    case parse_int(id) do
+      {:ok, set_id} ->
+        case Platform.remove_workspace_policy_set(socket.assigns.workspace.id, set_id) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Policy set removed.")
+             |> refresh_policy_assigns()}
+
+          _ ->
+            {:noreply, put_flash(socket, :error, "Policy set assignment not found.")}
+        end
+
+      :error ->
+        {:noreply, put_flash(socket, :error, "Invalid policy set id.")}
+    end
+  end
+
+  @impl true
+  def handle_event("mode_changed", %{"policy" => %{"mode" => mode}}, socket) do
+    {:noreply, assign(socket, :live_mode, mode)}
+  end
+
+  @impl true
+  def handle_event("pick_tool", %{"tool_picker" => tool}, socket) when tool != "" do
+    selected = socket.assigns.selected_tools
+    updated = if tool in selected, do: selected, else: selected ++ [tool]
+    {:noreply, assign(socket, :selected_tools, updated)}
+  end
+
+  def handle_event("pick_tool", _params, socket), do: {:noreply, socket}
+
+  def handle_event("remove_tool", %{"tool" => tool}, socket) do
+    {:noreply, assign(socket, :selected_tools, List.delete(socket.assigns.selected_tools, tool))}
+  end
+
+  @impl true
+  def handle_event("submit", %{"policy" => %{"mode" => mode}}, socket) do
+    tools = socket.assigns.selected_tools
+
+    case Accounts.set_workspace_tool_policy(socket.assigns.workspace.id, mode, tools) do
+      {:ok, policy} ->
+        saved_tools = WorkspaceToolPolicy.decode_tools(policy)
+
+        {:noreply,
+         socket
+         |> assign(:policy, policy)
+         |> assign(:selected_tools, saved_tools)
+         |> assign(:unknown_tools, saved_tools -- ToolGroups.all_tools())
+         |> assign(:live_mode, policy.mode)
+         |> put_flash(:info, "Tool policy saved (#{policy.mode}).")}
+
+      {:error, %Ecto.Changeset{} = cs} ->
+        msg = Enum.map_join(cs.errors, ", ", fn {f, {m, _}} -> "#{f}: #{m}" end)
+
+        {:noreply, put_flash(socket, :error, msg)}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <section class="w-full space-y-8">
+      <div class="flex flex-col justify-between gap-4 lg:flex-row lg:items-end">
+        <div class="space-y-2">
+          <p class="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+            <.link navigate={~p"/organizations/#{@workspace.org.slug}/workspaces/#{@workspace.id}"}>
+              {@workspace.name}
+            </.link>
+            · Settings
+          </p>
+          <h1 class="text-xl font-semibold tracking-tight sm:text-2xl text-foreground">
+            Workspace settings
+          </h1>
+        </div>
+      </div>
+
+      <div class="grid gap-6 lg:grid-cols-[200px_minmax(0,1fr)]">
+        <nav
+          class="rounded-2xl border bg-card shadow-card lg:self-start lg:p-3"
+          aria-label="Workspace settings sections"
+        >
+          <ul class="flex gap-1 list-none m-0 overflow-x-auto p-2 lg:flex-col lg:gap-1 lg:p-0">
+            <%= for tab <- @tabs do %>
+              <li class="shrink-0">
+                <button
+                  type="button"
+                  phx-click="set_tab"
+                  phx-value-tab={tab}
+                  aria-current={@active_tab == tab && "page"}
+                  class={[
+                    "w-full whitespace-nowrap rounded-lg px-3 py-2 text-left text-sm transition",
+                    @active_tab == tab &&
+                      "bg-primary/10 font-semibold text-primary",
+                    @active_tab != tab && "text-muted-foreground hover:bg-muted hover:text-foreground"
+                  ]}
+                >
+                  {tab_label(tab)}
+                </button>
+              </li>
+            <% end %>
+          </ul>
+        </nav>
+
+        <%= case @active_tab do %>
+          <% "tool_policy" -> %>
+            <.tool_policy_panel
+              workspace={@workspace}
+              form={@form}
+              modes={@modes}
+              tool_options={@tool_options}
+              selected_tools={@selected_tools}
+              unknown_tools={@unknown_tools}
+              live_mode={@live_mode}
+            />
+          <% _ -> %>
+            <.policy_sets_panel
+              policy_assignments={@policy_assignments}
+              available_sets={@available_sets}
+              apply_form={@apply_form}
+            />
+        <% end %>
+      </div>
+    </section>
+    """
+  end
+
+  attr :policy_assignments, :list, required: true
+  attr :available_sets, :list, required: true
+  attr :apply_form, :map, required: true
+
+  defp policy_sets_panel(assigns) do
+    ~H"""
+    <section class="rounded-2xl border bg-card p-5 shadow-card">
+      <.section_title>Policy sets</.section_title>
+      <p class="mt-1 text-xs text-muted-foreground">
+        Rules from applied sets run for every validation mapped to this workspace.
+        Lower precedence evaluates earlier.
+      </p>
+
+      <%= if @policy_assignments == [] do %>
+        <p class="mt-4 text-sm text-muted-foreground">No policy sets applied yet.</p>
+      <% else %>
+        <ul class="mt-4 divide-y divide-border">
+          <%= for a <- @policy_assignments do %>
+            <li class="flex items-center justify-between gap-3 py-3 first:pt-0 last:pb-0">
+              <div>
+                <p class="text-sm font-semibold text-foreground">
+                  #{a.policy_set.id} {a.policy_set.name}
+                </p>
+                <p class="mt-0.5 text-xs text-muted-foreground">
+                  precedence {a.precedence}
+                  <%= unless a.enabled do %>
+                    , disabled
+                  <% end %>
+                </p>
+              </div>
+              <button
+                type="button"
+                phx-click="remove_policy_set"
+                phx-value-policy-set-id={a.policy_set_id}
+                class="inline-flex items-center rounded-lg px-3 py-1.5 text-xs font-medium text-destructive transition hover:bg-destructive/10"
+              >
+                Remove
+              </button>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+
+      <.form
+        for={@apply_form}
+        phx-submit="apply_policy_set"
+        id="workspace-policy-apply-form"
+        class={[
+          "mt-4 flex flex-wrap items-end gap-3 border-t pt-4",
+          @available_sets == [] && "opacity-60"
+        ]}
+      >
+        <div class="min-w-[220px] flex-1">
+          <label
+            for="policy-set-select"
+            class="mb-1.5 flex items-center text-sm font-medium text-foreground/90"
+          >
+            Policy set
+          </label>
+          <select
+            id="policy-set-select"
+            name="assignment[policy_set_id]"
+            disabled={@available_sets == [] || nil}
+            class={[
+              "h-8 w-full rounded-lg border border-input bg-transparent px-2.5 py-1 text-base outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 md:text-sm",
+              @available_sets == [] && "cursor-not-allowed opacity-60"
+            ]}
+          >
+            <%= for s <- @available_sets do %>
+              <option value={s.id}>#{s.id} {s.name}</option>
+            <% end %>
+          </select>
+        </div>
+        <div class="w-28">
+          <.input_component
+            type="number"
+            id="policy-set-precedence"
+            name="assignment[precedence]"
+            value="100"
+            label="Precedence"
+            min="0"
+            disabled={@available_sets == [] || nil}
+          />
+        </div>
+        <.button type="submit" disabled={@available_sets == [] || nil}>Apply</.button>
+      </.form>
+
+      <%= if @available_sets == [] do %>
+        <p class="mt-4 text-xs text-muted-foreground">
+          All policy sets are applied. Go to
+          <.link navigate={~p"/policies"} class="font-medium text-primary hover:underline">
+            Policy Studio
+          </.link>
+          to create new policies.
+        </p>
+      <% end %>
+    </section>
+    """
+  end
+
+  attr :workspace, :map, required: true
+  attr :form, :map, required: true
+  attr :modes, :list, required: true
+  attr :tool_options, :list, required: true
+  attr :selected_tools, :list, required: true
+  attr :unknown_tools, :list, required: true
+  attr :live_mode, :string, required: true
+
+  defp tool_policy_panel(assigns) do
+    ~H"""
+    <section class="rounded-2xl border bg-card p-5 shadow-card">
+      <.section_title>Tool policy</.section_title>
+      <p class="mt-1 text-xs text-muted-foreground">
+        Restrict which MCP tools agents in this workspace may invoke. <code>inherit</code>
+        falls back to the global allowlist; <code>allowlist</code>
+        and <code>denylist</code>
+        override it.
+      </p>
+
+      <.form for={@form} phx-submit="submit" id="workspace-tool-policy-form" class="mt-4 space-y-4">
+        <div>
+          <label
+            for="tool-policy-mode"
+            class="mb-1.5 flex items-center text-sm font-medium text-foreground/90"
+          >
+            Mode
+          </label>
+          <select
+            id="tool-policy-mode"
+            name="policy[mode]"
+            phx-change="mode_changed"
+            class="w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 md:text-sm"
+          >
+            <%= for m <- @modes do %>
+              <option value={m} selected={@live_mode == m}>{m}</option>
+            <% end %>
+          </select>
+        </div>
+
+        <div>
+          <%= if @selected_tools == [] do %>
+            <p class="text-xs text-muted-foreground">No tools selected.</p>
+          <% else %>
+            <ul class="flex list-none flex-wrap gap-1.5 m-0 p-0">
+              <%= for tool <- @selected_tools do %>
+                <li class={[
+                  "inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-medium ring-1",
+                  tool in @tool_options &&
+                    "bg-primary/10 text-primary ring-primary/20",
+                  tool not in @tool_options && "bg-warning/10 text-warning ring-warning/20"
+                ]}>
+                  {tool}
+                  <button
+                    type="button"
+                    phx-click="remove_tool"
+                    phx-value-tool={tool}
+                    aria-label={"Remove #{tool}"}
+                    class="cursor-pointer transition hover:text-destructive"
+                  >
+                    <.icon name="hero-x-mark" class="size-3.5" />
+                  </button>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
+          <select
+            id="tool-policy-picker"
+            name="tool_picker"
+            phx-change="pick_tool"
+            disabled={@live_mode == "inherit" || nil}
+            class={[
+              "mt-2 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 md:text-sm",
+              @live_mode == "inherit" && "cursor-not-allowed opacity-50"
+            ]}
+          >
+            <option value="">Add a tool…</option>
+            <%= for tool <- @tool_options do %>
+              <%= unless tool in @selected_tools do %>
+                <option value={tool}>{tool}</option>
+              <% end %>
+            <% end %>
+          </select>
+
+          <p class="mt-1.5 text-xs text-muted-foreground">
+            Used by <code>allowlist</code>
+            and <code>denylist</code>
+            modes. Ignored under <code>inherit</code>.
+          </p>
+        </div>
+
+        <.button type="submit">Save policy</.button>
+      </.form>
+    </section>
+    """
+  end
+
+  defp refresh_policy_assigns(socket) do
+    assignments = Platform.list_workspace_policy_sets(socket.assigns.workspace.id)
+    assigned_ids = Enum.map(assignments, & &1.policy_set_id)
+
+    available_sets =
+      Platform.list_policy_sets()
+      |> Enum.reject(&(&1.id in assigned_ids))
+
+    socket
+    |> assign(:policy_assignments, assignments)
+    |> assign(:available_sets, available_sets)
+  end
+
+  defp tab_label("policies"), do: "Policies"
+  defp tab_label("tool_policy"), do: "Tool policy"
+
+  defp parse_int(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} -> {:ok, int}
+      _ -> :error
+    end
+  end
+
+  defp parse_int(_), do: :error
+
+  defp parse_precedence(value) do
+    case parse_int(value || "") do
+      {:ok, n} when n >= 0 -> {:ok, n}
+      _ -> :error
+    end
+  end
+
+  defp check_org_slug(%Workspace{org_id: org_id}, %{slug: slug}) when is_integer(org_id) do
+    case Accounts.get_org_by_slug(slug) do
+      %Org{id: ^org_id} -> :ok
+      _ -> {:error, "Workspace does not belong to this organization."}
+    end
+  end
+
+  defp check_org_slug(_, _), do: {:error, "Workspace does not belong to this organization."}
+
+  defp check_workspace_access(workspace, assigns) do
+    if Mode.current() == :local do
+      :ok
+    else
+      check_cloud_workspace_access(workspace, assigns)
+    end
+  end
+
+  defp check_cloud_workspace_access(%Workspace{org_id: nil}, _),
+    do: {:error, "Workspace is not bound to an org."}
+
+  defp check_cloud_workspace_access(%Workspace{org_id: ws_org}, %{
+         current_org_id: org_id,
+         current_membership: m
+       })
+       when is_integer(ws_org) and ws_org == org_id do
+    if m && Accounts.role_at_least?(m.role, "admin"),
+      do: :ok,
+      else: {:error, "Admin or owner role required."}
+  end
+
+  defp check_cloud_workspace_access(_, _),
+    do: {:error, "Workspace belongs to a different organization."}
+
+  defp redirect_with_flash(socket, kind, msg, path) do
+    socket
+    |> Phoenix.LiveView.put_flash(kind, msg)
+    |> Phoenix.LiveView.push_navigate(to: path)
+  end
+end

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -97,6 +97,7 @@ defmodule ControlKeelWeb.Router do
       live "/organizations", OrganizationsLive, :index
       live "/organizations/:slug", OrganizationDetailLive, :index
       live "/organizations/:slug/workspaces/:id", WorkspaceDetailLive, :index
+      live "/organizations/:slug/workspaces/:id/settings", WorkspaceSettingsLive, :show
       live "/workspaces/:id/repos", WorkspaceReposLive, :index
       live "/workspaces/:id/service-accounts", WorkspaceServiceAccountsLive, :index
       live "/workspaces/:id/webhooks", WorkspaceWebhooksLive, :index

--- a/test/controlkeel/platform_test.exs
+++ b/test/controlkeel/platform_test.exs
@@ -41,6 +41,38 @@ defmodule ControlKeel.PlatformTest do
     assert {:ok, _authed} = Platform.authenticate_service_account(rotated_token)
   end
 
+  test "assignment listings split display from evaluation on disabled rows" do
+    session = session_fixture()
+    set_a = policy_set_fixture(%{name: "Enabled Set"})
+    set_b = policy_set_fixture(%{name: "Disabled Set"})
+
+    {:ok, _} = Platform.apply_policy_set(session.workspace_id, set_a.id, %{"precedence" => 10})
+    {:ok, _} = Platform.apply_policy_set(session.workspace_id, set_b.id, %{"enabled" => false})
+
+    evaluation_ids =
+      session.workspace_id
+      |> Platform.list_workspace_policy_sets()
+      |> Enum.map(& &1.policy_set_id)
+
+    assert evaluation_ids == [set_a.id]
+
+    display_ids =
+      session.workspace_id
+      |> Platform.list_workspace_policy_assignments()
+      |> Enum.map(&{&1.policy_set_id, &1.enabled})
+
+    assert display_ids == [{set_a.id, true}, {set_b.id, false}]
+
+    # Nil (all-workspace) listings follow the same split.
+    assert Enum.any?(Platform.list_workspace_policy_sets(), &(&1.policy_set_id == set_b.id)) ==
+             false
+
+    assert Enum.any?(
+             Platform.list_workspace_policy_assignments(),
+             &(&1.policy_set_id == set_b.id)
+           )
+  end
+
   test "applied workspace policy sets participate in fast path scanning" do
     session = session_fixture()
     policy_set = policy_set_fixture()

--- a/test/controlkeel_web/live/policy_studio_live_test.exs
+++ b/test/controlkeel_web/live/policy_studio_live_test.exs
@@ -95,4 +95,123 @@ defmodule ControlKeelWeb.PolicyStudioLiveTest do
     assert html =~ "Cost"
     assert html =~ "Software"
   end
+
+  test "page action button opens the create policy set modal", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/policies")
+
+    refute has_element?(view, "#policy-set-form")
+
+    render_click(view, "open_create_modal")
+
+    assert has_element?(view, "#policy-set-form")
+    assert has_element?(view, "#policy-set-create-modal-title")
+    assert render(view) =~ "New policy set"
+  end
+
+  test "creating a policy set from the modal saves it and lists it", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/policies")
+
+    render_click(view, "open_create_modal")
+
+    rules_json =
+      ~s|[{"id": "shell.destructive_rm_rf", "category": "security", "severity": "critical", "action": "block", "plain_message": "blocked", "matcher": {"type": "regex", "patterns": ["rm -rf"]}}]|
+
+    render_submit(view, "save_policy_set", %{
+      "policy_set" => %{
+        "name" => "no-rm-rf-web",
+        "scope" => "workspace",
+        "description" => "Block destructive deletes from web",
+        "rules_json" => rules_json
+      }
+    })
+
+    html = render(view)
+
+    assert html =~ "Created policy set #"
+    assert html =~ "no-rm-rf-web"
+
+    assert Enum.any?(ControlKeel.Platform.list_policy_sets(), &(&1.name == "no-rm-rf-web"))
+  end
+
+  test "wrapped entries JSON is accepted like the CLI rules file format", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/policies")
+
+    render_click(view, "open_create_modal")
+
+    entries =
+      ~s|{"entries": [{"id": "cost.overrun", "category": "cost", "severity": "high", "action": "warn", "plain_message": "over budget", "matcher": {"type": "budget", "ratio_gte": 1.0}}]}|
+
+    render_submit(view, "save_policy_set", %{
+      "policy_set" => %{
+        "name" => "budget-warn-web",
+        "scope" => "global",
+        "description" => nil,
+        "rules_json" => entries
+      }
+    })
+
+    assert render(view) =~ "budget-warn-web"
+
+    set = Enum.find(ControlKeel.Platform.list_policy_sets(), &(&1.name == "budget-warn-web"))
+    assert length(ControlKeel.Platform.PolicySet.rule_entries(set)) == 1
+  end
+
+  test "invalid rules JSON keeps the modal open with an error", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/policies")
+
+    render_click(view, "open_create_modal")
+
+    render_submit(view, "save_policy_set", %{
+      "policy_set" => %{
+        "name" => "broken-json",
+        "scope" => "workspace",
+        "rules_json" => "{not json"
+      }
+    })
+
+    html = render(view)
+
+    assert has_element?(view, "#policy-set-form")
+    assert html =~ "invalid JSON"
+    refute Enum.any?(ControlKeel.Platform.list_policy_sets(), &(&1.name == "broken-json"))
+  end
+
+  test "non-array rules JSON shows a shape error", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/policies")
+
+    render_click(view, "open_create_modal")
+
+    render_change(view, "validate_policy_set", %{
+      "policy_set" => %{"name" => "shape-check", "rules_json" => "{\"id\": \"one-object\"}"}
+    })
+
+    assert render(view) =~ "must be an array of rule entries"
+  end
+
+  test "missing name shows validation error without saving", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/policies")
+
+    render_click(view, "open_create_modal")
+
+    render_submit(view, "save_policy_set", %{
+      "policy_set" => %{"name" => "", "scope" => "workspace", "rules_json" => ""}
+    })
+
+    html = render(view)
+
+    assert has_element?(view, "#policy-set-form")
+    assert html =~ "can&#39;t be blank"
+    assert ControlKeel.Platform.list_policy_sets() == []
+  end
+
+  test "cancel closes the create modal", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/policies")
+
+    render_click(view, "open_create_modal")
+    assert has_element?(view, "#policy-set-form")
+
+    render_click(view, "close_create_modal")
+
+    refute has_element?(view, "#policy-set-form")
+  end
 end

--- a/test/controlkeel_web/live/policy_studio_live_test.exs
+++ b/test/controlkeel_web/live/policy_studio_live_test.exs
@@ -241,4 +241,26 @@ defmodule ControlKeelWeb.PolicyStudioLiveTest do
 
     refute has_element?(view, "#policy-set-form")
   end
+
+  test "escape closes the packs dialog", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/policies")
+
+    render_click(view, "open_packs_dialog")
+    assert has_element?(view, "#packs-dialog")
+
+    view |> element("#packs-dialog") |> render_keydown(%{"key" => "escape"})
+
+    refute has_element?(view, "#packs-dialog")
+  end
+
+  test "escape closes the create modal", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/policies")
+
+    render_click(view, "open_create_modal")
+    assert has_element?(view, "#policy-set-form")
+
+    view |> element("#policy-set-create-modal") |> render_keydown(%{"key" => "escape"})
+
+    refute has_element?(view, "#policy-set-form")
+  end
 end

--- a/test/controlkeel_web/live/policy_studio_live_test.exs
+++ b/test/controlkeel_web/live/policy_studio_live_test.exs
@@ -18,6 +18,8 @@ defmodule ControlKeelWeb.PolicyStudioLiveTest do
   test "toggle_pack expands and collapses baseline pack", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/policies")
 
+    render_click(view, "open_packs_dialog")
+
     trigger = element(view, "button[phx-value-name=\"baseline\"]")
     render_click(trigger)
 
@@ -54,8 +56,7 @@ defmodule ControlKeelWeb.PolicyStudioLiveTest do
     {:ok, workspace} = Accounts.create_org(%{name: "Org A", slug: "test-org-a"})
     ws = workspace_fixture(%{org_id: workspace.id})
     {:ok, _assignment} = ControlKeel.Platform.apply_policy_set(ws.id, set.id, %{precedence: 10})
-
-    {:ok, _view, html} = live(conn, ~p"/policies")
+    {:ok, view, html} = live(conn, ~p"/policies")
 
     assert html =~ "no-rm-rf"
     assert html =~ "active"
@@ -63,6 +64,7 @@ defmodule ControlKeelWeb.PolicyStudioLiveTest do
     assert html =~ "Block destructive deletes"
     assert html =~ "workspace ##{ws.id}"
     assert html =~ "precedence 10"
+    assert has_element?(view, "span[title='block, security']", "destructive rm rf")
   end
 
   test "block count badge shows destructive class", %{conn: conn} do
@@ -74,13 +76,19 @@ defmodule ControlKeelWeb.PolicyStudioLiveTest do
   test "warn rules show warning class when pack is expanded", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/policies")
 
+    render_click(view, "open_packs_dialog")
     render_click(element(view, "button[phx-value-name=\"software\"]"))
 
     assert render(view) =~ "bg-warning/10"
   end
 
   test "renders pack labels for known domain packs", %{conn: conn} do
-    {:ok, _view, html} = live(conn, ~p"/policies")
+    {:ok, view, html} = live(conn, ~p"/policies")
+
+    refute html =~ "Baseline"
+
+    render_click(view, "open_packs_dialog")
+    html = render(view)
 
     assert html =~ "Baseline"
     assert html =~ "Cost"

--- a/test/controlkeel_web/live/policy_studio_live_test.exs
+++ b/test/controlkeel_web/live/policy_studio_live_test.exs
@@ -67,6 +67,34 @@ defmodule ControlKeelWeb.PolicyStudioLiveTest do
     assert has_element?(view, "span[title='block, security']", "destructive rm rf")
   end
 
+  test "lists disabled assignments with a marker", %{conn: conn} do
+    {:ok, set} =
+      ControlKeel.Platform.create_policy_set(%{
+        "name" => "paused-set",
+        "description" => "Paused controls",
+        "rules" => [
+          %{
+            "id" => "cost.overrun",
+            "category" => "cost",
+            "severity" => "high",
+            "action" => "warn",
+            "plain_message" => "over budget",
+            "matcher" => %{"type" => "budget", ratio_gte: 1.0}
+          }
+        ]
+      })
+
+    {:ok, org} = Accounts.create_org(%{name: "Paused Org", slug: "paused-org"})
+    ws = workspace_fixture(%{org_id: org.id})
+    {:ok, _} = ControlKeel.Platform.apply_policy_set(ws.id, set.id, %{"enabled" => false})
+
+    {:ok, _view, html} = live(conn, ~p"/policies")
+
+    assert html =~ "paused-set"
+    assert html =~ "workspace ##{ws.id}"
+    assert html =~ ", disabled"
+  end
+
   test "block count badge shows destructive class", %{conn: conn} do
     {:ok, _view, html} = live(conn, ~p"/policies")
 

--- a/test/controlkeel_web/live/policy_studio_live_test.exs
+++ b/test/controlkeel_web/live/policy_studio_live_test.exs
@@ -37,26 +37,41 @@ defmodule ControlKeelWeb.PolicyStudioLiveTest do
     refute render(view) =~ "Detects secrets, injection, and XSS"
   end
 
-  test "shows empty tool-policies state when no org_id is present", %{conn: conn} do
+  test "shows empty policy-sets state when none exist", %{conn: conn} do
     {:ok, _view, html} = live(conn, ~p"/policies")
 
-    assert html =~ "All workspaces inherit global tool access"
+    assert html =~ "No custom policy sets yet"
   end
 
-  test "shows workspace tool policies when org has non-inherit policies", %{conn: conn} do
-    {:ok, org} = Accounts.create_org(%{name: "Test Org", slug: "test-org-tool"})
-    workspace = workspace_fixture(%{org_id: org.id})
+  test "lists policy sets with status, rule count, and workspace assignments", %{conn: conn} do
+    {:ok, set} =
+      ControlKeel.Platform.create_policy_set(%{
+        "name" => "no-rm-rf",
+        "description" => "Block destructive deletes",
+        "rules" => [
+          %{
+            "id" => "shell.destructive_rm_rf",
+            "category" => "security",
+            "severity" => "critical",
+            "action" => "block",
+            "plain_message" => "blocked",
+            "matcher" => %{"type" => "regex", "patterns" => ["rm -rf"]}
+          }
+        ]
+      })
 
-    Accounts.set_workspace_tool_policy(workspace.id, "allowlist", ["file_read", "bash"])
-
-    conn = Plug.Test.init_test_session(conn, %{"current_org_id" => org.id})
+    {:ok, workspace} = Accounts.create_org(%{name: "Org A", slug: "test-org-a"})
+    ws = workspace_fixture(%{org_id: workspace.id})
+    {:ok, _assignment} = ControlKeel.Platform.apply_policy_set(ws.id, set.id, %{precedence: 10})
 
     {:ok, _view, html} = live(conn, ~p"/policies")
 
-    assert html =~ workspace.name
-    assert html =~ "allowlist"
-    assert html =~ "file_read"
-    assert html =~ "bash"
+    assert html =~ "no-rm-rf"
+    assert html =~ "active"
+    assert html =~ "1 rules"
+    assert html =~ "Block destructive deletes"
+    assert html =~ "workspace ##{ws.id}"
+    assert html =~ "precedence 10"
   end
 
   test "block count badge shows destructive class", %{conn: conn} do

--- a/test/controlkeel_web/live/policy_studio_live_test.exs
+++ b/test/controlkeel_web/live/policy_studio_live_test.exs
@@ -6,15 +6,6 @@ defmodule ControlKeelWeb.PolicyStudioLiveTest do
 
   alias ControlKeel.Accounts
 
-  test "renders policy packs with stats cards", %{conn: conn} do
-    {:ok, _view, html} = live(conn, ~p"/policies")
-
-    assert html =~ "Policy Studio"
-    assert html =~ "Active packs"
-    assert html =~ "Total rules"
-    assert html =~ "Blocking rules"
-  end
-
   test "toggle_pack ignores unknown pack names", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/policies")
 
@@ -77,7 +68,7 @@ defmodule ControlKeelWeb.PolicyStudioLiveTest do
   test "block count badge shows destructive class", %{conn: conn} do
     {:ok, _view, html} = live(conn, ~p"/policies")
 
-    assert html =~ "bg-destructive/15"
+    assert html =~ "bg-destructive/10"
   end
 
   test "warn rules show warning class when pack is expanded", %{conn: conn} do
@@ -85,7 +76,7 @@ defmodule ControlKeelWeb.PolicyStudioLiveTest do
 
     render_click(element(view, "button[phx-value-name=\"software\"]"))
 
-    assert render(view) =~ "var(--ck-warning)"
+    assert render(view) =~ "bg-warning/10"
   end
 
   test "renders pack labels for known domain packs", %{conn: conn} do
@@ -96,7 +87,7 @@ defmodule ControlKeelWeb.PolicyStudioLiveTest do
     assert html =~ "Software"
   end
 
-  test "page action button opens the create policy set modal", %{conn: conn} do
+  test "new policy set button opens the create modal", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/policies")
 
     refute has_element?(view, "#policy-set-form")

--- a/test/controlkeel_web/live/workspace_detail_live_test.exs
+++ b/test/controlkeel_web/live/workspace_detail_live_test.exs
@@ -95,6 +95,26 @@ defmodule ControlKeelWeb.WorkspaceDetailLiveTest do
       assert html =~ "Recursive force-delete commands are blocked."
     end
 
+    test "renders a marker for disabled policy assignments" do
+      {:ok, org} = Accounts.create_org(%{name: "DisWs", slug: "disws"})
+      ws = create_workspace(%{name: "Dis", slug: "dis", industry: "web", org_id: org.id})
+
+      set =
+        ControlKeel.PlatformFixtures.policy_set_fixture(%{name: "paused-set"})
+
+      {:ok, _} =
+        ControlKeel.Platform.apply_policy_set(ws.id, set.id, %{
+          "precedence" => 7,
+          "enabled" => false
+        })
+
+      {:ok, _view, html} = live(build_conn(), ~p"/organizations/disws/workspaces/#{ws.id}")
+
+      assert html =~ "paused-set"
+      assert html =~ "precedence 7"
+      assert html =~ ", disabled"
+    end
+
     test "shows an empty state when the workspace has no sessions" do
       {:ok, org} = Accounts.create_org(%{name: "Empty Org", slug: "empty-org"})
       ws = create_workspace(%{name: "Empty", slug: "empty", industry: "web", org_id: org.id})

--- a/test/controlkeel_web/live/workspace_detail_live_test.exs
+++ b/test/controlkeel_web/live/workspace_detail_live_test.exs
@@ -4,7 +4,9 @@ defmodule ControlKeelWeb.WorkspaceDetailLiveTest do
   import Phoenix.LiveViewTest
 
   alias ControlKeel.Accounts
+  alias ControlKeel.Accounts.Membership
   alias ControlKeel.Mission
+  alias ControlKeel.Repo
 
   defp create_user!(email) do
     {:ok, user} = Accounts.create_user(%{email: email})
@@ -187,6 +189,36 @@ defmodule ControlKeelWeb.WorkspaceDetailLiveTest do
 
       assert html =~ "Scoped"
       assert html =~ "Scoped"
+    end
+
+    test "a viewer role member of the workspace's org can view it" do
+      owner = create_user!("ws-view-owner@example.com")
+      {:ok, org} = Accounts.create_org_with_owner(owner.id, %{name: "ViewCo", slug: "viewco"})
+
+      ws =
+        create_workspace(%{name: "Viewable", slug: "viewable", industry: "web", org_id: org.id})
+
+      viewer = create_user!("ws-viewer@example.com")
+
+      %Membership{}
+      |> Membership.changeset(%{
+        user_id: viewer.id,
+        org_id: org.id,
+        role: "viewer",
+        status: "active"
+      })
+      |> Repo.insert!()
+
+      conn =
+        build_conn()
+        |> Plug.Test.init_test_session(%{
+          "current_user_id" => viewer.id,
+          "current_org_id" => org.id
+        })
+
+      {:ok, _view, html} = live(conn, ~p"/organizations/viewco/workspaces/#{ws.id}")
+
+      assert html =~ "Viewable"
     end
 
     test "a user outside the org is refused access" do

--- a/test/controlkeel_web/live/workspace_detail_live_test.exs
+++ b/test/controlkeel_web/live/workspace_detail_live_test.exs
@@ -57,14 +57,42 @@ defmodule ControlKeelWeb.WorkspaceDetailLiveTest do
 
       assert html =~ "Core"
       assert html =~ "core"
-      # Header stat row mirrors the org home layout.
-      assert html =~ "Slug"
-      assert html =~ "Sessions"
-      assert html =~ "Monthly budget"
+      # Meta line presents workspace facts inline, not as stat columns.
+      assert html =~ "2 total"
+      assert html =~ "No monthly budget"
       # Session rows render in the sessions-style table.
       assert html =~ "First session"
       assert html =~ "Second session"
-      assert html =~ "$100"
+    end
+
+    test "renders applied policy sets with rules revealed on hover markup", %{} do
+      {:ok, org} = Accounts.create_org(%{name: "PolWs", slug: "polws"})
+      ws = create_workspace(%{name: "Pol", slug: "pol", industry: "web", org_id: org.id})
+
+      {:ok, set} =
+        ControlKeel.Platform.create_policy_set(%{
+          "name" => "no-rm-rf",
+          "description" => "Block destructive deletes",
+          "rules" => [
+            %{
+              "id" => "shell.destructive_rm_rf",
+              "category" => "security",
+              "severity" => "critical",
+              "action" => "block",
+              "plain_message" => "Recursive force-delete commands are blocked.",
+              "matcher" => %{"type" => "regex", patterns: ["rm -rf"]}
+            }
+          ]
+        })
+
+      {:ok, _assignment} = ControlKeel.Platform.apply_policy_set(ws.id, set.id, %{precedence: 10})
+
+      {:ok, _view, html} = live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}")
+
+      assert html =~ "Applied policies"
+      assert html =~ "precedence 10"
+      assert html =~ "shell.destructive_rm_rf"
+      assert html =~ "Recursive force-delete commands are blocked."
     end
 
     test "shows an empty state when the workspace has no sessions" do

--- a/test/controlkeel_web/live/workspace_settings_live_test.exs
+++ b/test/controlkeel_web/live/workspace_settings_live_test.exs
@@ -87,13 +87,13 @@ defmodule ControlKeelWeb.WorkspaceSettingsLiveTest do
       assert has_element?(view, "#workspace-policy-apply-form")
     end
 
-    test "tool_policy tab renders via query param" do
+    test "agent_tools tab renders via query param" do
       {org, ws} = org_workspace()
 
       {:ok, view, _html} =
         live(
           build_conn(),
-          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=tool_policy"
+          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=agent_tools"
         )
 
       assert has_element?(view, "#workspace-tool-policy-form")
@@ -107,12 +107,12 @@ defmodule ControlKeelWeb.WorkspaceSettingsLiveTest do
         live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
 
       view
-      |> element("button[phx-value-tab='tool_policy']")
+      |> element("button[phx-value-tab='agent_tools']")
       |> render_click()
 
       assert_patch(
         view,
-        ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=tool_policy"
+        ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=agent_tools"
       )
 
       assert has_element?(view, "#workspace-tool-policy-form")
@@ -318,7 +318,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLiveTest do
       {:ok, view, html} =
         live(
           build_conn(),
-          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=tool_policy"
+          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=agent_tools"
         )
 
       assert html =~ "No tools selected."
@@ -356,7 +356,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLiveTest do
       {:ok, view, _html} =
         live(
           build_conn(),
-          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=tool_policy"
+          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=agent_tools"
         )
 
       view
@@ -386,7 +386,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLiveTest do
       {:ok, view, _html} =
         live(
           build_conn(),
-          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=tool_policy"
+          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=agent_tools"
         )
 
       # Stored tools are shown as chips on mount.
@@ -470,9 +470,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLiveTest do
       assert html =~ "Workspace settings"
     end
 
-    test "a viewer role member of the same org can open settings" do
-      # Role enforcement is deferred to centralized auth (TODO in the module);
-      # only the org-workspace relation is checked for now.
+    test "a viewer role member is refused access" do
       owner = create_user!("settings-view-owner@example.com")
 
       {:ok, org} =
@@ -491,9 +489,10 @@ defmodule ControlKeelWeb.WorkspaceSettingsLiveTest do
           "current_org_id" => org.id
         })
 
-      {:ok, _view, html} = live(conn, ~p"/organizations/viewerco/workspaces/#{ws.id}/settings")
+      assert {:error, {:live_redirect, %{to: "/organizations", flash: %{"error" => msg}}}} =
+               live(conn, ~p"/organizations/viewerco/workspaces/#{ws.id}/settings")
 
-      assert html =~ "Workspace settings"
+      assert msg =~ "Admin or owner role required."
     end
 
     test "a user outside the org is refused access" do

--- a/test/controlkeel_web/live/workspace_settings_live_test.exs
+++ b/test/controlkeel_web/live/workspace_settings_live_test.exs
@@ -470,7 +470,9 @@ defmodule ControlKeelWeb.WorkspaceSettingsLiveTest do
       assert html =~ "Workspace settings"
     end
 
-    test "a viewer role member is refused access" do
+    test "a viewer role member of the same org can open settings" do
+      # Role enforcement is deferred to centralized auth (TODO in the module);
+      # only the org-workspace relation is checked for now.
       owner = create_user!("settings-view-owner@example.com")
 
       {:ok, org} =
@@ -489,10 +491,9 @@ defmodule ControlKeelWeb.WorkspaceSettingsLiveTest do
           "current_org_id" => org.id
         })
 
-      assert {:error, {:live_redirect, %{to: "/organizations", flash: %{"error" => msg}}}} =
-               live(conn, ~p"/organizations/viewerco/workspaces/#{ws.id}/settings")
+      {:ok, _view, html} = live(conn, ~p"/organizations/viewerco/workspaces/#{ws.id}/settings")
 
-      assert msg =~ "Admin or owner role required."
+      assert html =~ "Workspace settings"
     end
 
     test "a user outside the org is refused access" do

--- a/test/controlkeel_web/live/workspace_settings_live_test.exs
+++ b/test/controlkeel_web/live/workspace_settings_live_test.exs
@@ -1,0 +1,431 @@
+defmodule ControlKeelWeb.WorkspaceSettingsLiveTest do
+  use ControlKeelWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias ControlKeel.Accounts
+  alias ControlKeel.Accounts.Membership
+  alias ControlKeel.Accounts.WorkspaceToolPolicy
+  alias ControlKeel.Mission
+  alias ControlKeel.Platform
+  alias ControlKeel.Repo
+
+  defp create_user!(email) do
+    {:ok, user} = Accounts.create_user(%{email: email})
+    user
+  end
+
+  defp create_workspace(attrs) do
+    attrs =
+      attrs
+      |> Enum.map(fn {k, v} -> {to_string(k), v} end)
+      |> Map.new()
+      |> Map.merge(%{
+        "agent" => "claude",
+        "industry" => "web",
+        "compliance_profile" => "general",
+        "status" => "active"
+      })
+
+    {:ok, ws} = Mission.create_workspace(attrs)
+    ws
+  end
+
+  defp org_workspace do
+    {:ok, org} = Accounts.create_org(%{name: "Settings Org", slug: "settings-org"})
+    ws = create_workspace(%{name: "Core", slug: "core", industry: "web", org_id: org.id})
+    {org, ws}
+  end
+
+  defp policy_set_fixture!(name) do
+    {:ok, set} =
+      Platform.create_policy_set(%{
+        "name" => name,
+        "description" => "Block destructive deletes",
+        "rules" => [
+          %{
+            "id" => "shell.destructive_rm_rf",
+            "category" => "security",
+            "severity" => "critical",
+            "action" => "block",
+            "plain_message" => "Recursive force-delete commands are blocked.",
+            "matcher" => %{"type" => "regex", "patterns" => ["rm -rf"]}
+          }
+        ]
+      })
+
+    set
+  end
+
+  defp submit_apply(view, params) do
+    view
+    |> element("#workspace-policy-apply-form")
+    |> render_submit(%{"assignment" => params})
+  end
+
+  describe "local mode" do
+    test "renders the policies tab by default" do
+      {org, ws} = org_workspace()
+
+      {:ok, view, html} =
+        live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
+
+      assert html =~ "Workspace settings"
+      assert has_element?(view, "#workspace-policy-apply-form")
+      refute has_element?(view, "#workspace-tool-policy-form")
+    end
+
+    test "unknown tab params fall back to the policies tab" do
+      {org, ws} = org_workspace()
+
+      {:ok, view, _html} =
+        live(
+          build_conn(),
+          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=nonsense"
+        )
+
+      assert has_element?(view, "#workspace-policy-apply-form")
+    end
+
+    test "tool_policy tab renders via query param" do
+      {org, ws} = org_workspace()
+
+      {:ok, view, _html} =
+        live(
+          build_conn(),
+          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=tool_policy"
+        )
+
+      assert has_element?(view, "#workspace-tool-policy-form")
+      refute has_element?(view, "#workspace-policy-apply-form")
+    end
+
+    test "set_tab patches the URL and switches panels" do
+      {org, ws} = org_workspace()
+
+      {:ok, view, _html} =
+        live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
+
+      view
+      |> element("button[phx-value-tab='tool_policy']")
+      |> render_click()
+
+      assert_patch(
+        view,
+        ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=tool_policy"
+      )
+
+      assert has_element?(view, "#workspace-tool-policy-form")
+
+      view
+      |> element("button[phx-value-tab='policies']")
+      |> render_click()
+
+      assert_patch(view, ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=policies")
+      assert has_element?(view, "#workspace-policy-apply-form")
+    end
+
+    test "applies a policy set to the workspace" do
+      {org, ws} = org_workspace()
+      set = policy_set_fixture!("no-rm-rf")
+
+      {:ok, view, _html} =
+        live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
+
+      html = submit_apply(view, %{"policy_set_id" => "#{set.id}", "precedence" => "10"})
+
+      assert html =~ "Policy set applied."
+      assert html =~ "no-rm-rf"
+      assert html =~ "precedence 10"
+      # Applied set leaves the available dropdown.
+      refute has_element?(view, "#policy-set-select option[value='#{set.id}']")
+
+      assert [%{policy_set_id: set_id, precedence: 10}] =
+               Platform.list_workspace_policy_sets(ws.id)
+
+      assert set_id == set.id
+    end
+
+    test "re-applying via upsert updates precedence" do
+      {org, ws} = org_workspace()
+      set = policy_set_fixture!("upsert-me")
+      {:ok, _} = Platform.apply_policy_set(ws.id, set.id, %{precedence: 10})
+
+      {:ok, view, _html} =
+        live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
+
+      # The set is already applied so it is not in the dropdown; remove then
+      # re-apply with a new precedence through the form.
+      render_click(view, "remove_policy_set", %{"policy-set-id" => "#{set.id}"})
+      submit_apply(view, %{"policy_set_id" => "#{set.id}", "precedence" => "42"})
+
+      assert [%{precedence: 42}] = Platform.list_workspace_policy_sets(ws.id)
+    end
+
+    test "apply with a non-numeric precedence flashes an error" do
+      {org, ws} = org_workspace()
+      set = policy_set_fixture!("bad-prec")
+
+      {:ok, view, _html} =
+        live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
+
+      html = submit_apply(view, %{"policy_set_id" => "#{set.id}", "precedence" => "abc"})
+
+      assert html =~ "Choose a policy set and a non-negative precedence."
+      assert Platform.list_workspace_policy_sets(ws.id) == []
+    end
+
+    test "apply with an out-of-range precedence flashes an error instead of crashing" do
+      {org, ws} = org_workspace()
+      set = policy_set_fixture!("huge-prec")
+
+      {:ok, view, _html} =
+        live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
+
+      html =
+        submit_apply(view, %{
+          "policy_set_id" => "#{set.id}",
+          "precedence" => "99999999999999999999"
+        })
+
+      assert html =~ "precedence"
+      assert html =~ "less than or equal to"
+      assert Platform.list_workspace_policy_sets(ws.id) == []
+      # The view survived the failed insert.
+      assert render(view) =~ "Workspace settings"
+    end
+
+    test "removes an applied policy set" do
+      {org, ws} = org_workspace()
+      set = policy_set_fixture!("remove-me")
+      {:ok, _} = Platform.apply_policy_set(ws.id, set.id, %{precedence: 5})
+
+      {:ok, view, _html} =
+        live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
+
+      html = render_click(view, "remove_policy_set", %{"policy-set-id" => "#{set.id}"})
+
+      assert html =~ "Policy set removed."
+      assert Platform.list_workspace_policy_sets(ws.id) == []
+      # Back in the dropdown once removed.
+      assert has_element?(view, "#policy-set-select option[value='#{set.id}']")
+    end
+
+    test "remove with an invalid policy set id flashes an error" do
+      {org, ws} = org_workspace()
+
+      {:ok, view, _html} =
+        live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
+
+      html = render_click(view, "remove_policy_set", %{"policy-set-id" => "abc"})
+
+      assert html =~ "Invalid policy set id."
+    end
+
+    test "tool picker adds and removes selected tools" do
+      {org, ws} = org_workspace()
+
+      {:ok, view, html} =
+        live(
+          build_conn(),
+          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=tool_policy"
+        )
+
+      assert html =~ "No tools selected."
+
+      # Fresh workspaces inherit, which disables the picker; pick a mode first.
+      view
+      |> element("#tool-policy-mode")
+      |> render_change(%{"policy" => %{"mode" => "allowlist"}})
+
+      view
+      |> element("#tool-policy-picker")
+      |> render_change(%{"tool_picker" => "ck_validate"})
+
+      assert has_element?(view, "button[phx-value-tool='ck_validate']")
+      # Picked tool leaves the picker options.
+      refute has_element?(view, "#tool-policy-picker option[value='ck_validate']")
+      # Duplicate picks are ignored.
+      view
+      |> element("#tool-policy-picker")
+      |> render_change(%{"tool_picker" => "ck_validate"})
+
+      chip_count =
+        (render(view) |> String.split("phx-value-tool=\"ck_validate\"") |> length()) - 1
+
+      assert chip_count == 1
+
+      render_click(view, "remove_tool", %{"tool" => "ck_validate"})
+
+      refute has_element?(view, "button[phx-value-tool='ck_validate']")
+    end
+
+    test "submit persists an allowlist policy with the picked tools" do
+      {org, ws} = org_workspace()
+
+      {:ok, view, _html} =
+        live(
+          build_conn(),
+          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=tool_policy"
+        )
+
+      view
+      |> element("#tool-policy-mode")
+      |> render_change(%{"policy" => %{"mode" => "allowlist"}})
+
+      view
+      |> element("#tool-policy-picker")
+      |> render_change(%{"tool_picker" => "ck_validate"})
+
+      html =
+        view
+        |> element("#workspace-tool-policy-form")
+        |> render_submit(%{"policy" => %{"mode" => "allowlist"}})
+
+      assert html =~ "Agent tools policy saved (allowlist)."
+
+      policy = Accounts.get_workspace_tool_policy(ws.id)
+      assert policy.mode == "allowlist"
+      assert WorkspaceToolPolicy.decode_tools(policy) == ["ck_validate"]
+    end
+
+    test "submitting inherit clears previously stored tools" do
+      {org, ws} = org_workspace()
+      Accounts.set_workspace_tool_policy(ws.id, "allowlist", ["ck_validate"])
+
+      {:ok, view, _html} =
+        live(
+          build_conn(),
+          ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings?tab=tool_policy"
+        )
+
+      # Stored tools are shown as chips on mount.
+      assert has_element?(view, "button[phx-value-tool='ck_validate']")
+
+      view
+      |> element("#tool-policy-mode")
+      |> render_change(%{"policy" => %{"mode" => "inherit"}})
+
+      html =
+        view
+        |> element("#workspace-tool-policy-form")
+        |> render_submit(%{"policy" => %{"mode" => "inherit"}})
+
+      assert html =~ "Agent tools policy saved (inherit)."
+
+      policy = Accounts.get_workspace_tool_policy(ws.id)
+      assert policy.mode == "inherit"
+      # Inherit never keeps stale selections around.
+      assert WorkspaceToolPolicy.decode_tools(policy) == []
+    end
+
+    test "redirects for an unknown workspace id" do
+      {:ok, _org} = Accounts.create_org(%{name: "None", slug: "none"})
+
+      assert {:error, {:live_redirect, %{to: "/organizations", flash: %{"error" => msg}}}} =
+               live(build_conn(), ~p"/organizations/none/workspaces/999999/settings")
+
+      assert msg =~ "Workspace not found."
+    end
+
+    test "redirects when the workspace belongs to a different org slug" do
+      {_org_a, ws} = org_workspace()
+
+      assert {:error, {:live_redirect, %{to: "/organizations", flash: %{"error" => msg}}}} =
+               live(build_conn(), ~p"/organizations/other-org/workspaces/#{ws.id}/settings")
+
+      assert msg =~ "does not belong to this organization"
+    end
+  end
+
+  describe "cloud mode org scoping" do
+    setup do
+      original = Application.get_env(:controlkeel, :runtime_mode)
+      Application.put_env(:controlkeel, :runtime_mode, :cloud)
+
+      on_exit(fn ->
+        if is_nil(original) do
+          Application.delete_env(:controlkeel, :runtime_mode)
+        else
+          Application.put_env(:controlkeel, :runtime_mode, original)
+        end
+      end)
+
+      :ok
+    end
+
+    defp add_active_membership(user_id, org_id, role) do
+      %Membership{}
+      |> Membership.changeset(%{user_id: user_id, org_id: org_id, role: role, status: "active"})
+      |> Repo.insert!()
+    end
+
+    test "an org admin can open workspace settings" do
+      owner = create_user!("settings-owner@example.com")
+      {:ok, org} = Accounts.create_org_with_owner(owner.id, %{name: "AdminCo", slug: "adminco"})
+      ws = create_workspace(%{name: "AdminWs", slug: "adminws", industry: "web", org_id: org.id})
+
+      admin = create_user!("settings-admin@example.com")
+      add_active_membership(admin.id, org.id, "admin")
+
+      conn =
+        build_conn()
+        |> Plug.Test.init_test_session(%{
+          "current_user_id" => admin.id,
+          "current_org_id" => org.id
+        })
+
+      {:ok, _view, html} = live(conn, ~p"/organizations/adminco/workspaces/#{ws.id}/settings")
+
+      assert html =~ "Workspace settings"
+    end
+
+    test "a viewer role member is refused access" do
+      owner = create_user!("settings-view-owner@example.com")
+
+      {:ok, org} =
+        Accounts.create_org_with_owner(owner.id, %{name: "ViewerCo", slug: "viewerco"})
+
+      ws =
+        create_workspace(%{name: "ViewerWs", slug: "viewerws", industry: "web", org_id: org.id})
+
+      viewer = create_user!("settings-viewer@example.com")
+      add_active_membership(viewer.id, org.id, "viewer")
+
+      conn =
+        build_conn()
+        |> Plug.Test.init_test_session(%{
+          "current_user_id" => viewer.id,
+          "current_org_id" => org.id
+        })
+
+      assert {:error, {:live_redirect, %{to: "/organizations", flash: %{"error" => msg}}}} =
+               live(conn, ~p"/organizations/viewerco/workspaces/#{ws.id}/settings")
+
+      assert msg =~ "Admin or owner role required."
+    end
+
+    test "a user outside the org is refused access" do
+      owner_a = create_user!("settings-a@example.com")
+      {:ok, org_a} = Accounts.create_org_with_owner(owner_a.id, %{name: "SetA", slug: "seta"})
+
+      ws_a =
+        create_workspace(%{name: "Secret", slug: "secret", industry: "web", org_id: org_a.id})
+
+      outsider = create_user!("settings-b@example.com")
+      {:ok, org_b} = Accounts.create_org_with_owner(outsider.id, %{name: "SetB", slug: "setb"})
+
+      conn =
+        build_conn()
+        |> Plug.Test.init_test_session(%{
+          "current_user_id" => outsider.id,
+          "current_org_id" => org_b.id
+        })
+
+      assert {:error, {:live_redirect, %{to: "/organizations", flash: %{"error" => msg}}}} =
+               live(conn, ~p"/organizations/seta/workspaces/#{ws_a.id}/settings")
+
+      assert msg =~ "Workspace belongs to a different organization."
+    end
+  end
+end

--- a/test/controlkeel_web/live/workspace_settings_live_test.exs
+++ b/test/controlkeel_web/live/workspace_settings_live_test.exs
@@ -206,9 +206,99 @@ defmodule ControlKeelWeb.WorkspaceSettingsLiveTest do
       html = render_click(view, "remove_policy_set", %{"policy-set-id" => "#{set.id}"})
 
       assert html =~ "Policy set removed."
-      assert Platform.list_workspace_policy_sets(ws.id) == []
+      assert Platform.list_workspace_policy_assignments(ws.id) == []
       # Back in the dropdown once removed.
       assert has_element?(view, "#policy-set-select option[value='#{set.id}']")
+    end
+
+    test "disabled assignments are listed with a marker and kept out of the dropdown" do
+      {org, ws} = org_workspace()
+      set = policy_set_fixture!("paused-set")
+      {:ok, _} = Platform.apply_policy_set(ws.id, set.id, %{"enabled" => false})
+
+      {:ok, view, html} =
+        live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
+
+      assert html =~ "paused-set"
+      assert html =~ "precedence 100"
+      assert html =~ ", disabled"
+      # The disabled row still occupies the assignment slot: re-applying via
+      # the dropdown would silently flip it to enabled, so it is not offered.
+      refute has_element?(view, "#policy-set-select option[value='#{set.id}']")
+      # Removing the disabled assignment works without an enabled re-apply.
+      html = render_click(view, "remove_policy_set", %{"policy-set-id" => "#{set.id}"})
+      assert html =~ "Policy set removed."
+      assert Platform.list_workspace_policy_assignments(ws.id) == []
+    end
+
+    test "toggle_assignment disables an enabled assignment and stops rule evaluation" do
+      {org, ws} = org_workspace()
+      set = policy_set_fixture!("toggle-off")
+      {:ok, _} = Platform.apply_policy_set(ws.id, set.id, %{precedence: 25})
+
+      {:ok, view, _html} =
+        live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
+
+      html =
+        render_click(
+          view,
+          "toggle_assignment",
+          %{"policy-set-id" => "#{set.id}"}
+        )
+
+      assert html =~ "Policy set disabled."
+      assert html =~ ", disabled"
+
+      assert [%{enabled: false, precedence: 25}] =
+               Platform.list_workspace_policy_assignments(ws.id)
+
+      # Disabled assignments no longer participate in rule evaluation.
+      assert Platform.list_workspace_policy_sets(ws.id) == []
+    end
+
+    test "toggle_assignment re-enables a disabled assignment preserving precedence" do
+      {org, ws} = org_workspace()
+      set = policy_set_fixture!("toggle-on")
+      {:ok, _} = Platform.apply_policy_set(ws.id, set.id, %{precedence: 15, enabled: false})
+
+      {:ok, view, _html} =
+        live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
+
+      assert has_element?(
+               view,
+               "button[phx-click='toggle_assignment'][phx-value-policy-set-id='#{set.id}']",
+               "Enable"
+             )
+
+      html =
+        render_click(
+          view,
+          "toggle_assignment",
+          %{"policy-set-id" => "#{set.id}"}
+        )
+
+      assert html =~ "Policy set enabled."
+      refute html =~ ", disabled"
+
+      assert [%{enabled: true, precedence: 15}] =
+               Platform.list_workspace_policy_assignments(ws.id)
+
+      assert [%{policy_set_id: set_id}] = Platform.list_workspace_policy_sets(ws.id)
+      assert set_id == set.id
+    end
+
+    test "toggle_assignment with an unknown policy set id flashes an error" do
+      {org, ws} = org_workspace()
+      set = policy_set_fixture!("not-toggled")
+      {:ok, _} = Platform.apply_policy_set(ws.id, set.id, %{precedence: 1})
+
+      {:ok, view, _html} =
+        live(build_conn(), ~p"/organizations/#{org.slug}/workspaces/#{ws.id}/settings")
+
+      html = render_click(view, "toggle_assignment", %{"policy-set-id" => "999999"})
+
+      assert html =~ "Policy set assignment not found."
+      assert [%{enabled: true}] = Platform.list_workspace_policy_assignments(ws.id)
     end
 
     test "remove with an invalid policy set id flashes an error" do


### PR DESCRIPTION
## Summary

Policy sets are now fully manageable from the web. Policy Studio (`/policies`) lists and creates DB-backed policy sets alongside the built-in JSON packs, and a new workspace settings page handles per-workspace assignment management. Workspace detail gains a read-only governance section.

## What changed

### Issue #117 scope

- **Policy Studio** (`lib/controlkeel_web/live/policy_studio_live.ex`)
  - Lists all DB policy sets with rule counts, status, and per-workspace assignment summaries (`Platform.list_policy_sets/1` + `list_workspace_policy_assignments/1`).
  - Create modal with a JSON rules editor validated against the same entry shape `PolicySet.changeset/2` enforces; changeset errors render inline.
- **Workspace settings** (`lib/controlkeel_web/live/workspace_settings_live.ex`, route `/organizations/:slug/workspaces/:id/settings`)
  - `policies` tab: apply/remove/toggle policy set assignments with precedence (upsert semantics via `Platform.apply_policy_set/3`).
  - `agent_tools` tab: the MCP tool gate editor (same model as the standalone `/workspaces/:id/tool-policy` page).
- **Workspace detail** (`workspace_detail_live.ex`) — read-only governance section: applied policy sets and tool-policy mode summary.
- **Platform** (`lib/controlkeel/platform.ex`) — `list_workspace_policy_sets/1` (enabled-only, evaluation path), `list_workspace_policy_assignments/1` (display counterpart), `remove_workspace_policy_set/2`. Precedence validated to the int4 range (0..2^31-1).

### Beyond the issue (reviewed and ruled on)

- **Auth model** (operator-specified):
  - Local mode: no auth; single-user context.
  - Cloud mode: org and workspace pages require membership of the workspace's org (view); workspace settings require admin/owner role — same guard as `WorkspaceToolPolicyLive`.
  - Policy set creation on `/policies` is intentionally open to all members regardless of intended use (operator ruling, recorded in code).
  - Cross-org visibility of assignment summaries on `/policies` is accepted for now; tightening deferred to a future auth pass (TODO in code).
- **Breadcrumbs** — `Layouts.dashboard_header` support, workspace pages wired.
- **UI infra** — reusable modal + `rule_tag` components; tool policy renamed to "Agent tools" in navigation and tab param (`?tab=agent_tools`).
- **Tool policy storage** — `Accounts.set_workspace_tool_policy/3` now drops the tools list when mode is `inherit` (inert data never stored). This is CLI/API-visible; called out for reviewer attention.

## Tests

- New: `workspace_settings_live_test.exs` (522 lines), policy studio suite expanded, platform precedence tests.
- Auth coverage: local-mode open access, cloud member view, cloud viewer refused settings ("Admin or owner role required."), cross-org refused, admin allowed.
- `mix precommit`: full suite green (one MCP stdout test flake on first run was a compile-output artifact; passes standalone).
