### PR TITLE
⚡ Bolt: [performance improvement] Optimize unique element counting

### DIFF
--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -270,7 +270,8 @@ defmodule ControlKeel.Benchmark do
   # itself), so we skip the recompute and keep the export payload lean. The
   # explicit `benchmark compare <id>` command always computes a comparison.
   defp maybe_comparison(%Run{subjects: subjects} = run) when is_list(subjects) do
-    if length(Enum.uniq(subjects)) >= 2, do: compare_run(run), else: nil
+    # Bolt: Avoid Enum.uniq |> length() to eliminate intermediate list allocation
+    if MapSet.size(MapSet.new(subjects)) >= 2, do: compare_run(run), else: nil
   end
 
   defp maybe_comparison(_run), do: nil

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -2784,7 +2784,8 @@ defmodule ControlKeel.Mission do
     |> Enum.group_by(fn pattern -> {pattern["type"], pattern["code"]} end)
     |> Enum.map(fn {{type, code}, rows} ->
       severity = rows |> Enum.map(&(&1["severity"] || "low")) |> Enum.max_by(&severity_rank/1)
-      sessions = rows |> Enum.map(& &1["session_id"]) |> Enum.uniq()
+      # Bolt: Replaced intermediate list mapping and Enum.uniq() with MapSet.new() to avoid allocations.
+      sessions = rows |> MapSet.new(& &1["session_id"])
       titles = rows |> Enum.map(& &1["title"]) |> Enum.reject(&is_nil/1) |> Enum.uniq()
 
       %{
@@ -2792,7 +2793,7 @@ defmodule ControlKeel.Mission do
         "code" => code,
         "severity" => severity,
         "count" => length(rows),
-        "session_count" => length(sessions),
+        "session_count" => MapSet.size(sessions),
         "titles" => Enum.take(titles, 3),
         "summary" => cluster_summary(rows),
         "examples" =>


### PR DESCRIPTION
### 💡 What
Replaced intermediate list allocations when counting unique elements.
Specifically:
- Changed `Enum.map |> Enum.uniq |> length` to `MapSet.new |> MapSet.size()` in `lib/controlkeel/mission.ex`.
- Changed `Enum.uniq |> length` to `MapSet.new |> MapSet.size()` in `lib/controlkeel/benchmark.ex`.

### 🎯 Why
Chaining `Enum.map/2` into `Enum.uniq/1` and then `length/1` forces the creation of intermediate lists in Elixir. By using `MapSet.new/2` or `MapSet.new/1` and directly requesting the size, we avoid the overhead of allocating and garbage collecting these temporary lists, improving execution efficiency.

### 📊 Impact
Reduces memory overhead and garbage collection pressure in areas where unique item counting is performed, particularly when dealing with large datasets or frequent operations.

### 🔬 Measurement
Run application profiling or micro-benchmarking on the modified functions. The garbage collection runs should decrease, and the execution time should remain identical or slightly improve due to avoided intermediate lists. Note that a journal entry has been added to `.jules/bolt.md` documenting this optimization.

---
*PR created automatically by Jules for task [16654426800614164338](https://jules.google.com/task/16654426800614164338) started by @aryaminus*