### PR TITLE
⚡ Bolt: Optimize Elixir list and unique count allocations

### DIFF
--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -270,7 +270,8 @@ defmodule ControlKeel.Benchmark do
   # itself), so we skip the recompute and keep the export payload lean. The
   # explicit `benchmark compare <id>` command always computes a comparison.
   defp maybe_comparison(%Run{subjects: subjects} = run) when is_list(subjects) do
-    if length(Enum.uniq(subjects)) >= 2, do: compare_run(run), else: nil
+    # Optimize unique count by avoiding intermediate list allocations
+    if MapSet.size(MapSet.new(subjects)) >= 2, do: compare_run(run), else: nil
   end
 
   defp maybe_comparison(_run), do: nil

--- a/lib/controlkeel_web/live/benchmarks_live.ex
+++ b/lib/controlkeel_web/live/benchmarks_live.ex
@@ -963,7 +963,8 @@ defmodule ControlKeelWeb.BenchmarksLive do
   defp format_percent(value), do: "#{Float.round(value, 1)}%"
 
   defp comparable_run?(%Benchmark.Run{subjects: subjects}) do
-    subjects |> List.wrap() |> Enum.uniq() |> length() >= 2
+    # Optimize unique count by avoiding intermediate list allocations
+    subjects |> List.wrap() |> MapSet.new() |> MapSet.size() >= 2
   end
 
   defp assign_run_details(socket, %Benchmark.Run{} = run) do

--- a/test/controlkeel/budget/cost_optimizer_test.exs
+++ b/test/controlkeel/budget/cost_optimizer_test.exs
@@ -30,7 +30,8 @@ defmodule ControlKeel.Budget.CostOptimizerTest do
       end
 
     assert {:ok, suggestions} = CostOptimizer.suggest("session_3", spending: spending)
-    cache_count = length(Enum.filter(suggestions, &(&1.type == :caching)))
+    # Optimize filter/length with Enum.count to avoid intermediate lists
+    cache_count = Enum.count(suggestions, &(&1.type == :caching))
     assert cache_count >= 0
   end
 
@@ -41,7 +42,8 @@ defmodule ControlKeel.Budget.CostOptimizerTest do
       end
 
     assert {:ok, suggestions} = CostOptimizer.suggest("session_4", spending: spending)
-    local_count = length(Enum.filter(suggestions, &(&1.type == :local_model)))
+    # Optimize filter/length with Enum.count to avoid intermediate lists
+    local_count = Enum.count(suggestions, &(&1.type == :local_model))
     assert local_count >= 0
   end
 


### PR DESCRIPTION
**💡 What:** 
Replaced multi-step Elixir list operations with optimized equivalents. Specifically, replaced `length(Enum.uniq(...))` with `MapSet.new(...) |> MapSet.size()` and `length(Enum.filter(...))` with `Enum.count(...)`.

**🎯 Why:** 
`Enum.uniq/1` followed by `length/1` requires traversing the list twice and allocating an intermediate list for the unique elements. Using `MapSet` directly calculates the unique size more efficiently. Similarly, `length(Enum.filter(...))` creates an intermediate list of filtered items in memory before returning the length. `Enum.count(...)` does this in a single pass without allocating a new list, reducing memory overhead and garbage collection pressure.

**📊 Impact:** 
Reduces intermediate memory allocations and loop traversals, resulting in faster and more memory-efficient counts, especially for larger data sets.

**🔬 Measurement:** 
Code inspection confirms the logical equivalency of the operations while utilizing the more direct standard library functions. Note: Standard test/linting environment is not present to run automated verification, so rely on standard Elixir knowledge for this correctness guarantee.

---
*PR created automatically by Jules for task [2068596476068327017](https://jules.google.com/task/2068596476068327017) started by @aryaminus*