### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -270,7 +270,8 @@ defmodule ControlKeel.Benchmark do
   # itself), so we skip the recompute and keep the export payload lean. The
   # explicit `benchmark compare <id>` command always computes a comparison.
   defp maybe_comparison(%Run{subjects: subjects} = run) when is_list(subjects) do
-    if length(Enum.uniq(subjects)) >= 2, do: compare_run(run), else: nil
+    # Optimized: Use MapSet.size/1 and MapSet.new/1 instead of Enum.uniq/1 and length/1 to avoid intermediate list allocations
+    if MapSet.size(MapSet.new(subjects)) >= 2, do: compare_run(run), else: nil
   end
 
   defp maybe_comparison(_run), do: nil

--- a/lib/controlkeel/governance/tech_debt_detector.ex
+++ b/lib/controlkeel/governance/tech_debt_detector.ex
@@ -84,9 +84,10 @@ defmodule ControlKeel.Governance.TechDebtDetector do
     |> Enum.reject(&tech_debt_rule?/1)
     |> Enum.group_by(& &1.rule_id)
     |> Enum.flat_map(fn {rule_id, items} ->
-      distinct_sessions = items |> Enum.map(& &1.session_id) |> Enum.uniq()
+      # Optimized: Use MapSet.new/2 instead of Enum.map/2 and Enum.uniq/1 to avoid intermediate list allocations
+      distinct_sessions = items |> MapSet.new(& &1.session_id)
 
-      if length(distinct_sessions) >= threshold do
+      if MapSet.size(distinct_sessions) >= threshold do
         [build_unresolved_pattern_signal(rule_id, items, distinct_sessions)]
       else
         []
@@ -150,7 +151,7 @@ defmodule ControlKeel.Governance.TechDebtDetector do
       recent_session_ids: Enum.sort(distinct_sessions),
       message:
         "Rule #{rule_id} fired #{length(items)} times across " <>
-          "#{length(distinct_sessions)} sessions without resolution"
+          "#{MapSet.size(distinct_sessions)} sessions without resolution"
     }
   end
 end


### PR DESCRIPTION
What: Replaced uses of `Enum.map/2 |> Enum.uniq/1 |> length/1` and `Enum.uniq/1 |> length/1` with `MapSet.new/2 |> MapSet.size()` and `MapSet.new/1 |> MapSet.size()`.
Why: Intermediate list allocations incur unnecessary memory overhead and Garbage Collection pressure during distinct counting.
Impact: Decreases memory consumption and improves execution speed for list operations.
Measurement: Performance improvements can be measured with memory profiling during operations handling large inputs where these counting patterns are used.

---
*PR created automatically by Jules for task [14020040401573267323](https://jules.google.com/task/14020040401573267323) started by @aryaminus*