### PR TITLE
feat(mcp): Streamable HTTP session semantics (Mcp-Session-Id lifecycle)

### DIFF
--- a/lib/controlkeel/application.ex
+++ b/lib/controlkeel/application.ex
@@ -81,6 +81,7 @@ defmodule ControlKeel.Application do
       db_maintenance_children() ++
       autonomy_scheduler_children() ++
       [ControlKeel.Cloud.RateLimiter, ControlKeel.Cloud.Usage.Meter] ++
+      [ControlKeel.Mcp.StreamableSessions] ++
       [
         {DNSCluster, query: Application.get_env(:controlkeel, :dns_cluster_query) || :ignore},
         {Phoenix.PubSub, name: ControlKeel.PubSub},

--- a/lib/controlkeel/mcp/streamable_sessions.ex
+++ b/lib/controlkeel/mcp/streamable_sessions.ex
@@ -1,0 +1,122 @@
+defmodule ControlKeel.Mcp.StreamableSessions do
+  @moduledoc """
+  Session registry for the Streamable HTTP MCP transport (MCP 2025-03-26).
+
+  The server assigns an `Mcp-Session-Id` response header on `initialize`,
+  validates it on subsequent requests, and terminates it on `DELETE /mcp`.
+  Sessions are advisory identification (the transport is otherwise
+  stateless); unknown or expired ids must yield 404 per spec.
+
+  Storage is an ETS table owned by this module, started under the app
+  supervision tree when hosted MCP is available. Entries carry a TTL and
+  are evicted lazily on read plus on every sweep.
+  """
+
+  use GenServer
+
+  @table :controlkeel_mcp_streamable_sessions
+  @default_ttl_minutes 60
+  @sweep_interval :timer.minutes(5)
+
+  # ─── Client API ───────────────────────────────────────────────────────────────
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Registers a new session and returns its id (ULID-based).
+  """
+  def issue do
+    session_id = "mcp_" <> ControlKeel.Cloud.Telemetry.Envelope.ulid()
+    ttl = ttl_seconds()
+    now = System.os_time(:second)
+
+    :ets.insert_new(@table, {session_id, now + ttl})
+    session_id
+  end
+
+  @doc """
+  True when the session id is known and unexpired (touches it).
+  False otherwise.
+  """
+  def valid?(session_id) when is_binary(session_id) do
+    now = System.os_time(:second)
+
+    case :ets.lookup(@table, session_id) do
+      [{^session_id, expires_at}] when expires_at > now ->
+        :ets.insert(@table, {session_id, now + ttl_seconds()})
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  def valid?(_), do: false
+
+  @doc """
+  Removes a session. Returns :ok regardless (idempotent termination).
+  """
+  def terminate(session_id) when is_binary(session_id) do
+    :ets.delete(@table, session_id)
+    :ok
+  end
+
+  def terminate(_), do: :ok
+
+  @doc """
+  Number of live sessions (diagnostics/tests).
+  """
+  def count do
+    sweep()
+    :ets.info(@table, :size)
+  end
+
+  # ─── GenServer ────────────────────────────────────────────────────────────────
+
+  @impl true
+  def init(_opts) do
+    table = :ets.new(@table, [:set, :named_table, :public, read_concurrency: true])
+
+    schedule_sweep()
+    {:ok, table}
+  end
+
+  @impl true
+  def handle_info(:sweep, table) do
+    sweep()
+    schedule_sweep()
+    {:noreply, table}
+  end
+
+  defp schedule_sweep, do: Process.send_after(self(), :sweep, @sweep_interval)
+
+  defp sweep do
+    if :ets.whereis(@table) != :undefined do
+      now = System.os_time(:second)
+
+      :ets.safe_fixtable(@table, true)
+
+      :ets.foldl(
+        fn {session_id, expires_at}, _acc ->
+          if expires_at <= now, do: :ets.delete(@table, session_id)
+          :ok
+        end,
+        :ok,
+        @table
+      )
+
+      :ets.safe_fixtable(@table, false)
+    end
+
+    :ok
+  end
+
+  defp ttl_seconds do
+    case Application.get_env(:controlkeel, :mcp_session_ttl_minutes) do
+      minutes when is_integer(minutes) and minutes > 0 -> minutes * 60
+      _ -> @default_ttl_minutes * 60
+    end
+  end
+end

--- a/lib/controlkeel_web/controllers/protocol_controller.ex
+++ b/lib/controlkeel_web/controllers/protocol_controller.ex
@@ -3,40 +3,99 @@ defmodule ControlKeelWeb.ProtocolController do
 
   alias ControlKeel.Mcp.ProtocolAccess
   alias ControlKeel.Mcp.ProtocolInterop
+  alias ControlKeel.Mcp.StreamableSessions
+
+  @session_header "mcp-session-id"
 
   def mcp(conn, _params) do
     request = conn.body_params
     auth_context = conn.assigns.protocol_auth
 
-    case ProtocolInterop.handle_mcp_request(request, auth_context) do
-      :no_response ->
-        send_resp(conn, :accepted, "")
+    with :ok <- validate_session_header(conn, request) do
+      case ProtocolInterop.handle_mcp_request(request, auth_context) do
+        :no_response ->
+          send_resp(conn, :accepted, "")
 
-      response ->
-        conn
-        |> maybe_put_protocol_error_status(response)
-        |> json(response)
+        response ->
+          conn
+          |> maybe_issue_session(request, response)
+          |> maybe_put_protocol_error_status(response)
+          |> json(response)
+      end
     end
   end
 
+  # Streamable HTTP (MCP 2025-03-26): the server assigns Mcp-Session-Id on
+  # initialize; a client-present id on any later request MUST be known, else
+  # 404. Requests without a header stay valid (stateless v1 clients).
+  defp validate_session_header(_conn, %{"method" => "initialize"}), do: :ok
+
+  defp validate_session_header(conn, _request) do
+    case get_req_header(conn, @session_header) do
+      [session_id | _] when session_id != "" ->
+        if StreamableSessions.valid?(session_id) do
+          :ok
+        else
+          conn
+          |> put_status(:not_found)
+          |> json(%{
+            jsonrpc: "2.0",
+            error: %{
+              code: -32001,
+              message: "MCP session not found or expired. Re-initialize the session."
+            }
+          })
+          |> halt()
+        end
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp maybe_issue_session(conn, %{"method" => "initialize"}, %{"result" => _result}) do
+    case get_req_header(conn, @session_header) do
+      [session_id | _] when session_id != "" ->
+        # Client echoed an id it already holds: keep it valid.
+        if StreamableSessions.valid?(session_id) do
+          put_resp_header(conn, @session_header, session_id)
+        else
+          conn
+        end
+
+      _ ->
+        put_resp_header(conn, @session_header, StreamableSessions.issue())
+    end
+  end
+
+  defp maybe_issue_session(conn, _request, _response), do: conn
+
   def mcp_get(conn, _params) do
+    # The server does not offer a GET SSE stream (spec-permitted); clients
+    # MUST fall back to POST-only JSON responses.
     conn
-    |> put_resp_header("allow", "POST")
+    |> put_resp_header("allow", "POST, DELETE")
     |> put_status(:method_not_allowed)
     |> json(%{
       error: "method_not_allowed",
-      message: "Hosted MCP uses stateless JSON-response POST requests in v1."
+      message: "This MCP server uses POST-only JSON responses; GET streams are not offered."
     })
   end
 
   def mcp_delete(conn, _params) do
-    conn
-    |> put_resp_header("allow", "POST")
-    |> put_status(:method_not_allowed)
-    |> json(%{
-      error: "method_not_allowed",
-      message: "Hosted MCP does not expose session lifecycle endpoints in v1."
-    })
+    case get_req_header(conn, @session_header) do
+      [session_id | _] when session_id != "" ->
+        StreamableSessions.terminate(session_id)
+        send_resp(conn, :no_content, "")
+
+      _ ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{
+          error: "session_not_found",
+          message: "DELETE requires an #{Macro.camelize(@session_header)} header."
+        })
+    end
   end
 
   def protected_resource_mcp(conn, _params) do

--- a/test/controlkeel_web/controllers/protocol_controller_test.exs
+++ b/test/controlkeel_web/controllers/protocol_controller_test.exs
@@ -87,12 +87,97 @@ defmodule ControlKeelWeb.ProtocolControllerTest do
       assert challenge =~ "/.well-known/oauth-protected-resource/mcp"
     end
 
-    test "returns 405 for GET and DELETE on /mcp", %{conn: conn} do
+    test "returns 405 for GET on /mcp (POST-only streamable server)", %{conn: conn} do
       conn = get(conn, "/mcp")
       assert %{"error" => "method_not_allowed"} = json_response(conn, 405)
+    end
 
+    test "initialize issues Mcp-Session-Id; tools/list accepts it; DELETE terminates", %{
+      conn: conn
+    } do
+      token = hosted_token_for("mcp:access")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/mcp", %{
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize"
+        })
+
+      assert %{"result" => %{"serverInfo" => %{"name" => "controlkeel"}}} =
+               json_response(conn, 200)
+
+      [session_id] = get_resp_header(conn, "mcp-session-id")
+      assert is_binary(session_id) and session_id != ""
+
+      conn =
+        build_conn()
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> put_req_header("mcp-session-id", session_id)
+        |> post("/mcp", %{
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/list"
+        })
+
+      assert %{"result" => %{"tools" => _}} = json_response(conn, 200)
+
+      conn =
+        build_conn()
+        |> put_req_header("mcp-session-id", session_id)
+        |> delete("/mcp")
+
+      assert response(conn, 204)
+
+      conn =
+        build_conn()
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> put_req_header("mcp-session-id", session_id)
+        |> post("/mcp", %{
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/list"
+        })
+
+      assert %{"error" => %{"code" => -32001}} = json_response(conn, 404)
+    end
+
+    test "unknown Mcp-Session-Id on a non-initialize request yields 404", %{conn: conn} do
+      token = hosted_token_for("mcp:access")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> put_req_header("mcp-session-id", "mcp_nonexistent")
+        |> post("/mcp", %{
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list"
+        })
+
+      assert %{"error" => %{"code" => -32001}} = json_response(conn, 404)
+    end
+
+    test "headerless non-initialize requests remain valid (stateless clients)", %{conn: conn} do
+      token = hosted_token_for("mcp:access")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/mcp", %{
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list"
+        })
+
+      assert %{"result" => %{"tools" => _}} = json_response(conn, 200)
+    end
+
+    test "DELETE without a session header yields 404", %{conn: conn} do
       conn = build_conn() |> delete("/mcp")
-      assert %{"error" => "method_not_allowed"} = json_response(conn, 405)
+      assert %{"error" => "session_not_found"} = json_response(conn, 404)
     end
 
     test "allows initialize and tools/list with a valid MCP access token", %{conn: conn} do


### PR DESCRIPTION
## Summary

Stacked on #128. Closes the Streamable HTTP item from the audit's P2 list: hosted MCP was stateless JSON POST only — no session management per MCP 2025-03-26 Streamable HTTP.

## Change

- **`Mcp.StreamableSessions`** — ETS-backed session registry with TTL (60m default, `:mcp_session_ttl_minutes` configurable), lazy touch-on-read + periodic sweep, started under the late-children supervision tree.
- **`ProtocolController`**:
  - `initialize` → issues `Mcp-Session-Id` response header
  - Any later request carrying an unknown/expired id → **404** with JSON-RPC `-32001` (spec-mandated)
  - Headerless requests stay valid — stateless v1 clients unchanged
  - `DELETE /mcp` terminates the session (204; 404 without a header)
  - `GET /mcp` keeps 405 — spec-permitted POST-only server, no SSE stream offered

## Verification

- `mix compile --warnings-as-errors` clean
- `protocol_controller_test` — 18/0, including new lifecycle test (issue → use → DELETE → 404), unknown-id 404, headerless pass-through, headerless DELETE 404