### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to sidebar toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-26 - Dynamic ARIA Labels in Loops
+**Learning:** When adding ARIA labels to toggle buttons inside dynamically rendered loops (e.g., sidebar nav items in `layouts.ex`), the label must interpolate the unique item context (e.g., `aria-label={"Toggle #{item.label} menu"}`) instead of a static generic string. A static string like "Toggle menu" creates duplicate ambiguous announcements for screen readers.
+**Action:** Always inspect the surrounding scope for loop variables when adding accessibility attributes to ensure they provide distinct context per item.

--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -62,6 +62,7 @@ defmodule ControlKeelWeb.Layouts do
                 data-sidebar-toggle
                 aria-expanded={(opened && "true") || "false"}
                 aria-controls={collapse_id}
+                aria-label={"Toggle #{item.label} menu"}
                 class={["w-full text-left cursor-pointer", sidebar_link_class(active)]}
               >
                 <.icon name={item.icon} class={sidebar_icon_class(active)} />


### PR DESCRIPTION
### 💡 What
Added a dynamic `aria-label` to the sidebar navigation toggle button in `lib/controlkeel_web/components/layouts.ex`.

### 🎯 Why
The sidebar toggle button was an icon-only button without any accessible name. Screen reader users would hear an unlabelled button, making it difficult to understand its purpose.

### 📸 Before/After
**Before:** `<button ...> <.icon ... /> <span>Label</span> <.icon ... /> </button>` (without `aria-label`)
**After:** `<button aria-label="Toggle Dashboard menu" ...> <.icon ... /> <span>Label</span> <.icon ... /> </button>`

### ♿ Accessibility
- Improves navigation by explicitly stating the purpose of the sidebar toggle button for assistive technologies.
- Interpolates the specific item label into the ARIA label so each toggle button in the loop has a unique and descriptive accessible name (e.g., "Toggle Dashboard menu", "Toggle Sessions menu").

---
*PR created automatically by Jules for task [12833465215209054001](https://jules.google.com/task/12833465215209054001) started by @aryaminus*