### PR TITLE
security(web): shared session-access gate + auth-gate observability export

### DIFF
--- a/lib/controlkeel/accounts.ex
+++ b/lib/controlkeel/accounts.ex
@@ -634,6 +634,29 @@ defmodule ControlKeel.Accounts do
   end
 
   @doc """
+  Shared session-access gate for org-scoped surfaces.
+
+  Returns `true` when `session` is accessible from `org_id`:
+
+    * `org_id` is `nil` (local mode, or no org selected) — passthrough.
+    * otherwise the session's workspace must belong to the org.
+
+  Every web surface that renders org-scoped session data should route its
+  access decision through this predicate instead of copying the
+  workspace-membership check per view (issue #83).
+  """
+  @spec session_accessible?(%{workspace_id: integer() | nil}, integer() | nil) :: boolean()
+  def session_accessible?(_session, nil), do: true
+
+  def session_accessible?(%{workspace_id: ws_id}, org_id) when is_integer(org_id) do
+    org_id
+    |> list_workspaces_for_org()
+    |> Enum.any?(&(&1.id == ws_id))
+  end
+
+  def session_accessible?(_session, _org_id), do: true
+
+  @doc """
   List workspaces visible to a user through their active memberships.
 
   Returns workspaces of every org where the user has an `active` membership.

--- a/lib/controlkeel_web/controllers/observability_controller.ex
+++ b/lib/controlkeel_web/controllers/observability_controller.ex
@@ -1,10 +1,10 @@
 defmodule ControlKeelWeb.ObservabilityController do
   use ControlKeelWeb, :controller
 
-  # TODO: Add `plug ControlKeelWeb.Plugs.RequireSessionAuth` when OAuth/session auth
-  # lands (refactor/web-auth). Should mirror LiveAuth.require_cloud_auth: passthrough
-  # in local mode, require membership in cloud/self_hosted, verify org ownership of
-  # the session's workspace to prevent cross-org data leakage.
+  # Mirrors LiveAuth.require_cloud_auth: passthrough in local mode, requires a
+  # signed-in user in cloud/self_hosted, and verifies org ownership of the
+  # session's workspace to prevent cross-org data leakage (CK-AUTH-001).
+  plug ControlKeelWeb.Plugs.RequireSessionAuth
 
   alias ControlKeel.Observability.Telemetry
 

--- a/lib/controlkeel_web/live/deploy_review_live.ex
+++ b/lib/controlkeel_web/live/deploy_review_live.ex
@@ -7,6 +7,7 @@ defmodule ControlKeelWeb.DeployReviewLive do
 
   use ControlKeelWeb, :live_view
 
+  alias ControlKeel.Accounts
   alias ControlKeel.Mission
   alias ControlKeel.Ops.DeploymentAdvisor
   alias ControlKeel.Ops.HostingCost
@@ -30,7 +31,7 @@ defmodule ControlKeelWeb.DeployReviewLive do
          |> push_navigate(to: ~p"/")}
 
       session when not is_nil(org_id) and not is_nil(session) ->
-        if session_accessible?(session, org_id) do
+        if Accounts.session_accessible?(session, org_id) do
           {:ok, mount_session(socket, session)}
         else
           {:ok,
@@ -320,10 +321,4 @@ defmodule ControlKeelWeb.DeployReviewLive do
   end
 
   defp parse_non_negative_int(_value, default), do: default
-
-  defp session_accessible?(%{workspace_id: ws_id}, org_id) when is_integer(org_id) do
-    org_id
-    |> ControlKeel.Accounts.list_workspaces_for_org()
-    |> Enum.any?(fn ws -> ws.id == ws_id end)
-  end
 end

--- a/lib/controlkeel_web/live/mission_control_live.ex
+++ b/lib/controlkeel_web/live/mission_control_live.ex
@@ -24,7 +24,7 @@ defmodule ControlKeelWeb.MissionControlLive do
          |> push_navigate(to: ~p"/")}
 
       session when not is_nil(org_id) and not is_nil(session) ->
-        if session_accessible?(session, org_id) do
+        if ControlKeel.Accounts.session_accessible?(session, org_id) do
           if connected?(socket), do: schedule_refresh()
           project_root = socket.endpoint.config(:project_root) || File.cwd!()
 
@@ -1355,11 +1355,5 @@ defmodule ControlKeelWeb.MissionControlLive do
       total_findings: 0,
       blocked_findings_total: 0
     }
-  end
-
-  defp session_accessible?(%{workspace_id: ws_id}, org_id) when is_integer(org_id) do
-    org_id
-    |> ControlKeel.Accounts.list_workspaces_for_org()
-    |> Enum.any?(fn ws -> ws.id == ws_id end)
   end
 end

--- a/lib/controlkeel_web/live/observability_live.ex
+++ b/lib/controlkeel_web/live/observability_live.ex
@@ -1,6 +1,7 @@
 defmodule ControlKeelWeb.ObservabilityLive do
   use ControlKeelWeb, :live_view
 
+  alias ControlKeel.Accounts
   alias ControlKeel.Observability
   alias ControlKeelWeb.CommandPill
 
@@ -13,7 +14,7 @@ defmodule ControlKeelWeb.ObservabilityLive do
 
     case Observability.session_run(id) do
       {:ok, run} ->
-        if org_owns_session?(org_id, run.session) do
+        if Accounts.session_accessible?(run.session, org_id) do
           {:ok,
            socket
            |> assign(:page_title, "Observability — #{run.session.title}")
@@ -34,16 +35,6 @@ defmodule ControlKeelWeb.ObservabilityLive do
          |> push_navigate(to: ~p"/")}
     end
   end
-
-  defp org_owns_session?(nil, _session), do: true
-
-  defp org_owns_session?(org_id, %{workspace_id: ws_id}) when is_integer(org_id) do
-    org_id
-    |> ControlKeel.Accounts.list_workspaces_for_org()
-    |> Enum.any?(fn ws -> ws.id == ws_id end)
-  end
-
-  defp org_owns_session?(_org_id, _session), do: true
 
   @impl true
   def render(assigns) do

--- a/lib/controlkeel_web/live/review_live.ex
+++ b/lib/controlkeel_web/live/review_live.ex
@@ -1,6 +1,7 @@
 defmodule ControlKeelWeb.ReviewLive do
   use ControlKeelWeb, :live_view
 
+  alias ControlKeel.Accounts
   alias ControlKeel.Mission
 
   @impl true
@@ -13,29 +14,26 @@ defmodule ControlKeelWeb.ReviewLive do
      |> assign(:response_form, response_form())}
   end
 
-  # TODO(security): backend endpoints/contexts lack per-user auth/token checks.
-  # See https://github.com/aryaminus/controlkeel/issues/83
+  # Cross-session ownership is enforced by matching review.session_id against
+  # the sid path segment; org-level access is enforced via the shared
+  # Accounts.session_accessible?/2 gate (issue #83).
   @impl true
   def handle_params(%{"rid" => rid, "sid" => sid}, _uri, socket) do
     with {:ok, review_id} <- parse_integer(rid),
          {:ok, session_id} <- parse_integer(sid) do
       case Mission.get_review_with_context(review_id) do
         nil ->
-          {:noreply,
-           socket
-           |> put_flash(:error, "Review not found.")
-           |> assign(:review, nil)
-           |> assign(:diff_chunks, [])}
+          {:noreply, review_not_found(socket)}
 
         %{session_id: ^session_id} = review ->
-          {:noreply, assign_review(socket, review)}
+          if Accounts.session_accessible?(review.session, socket.assigns[:current_org_id]) do
+            {:noreply, assign_review(socket, review)}
+          else
+            {:noreply, review_not_found(socket)}
+          end
 
         _review ->
-          {:noreply,
-           socket
-           |> put_flash(:error, "Review not found.")
-           |> assign(:review, nil)
-           |> assign(:diff_chunks, [])}
+          {:noreply, review_not_found(socket)}
       end
     else
       :error ->
@@ -370,6 +368,13 @@ defmodule ControlKeelWeb.ReviewLive do
     |> assign(:page_title, review.title)
     |> assign(:diff_chunks, diff_chunks(review))
     |> assign(:response_form, response_form(review))
+  end
+
+  defp review_not_found(socket) do
+    socket
+    |> put_flash(:error, "Review not found.")
+    |> assign(:review, nil)
+    |> assign(:diff_chunks, [])
   end
 
   defp response_form(review \\ nil) do

--- a/lib/controlkeel_web/live/session_reviews_live.ex
+++ b/lib/controlkeel_web/live/session_reviews_live.ex
@@ -1,6 +1,7 @@
 defmodule ControlKeelWeb.SessionReviewsLive do
   use ControlKeelWeb, :live_view
 
+  alias ControlKeel.Accounts
   alias ControlKeel.Mission
 
   @refresh_interval_ms 2_000
@@ -17,7 +18,7 @@ defmodule ControlKeelWeb.SessionReviewsLive do
          |> push_navigate(to: ~p"/")}
 
       session when not is_nil(org_id) and not is_nil(session) ->
-        if session_accessible?(session, org_id) do
+        if Accounts.session_accessible?(session, org_id) do
           {:ok, mount_session(socket, session)}
         else
           {:ok,
@@ -143,10 +144,4 @@ defmodule ControlKeelWeb.SessionReviewsLive do
   defp review_status_pill_class(_status),
     do:
       "inline-flex rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1 bg-info/10 text-info ring-info/20"
-
-  defp session_accessible?(%{workspace_id: ws_id}, org_id) when is_integer(org_id) do
-    org_id
-    |> ControlKeel.Accounts.list_workspaces_for_org()
-    |> Enum.any?(fn ws -> ws.id == ws_id end)
-  end
 end

--- a/lib/controlkeel_web/plugs/require_session_auth.ex
+++ b/lib/controlkeel_web/plugs/require_session_auth.ex
@@ -1,0 +1,97 @@
+defmodule ControlKeelWeb.Plugs.RequireSessionAuth do
+  @moduledoc """
+  Controller-side counterpart of `LiveAuth.require_cloud_auth` for
+  session-scoped, non-LiveView routes (issue #123 item 4a, CK-AUTH-001).
+
+  Semantics mirror the LiveView on_mount hook:
+
+    * **local mode** — passthrough (no user model exists locally).
+    * **cloud/self_hosted mode** — requires a signed-in user
+      (`conn.assigns.current_user`, loaded by `LoadCurrentUser`); otherwise
+      halts with `401` JSON.
+
+  When the request path carries a session `id` param, the plug additionally
+  resolves that ControlKeel session and enforces org ownership through the
+  shared `Accounts.session_accessible?/2` gate: a missing session or a
+  session whose workspace belongs to another org halts with `404` JSON
+  (existence is not leaked). Routes without an `id` path param only get the
+  authentication check.
+
+  Expected to run inside the `:browser` pipeline so `LoadCurrentUser` has
+  already populated `current_user` / `current_org_id`.
+  """
+
+  import Plug.Conn
+  alias ControlKeel.Accounts
+  alias ControlKeel.Mission
+  alias ControlKeel.Runtime.Mode
+
+  @behaviour Plug
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(conn, _opts) do
+    if Mode.current() == :local do
+      conn
+    else
+      conn
+      |> require_user()
+      |> authorize_session_access()
+    end
+  end
+
+  defp require_user(%{assigns: %{current_user: %{} = _user}} = conn), do: conn
+
+  defp require_user(conn) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(:unauthorized, Jason.encode!(%{error: "sign in required"}))
+    |> halt()
+  end
+
+  defp authorize_session_access(conn) do
+    case session_id(conn) do
+      nil ->
+        conn
+
+      id ->
+        case resolve_session(id) do
+          nil -> not_found(conn)
+          session -> check_org_access(conn, session)
+        end
+    end
+  end
+
+  defp session_id(conn) do
+    case Map.get(conn.path_params, "id") do
+      binary when is_binary(binary) ->
+        case Integer.parse(binary) do
+          {id, ""} when id > 0 -> id
+          _ -> nil
+        end
+
+      other ->
+        other
+    end
+  end
+
+  defp resolve_session(id) when is_integer(id), do: Mission.get_session_context(id)
+  defp resolve_session(_id), do: nil
+
+  defp check_org_access(conn, session) do
+    if Accounts.session_accessible?(session, conn.assigns[:current_org_id]) do
+      conn
+    else
+      not_found(conn)
+    end
+  end
+
+  defp not_found(conn) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(:not_found, Jason.encode!(%{error: "session not found"}))
+    |> halt()
+  end
+end

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -48,6 +48,10 @@ defmodule ControlKeelWeb.Router do
     plug ControlKeelWeb.Plugs.RequireCloudAuth
   end
 
+  pipeline :require_session_auth do
+    plug ControlKeelWeb.Plugs.RequireSessionAuth
+  end
+
   pipeline :proxy_api do
   end
 
@@ -162,7 +166,7 @@ defmodule ControlKeelWeb.Router do
 
   # Session export is authenticated in cloud/self_hosted (passthrough in local mode).
   scope "/", ControlKeelWeb do
-    pipe_through [:browser, :require_cloud_auth]
+    pipe_through [:browser, :require_session_auth]
 
     # Session export is auth-gated via Plugs.RequireSessionAuth (mirrors
     # LiveAuth.require_cloud_auth plus org ownership of the session).

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -164,6 +164,8 @@ defmodule ControlKeelWeb.Router do
   scope "/", ControlKeelWeb do
     pipe_through [:browser, :require_cloud_auth]
 
+    # Session export is auth-gated via Plugs.RequireSessionAuth (mirrors
+    # LiveAuth.require_cloud_auth plus org ownership of the session).
     get "/observability/sessions/:id/export.json", ObservabilityController, :export_session
   end
 

--- a/test/controlkeel_web/controllers/observability_controller_test.exs
+++ b/test/controlkeel_web/controllers/observability_controller_test.exs
@@ -1,0 +1,103 @@
+defmodule ControlKeelWeb.ObservabilityControllerTest do
+  use ControlKeelWeb.ConnCase, async: false
+
+  import ControlKeel.MissionFixtures
+
+  alias ControlKeel.Accounts
+  alias ControlKeel.Repo
+
+  describe "GET /observability/sessions/:id/export.json (local mode)" do
+    test "exports the session envelope without authentication", %{conn: conn} do
+      session = session_fixture()
+
+      conn = get(conn, ~p"/observability/sessions/#{session.id}/export.json")
+
+      body = json_response(conn, :ok)
+      assert body["integrity"]["session_id"] == session.id
+      assert is_binary(body["integrity"]["payload_sha256"])
+    end
+
+    test "returns 404 for an unknown session", %{conn: conn} do
+      conn = get(conn, "/observability/sessions/999999/export.json")
+      assert json_response(conn, :not_found) == %{"error" => "session not found"}
+    end
+  end
+
+  describe "GET /observability/sessions/:id/export.json (cloud mode)" do
+    setup do
+      original = Application.get_env(:controlkeel, :runtime_mode)
+      Application.put_env(:controlkeel, :runtime_mode, :cloud)
+
+      on_exit(fn ->
+        if is_nil(original) do
+          Application.delete_env(:controlkeel, :runtime_mode)
+        else
+          Application.put_env(:controlkeel, :runtime_mode, original)
+        end
+      end)
+
+      :ok
+    end
+
+    setup %{conn: conn} do
+      {:ok, org} =
+        Accounts.create_org(%{name: "Acme", slug: "acme-#{System.unique_integer([:positive])}"})
+
+      {:ok, user} =
+        Accounts.create_user(%{email: "acme-#{System.unique_integer([:positive])}@example.com"})
+
+      %Accounts.Membership{}
+      |> Accounts.Membership.changeset(%{
+        user_id: user.id,
+        org_id: org.id,
+        role: "admin",
+        status: "active"
+      })
+      |> Repo.insert!()
+
+      workspace = workspace_fixture(%{org_id: org.id})
+      session = session_fixture(%{workspace: workspace})
+
+      conn = init_test_session(conn, %{current_user_id: user.id, current_org_id: org.id})
+
+      {:ok, conn: conn, org: org, user: user, workspace: workspace, session: session}
+    end
+
+    test "unauthenticated requests are rejected with 401", %{session: session} do
+      conn = build_conn()
+      conn = get(conn, ~p"/observability/sessions/#{session.id}/export.json")
+
+      assert json_response(conn, :unauthorized) == %{"error" => "sign in required"}
+    end
+
+    test "authenticated requests for own-org sessions export the envelope", %{
+      conn: conn,
+      session: session
+    } do
+      conn = get(conn, ~p"/observability/sessions/#{session.id}/export.json")
+
+      body = json_response(conn, :ok)
+      assert body["integrity"]["session_id"] == session.id
+    end
+
+    test "sessions from another org are not exportable", %{conn: conn} do
+      {:ok, outsider_org} =
+        Accounts.create_org(%{
+          name: "Outsider",
+          slug: "outsider-#{System.unique_integer([:positive])}"
+        })
+
+      outsider_workspace = workspace_fixture(%{org_id: outsider_org.id})
+      outsider_session = session_fixture(%{workspace: outsider_workspace})
+
+      conn = get(conn, ~p"/observability/sessions/#{outsider_session.id}/export.json")
+
+      assert json_response(conn, :not_found) == %{"error" => "session not found"}
+    end
+
+    test "unknown sessions return 404 for authenticated users", %{conn: conn} do
+      conn = get(conn, "/observability/sessions/999999/export.json")
+      assert json_response(conn, :not_found) == %{"error" => "session not found"}
+    end
+  end
+end

--- a/test/controlkeel_web/live/review_live_test.exs
+++ b/test/controlkeel_web/live/review_live_test.exs
@@ -157,4 +157,61 @@ defmodule ControlKeelWeb.ReviewLiveTest do
 
     assert html =~ String.capitalize(revision.status)
   end
+
+  test "review live rejects reviews from sessions outside the current org", %{conn: conn} do
+    # Cloud-mode org scoping: the session belongs to a workspace of another
+    # org, so the signed-in user must not see the review (issue #83).
+    original = Application.get_env(:controlkeel, :runtime_mode)
+    Application.put_env(:controlkeel, :runtime_mode, :cloud)
+
+    on_exit(fn ->
+      if is_nil(original) do
+        Application.delete_env(:controlkeel, :runtime_mode)
+      else
+        Application.put_env(:controlkeel, :runtime_mode, original)
+      end
+    end)
+
+    alias ControlKeel.Accounts
+    alias ControlKeel.Repo
+
+    {:ok, my_org} =
+      Accounts.create_org(%{name: "Mine", slug: "mine-#{System.unique_integer([:positive])}"})
+
+    {:ok, user} =
+      Accounts.create_user(%{email: "me-#{System.unique_integer([:positive])}@example.com"})
+
+    %Accounts.Membership{}
+    |> Accounts.Membership.changeset(%{
+      user_id: user.id,
+      org_id: my_org.id,
+      role: "admin",
+      status: "active"
+    })
+    |> Repo.insert!()
+
+    {:ok, other_org} =
+      Accounts.create_org(%{name: "Theirs", slug: "theirs-#{System.unique_integer([:positive])}"})
+
+    other_workspace = workspace_fixture(%{org_id: other_org.id})
+    other_session = session_fixture(%{workspace: other_workspace})
+
+    task = task_fixture(%{session: other_session, status: "queued", title: "Cross-org plan"})
+
+    assert {:ok, review} =
+             Mission.submit_review(%{
+               "task_id" => task.id,
+               "review_type" => "plan",
+               "submission_body" => "Should be invisible cross-org"
+             })
+
+    conn =
+      conn
+      |> Plug.Test.init_test_session(%{current_user_id: user.id, current_org_id: my_org.id})
+
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{other_session.id}/reviews/#{review.id}")
+
+    assert html =~ "Review not found"
+    refute html =~ "Should be invisible cross-org"
+  end
 end


### PR DESCRIPTION
## Summary

Two related security fixes from the open issues:

1. **CK-AUTH-001 / #123 item 4a** — `GET /observability/sessions/:id/export.json` was completely unauthenticated (the router carried a TODO admitting it). Any caller could read a session's proof counts, budget, memory summaries, and integrity fingerprint by guessing ids. Fixed with `ControlKeelWeb.Plugs.RequireSessionAuth` — the controller-side mirror of `LiveAuth.require_cloud_auth`: passthrough in local mode, `401` JSON for unauthenticated cloud/self_hosted requests, `404` when the session's workspace belongs to another org (existence not leaked).

2. **#83 (partial)** — the session-access check was copy-pasted as a private `session_accessible?/2` in three LiveViews plus a variant `org_owns_session?/2` in a fourth, and `ReviewLive` had **no org gate at all** — it only matched `review.session_id == sid`, so any signed-in user could read and approve/deny another org's pending reviews. Fixed by:
   - consolidating the check into a single shared `Accounts.session_accessible?/2` gate
   - deduplicating all four per-view copies
   - applying the missing gate to `ReviewLive.handle_params` (cross-org renders the same "Review not found" as a missing review)

## Changes

| File | Change |
|---|---|
| `lib/controlkeel/accounts.ex` | + `session_accessible?/2` shared gate (nil org → passthrough; workspace-org membership otherwise) |
| `lib/controlkeel_web/plugs/require_session_auth.ex` | new plug: auth + org ownership of the path session id |
| `lib/controlkeel_web/controllers/observability_controller.ex` | plug wired in; TODO removed |
| `lib/controlkeel_web/router.ex` | TODO removed; route now gated via the controller plug |
| `lib/controlkeel_web/live/review_live.ex` | org gate on `handle_params`; `review_not_found/1` helper; security TODO removed |
| `mission_control_live.ex`, `session_reviews_live.ex`, `deploy_review_live.ex`, `observability_live.ex` | per-view copies replaced with the shared gate |

## Verification

- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` — clean
- `mix precommit` — **2246 tests, 0 failures** (1 performance-tagged excluded); one unrelated mcp/server_test ordering flake passed on re-run and in isolation
- New tests:
  - export route: local 200 + envelope integrity / 404; cloud 401 unauthenticated / 200 own-org / 404 cross-org / 404 unknown
  - ReviewLive: cross-org review renders "Review not found" without leaking the submission body

## Out of scope (still open on #83)

- API-token scoping for `/api/v1` endpoints
- Server-side re-verification on remaining write paths beyond ReviewLive

Refs #83, refs #123 (item 4a)
