### PR TITLE
⚡ Bolt: optimize distinct session count in mission clusters

### DIFF
--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -2784,7 +2784,7 @@ defmodule ControlKeel.Mission do
     |> Enum.group_by(fn pattern -> {pattern["type"], pattern["code"]} end)
     |> Enum.map(fn {{type, code}, rows} ->
       severity = rows |> Enum.map(&(&1["severity"] || "low")) |> Enum.max_by(&severity_rank/1)
-      sessions = rows |> Enum.map(& &1["session_id"]) |> Enum.uniq()
+      session_count = rows |> MapSet.new(& &1["session_id"]) |> MapSet.size()
       titles = rows |> Enum.map(& &1["title"]) |> Enum.reject(&is_nil/1) |> Enum.uniq()
 
       %{
@@ -2792,7 +2792,8 @@ defmodule ControlKeel.Mission do
         "code" => code,
         "severity" => severity,
         "count" => length(rows),
-        "session_count" => length(sessions),
+        # Bolt: Avoid intermediate list allocation for distinct count
+        "session_count" => session_count,
         "titles" => Enum.take(titles, 3),
         "summary" => cluster_summary(rows),
         "examples" =>


### PR DESCRIPTION
💡 **What**: Replaced intermediate list allocation for distinct session counting (`Enum.map/2 |> Enum.uniq/1 |> length/1`) with direct set sizing (`MapSet.new/2 |> MapSet.size()`) in `lib/controlkeel/mission.ex`.

🎯 **Why**: When building failure clusters, creating intermediate lists of mapped session IDs just to count the distinct elements creates unnecessary garbage collection overhead, particularly with large numbers of failures.

📊 **Impact**: Skips intermediate list creation, reducing GC pressure and marginally improving performance when processing large session logs.

🔬 **Measurement**: Benchmark `build_failure_clusters/1` on a list of large error patterns. The memory allocation should be lower, keeping performance stable under heavier load.

---
*PR created automatically by Jules for task [16019318508067772838](https://jules.google.com/task/16019318508067772838) started by @aryaminus*