### PR TITLE
refactor: first god-module split — Mission.FindingOps + API.FindingController

### DIFF
--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -24,7 +24,7 @@ defmodule ControlKeel.Mission do
 
   alias ControlKeel.Mission.{
     Finding,
-    FindingAuditEvent,
+    FindingOps,
     Invocation,
     Planner,
     ProofBundle,
@@ -1182,252 +1182,15 @@ defmodule ControlKeel.Mission do
 
   def auto_fix_for_finding(%Finding{} = finding), do: AutoFix.generate(finding)
 
-  def approve_finding(finding_or_id, opts \\ [])
+  # ── Finding disposition (extracted to Mission.FindingOps) ────────────────────
 
-  def approve_finding(%Finding{} = finding, opts) when is_list(opts) do
-    metadata =
-      Map.merge(finding.metadata || %{}, %{
-        "approved_at" => DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
-      })
-
-    case update_finding_with_audit(
-           finding,
-           %{status: "approved", metadata: metadata},
-           :approved,
-           opts
-         ) do
-      {:ok, updated} ->
-        emit_finding_event(:approved, updated)
-        record_finding_memory(:approved, updated)
-        emit_platform_finding_event("finding.approved", updated)
-        {:ok, updated}
-
-      other ->
-        other
-    end
-  end
-
-  def approve_finding(id, opts) when is_integer(id) and is_list(opts) do
-    case get_finding(id) do
-      nil -> {:error, :not_found}
-      finding -> approve_finding(finding, opts)
-    end
-  end
-
-  def reject_finding(finding_or_id, reason \\ nil, opts \\ [])
-
-  def reject_finding(%Finding{} = finding, reason, opts) when is_list(opts) do
-    metadata =
-      finding.metadata
-      |> Kernel.||(%{})
-      |> Map.merge(%{
-        "rejected_at" => DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
-      })
-      |> maybe_put_metadata("rejection_reason", reason)
-
-    case update_finding_with_audit(
-           finding,
-           %{status: "rejected", metadata: metadata},
-           :rejected,
-           Keyword.put(opts, :reason, reason)
-         ) do
-      {:ok, updated} ->
-        emit_finding_event(:rejected, updated)
-        record_finding_memory(:rejected, updated)
-        emit_platform_finding_event("finding.rejected", updated)
-        {:ok, updated}
-
-      other ->
-        other
-    end
-  end
-
-  def reject_finding(id, reason, opts) when is_integer(id) and is_list(opts) do
-    case get_finding(id) do
-      nil -> {:error, :not_found}
-      finding -> reject_finding(finding, reason, opts)
-    end
-  end
-
-  def escalate_finding(finding_or_id, opts \\ [])
-
-  def escalate_finding(%Finding{} = finding, opts) when is_list(opts) do
-    metadata =
-      Map.merge(finding.metadata || %{}, %{
-        "escalated_at" =>
-          DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
-      })
-
-    case update_finding_with_audit(
-           finding,
-           %{status: "escalated", metadata: metadata},
-           :escalated,
-           opts
-         ) do
-      {:ok, updated} ->
-        emit_finding_event(:escalated, updated)
-        record_finding_memory(:escalated, updated)
-        {:ok, updated}
-
-      other ->
-        other
-    end
-  end
-
-  def escalate_finding(id, opts) when is_integer(id) and is_list(opts) do
-    case get_finding(id) do
-      nil -> {:error, :not_found}
-      finding -> escalate_finding(finding, opts)
-    end
-  end
-
-  @disposition_actions ~w(resolve dismiss escalate)
-  @disposition_statuses ~w(open blocked escalated)
-
-  @doc """
-  Disposition a single finding via a high-level action so agents (and bulk paths) can
-  resolve the findings they create instead of only filing compensating records:
-
-    * `"resolve"`  -> approved
-    * `"dismiss"`  -> rejected (records `opts[:reason]`)
-    * `"escalate"` -> escalated
-
-  Accepts a `%Finding{}` or an integer id. Returns `{:ok, finding}` / `{:error, reason}`.
-  """
-  def dispose_finding(action, finding_or_id, opts \\ [])
-
-  def dispose_finding(action, %Finding{} = finding, opts),
-    do: do_dispose_finding(action, finding, opts)
-
-  def dispose_finding(action, id, opts) when is_integer(id) do
-    case get_finding(id) do
-      nil -> {:error, :not_found}
-      finding -> do_dispose_finding(action, finding, opts)
-    end
-  end
-
-  defp do_dispose_finding("resolve", finding, opts), do: approve_finding(finding, opts)
-
-  defp do_dispose_finding("dismiss", finding, opts),
-    do: reject_finding(finding, Keyword.get(opts, :reason), opts)
-
-  defp do_dispose_finding("escalate", finding, opts), do: escalate_finding(finding, opts)
-  defp do_dispose_finding(_action, _finding, _opts), do: {:error, :invalid_action}
-
-  @doc """
-  Bulk-disposition findings in a session matching a filter map.
-
-  Filter keys: `:rule_id`, `:category`, `:statuses` (defaults to the active set
-  `~w(open blocked escalated)`), and `:reason` (recorded when dismissing). Only findings
-  currently in the matched statuses are touched, so the operation is idempotent. Returns
-  `{:ok, %{count: n, ids: [finding_id]}}`.
-  """
-  def dispose_session_findings(session_id, filter, action)
-      when is_integer(session_id) and action in @disposition_actions do
-    reason = Map.get(filter, :reason)
-    disposition_opts = Map.get(filter, :disposition_opts, [])
-
-    ids =
-      session_id
-      |> list_findings_for_session()
-      |> Enum.filter(&matches_disposition_filter?(&1, filter))
-      |> Enum.reduce([], fn finding, acc ->
-        case do_dispose_finding(action, finding, Keyword.put(disposition_opts, :reason, reason)) do
-          {:ok, updated} -> [updated.id | acc]
-          _ -> acc
-        end
-      end)
-      |> Enum.reverse()
-
-    {:ok, %{count: length(ids), ids: ids}}
-  end
-
-  def dispose_session_findings(_session_id, _filter, _action), do: {:error, :invalid_action}
-
-  @doc """
-  Bulk-disposition a list of finding ids via a single action (`resolve`,
-  `dismiss`, or `escalate`). Dismissals record `opts[:reason]` on the finding
-  metadata and audit event. Only findings currently in an active status
-  (`open`, `blocked`, `escalated`) are touched, so the operation is idempotent.
-  Returns `{:ok, %{count: n, ids: [finding_id]}}`.
-  """
-  def dispose_findings(ids, action, opts \\ []) when is_list(ids) do
-    if action in @disposition_actions do
-      disposition_opts = Keyword.put(opts, :reason, opts[:reason] && to_string(opts[:reason]))
-
-      ids =
-        Enum.reduce(ids, [], fn id, acc ->
-          with %Finding{status: status} <- get_finding(id),
-               true <- status in @disposition_statuses,
-               {:ok, updated} <- do_dispose_finding(action, id, disposition_opts) do
-            [updated.id | acc]
-          else
-            _ -> acc
-          end
-        end)
-        |> Enum.reverse()
-
-      {:ok, %{count: length(ids), ids: ids}}
-    else
-      {:error, :invalid_action}
-    end
-  end
-
-  defp matches_disposition_filter?(finding, filter) do
-    statuses = Map.get(filter, :statuses) || ~w(open blocked escalated)
-
-    finding.status in statuses and
-      disposition_filter_match?(finding.rule_id, Map.get(filter, :rule_id)) and
-      disposition_filter_match?(finding.category, Map.get(filter, :category))
-  end
-
-  defp disposition_filter_match?(_value, nil), do: true
-  defp disposition_filter_match?(value, expected), do: value == expected
-
-  @doc "List append-only audit events for a finding, oldest first."
-  @spec finding_audit_events(integer()) :: [FindingAuditEvent.t()]
-  def finding_audit_events(finding_id) when is_integer(finding_id) do
-    FindingAuditEvent
-    |> where([event], event.finding_id == ^finding_id)
-    |> order_by([event], asc: event.recorded_at, asc: event.id)
-    |> Repo.all()
-  end
-
-  # Atomically persist a finding status change and its append-only audit event.
-  # Mirrors the review-decision Multi in respond_review so the lineage guarantee
-  # holds even under a failed audit insert: the status update and the audit row
-  # commit together or roll back together (no status change without a trail).
-  defp update_finding_with_audit(finding, attrs, event_type, opts) do
-    Multi.new()
-    |> Multi.update(:finding, Finding.changeset(finding, attrs))
-    |> Multi.insert(:finding_audit_event, fn %{finding: updated} ->
-      FindingAuditEvent.changeset(
-        %FindingAuditEvent{},
-        finding_audit_attrs(event_type, finding, updated, opts)
-      )
-    end)
-    |> RepoRetry.transaction_with_busy_retry()
-    |> case do
-      {:ok, %{finding: updated}} -> {:ok, updated}
-      {:error, _step, reason, _changes} -> {:error, reason}
-    end
-  end
-
-  defp finding_audit_attrs(event_type, previous, updated, opts) do
-    actor_source = Keyword.get(opts, :actor_source) || "unknown"
-
-    %{
-      finding_id: updated.id,
-      event_type: Atom.to_string(event_type),
-      previous_status: previous.status,
-      new_status: updated.status,
-      reason: Keyword.get(opts, :reason),
-      actor_user_id: Keyword.get(opts, :actor_user_id),
-      actor_source: actor_source,
-      actor_identifier: Keyword.get(opts, :actor_identifier) || actor_source,
-      recorded_at: DateTime.utc_now() |> DateTime.truncate(:second)
-    }
-  end
+  defdelegate approve_finding(finding_or_id, opts \\ []), to: FindingOps
+  defdelegate reject_finding(finding_or_id, reason \\ nil, opts \\ []), to: FindingOps
+  defdelegate escalate_finding(finding_or_id, opts \\ []), to: FindingOps
+  defdelegate dispose_finding(action, finding_or_id, opts \\ []), to: FindingOps
+  defdelegate dispose_session_findings(session_id, filter, action), to: FindingOps
+  defdelegate dispose_findings(ids, action, opts \\ []), to: FindingOps
+  defdelegate finding_audit_events(finding_id), to: FindingOps
 
   @doc """
   Complete a task, gating on open/blocked findings and deploy readiness.
@@ -4876,7 +4639,7 @@ defmodule ControlKeel.Mission do
   defp task_memory_title(:updated, task), do: "Task updated: #{task.title}"
   defp task_memory_title(_action, task), do: "Task changed: #{task.title}"
 
-  defp record_finding_memory(action, %Finding{} = finding) do
+  def record_finding_memory(action, %Finding{} = finding) do
     case get_session_with_workspace(finding.session_id) do
       nil ->
         :ok
@@ -6450,7 +6213,7 @@ defmodule ControlKeel.Mission do
     )
   end
 
-  defp emit_platform_finding_event(event, finding) do
+  def emit_platform_finding_event(event, finding) do
     Platform.emit_event(
       event,
       %{
@@ -6472,7 +6235,7 @@ defmodule ControlKeel.Mission do
     end
   end
 
-  defp emit_finding_event(action, %Finding{} = finding) do
+  def emit_finding_event(action, %Finding{} = finding) do
     :telemetry.execute(
       [:controlkeel, :finding, action],
       %{count: 1},
@@ -7000,9 +6763,6 @@ defmodule ControlKeel.Mission do
   defp maybe_filter_proof_risk(query, risk_tier) do
     from([_proof, _task, session, _workspace] in query, where: session.risk_tier == ^risk_tier)
   end
-
-  defp maybe_put_metadata(metadata, _key, nil), do: metadata
-  defp maybe_put_metadata(metadata, key, value), do: Map.put(metadata, key, value)
 
   defp count_by_metadata(findings, key) do
     findings

--- a/lib/controlkeel/mission/finding_ops.ex
+++ b/lib/controlkeel/mission/finding_ops.ex
@@ -1,0 +1,276 @@
+defmodule ControlKeel.Mission.FindingOps do
+  @moduledoc """
+  Finding disposition operations extracted from the `Mission` context.
+
+  Owns the approve / reject / escalate / bulk-disposition surface and the
+  atomic status+audit Multi that guarantees every disposition leaves an
+  append-only `FindingAuditEvent` trail. `Mission` delegates to this module,
+  so all existing `Mission.*` call sites keep working.
+
+  Read paths (`get_finding/1`, `list_findings_for_session/1`) and the
+  memory/event emitters stay in `Mission`; this module calls back into them.
+  """
+
+  import Ecto.Query, only: [where: 3, order_by: 3]
+
+  alias ControlKeel.Mission
+  alias ControlKeel.Mission.Finding
+  alias ControlKeel.Mission.FindingAuditEvent
+  alias ControlKeel.Repo
+  alias ControlKeel.Repo.Retry, as: RepoRetry
+  alias Ecto.Multi
+
+  @disposition_actions ~w(resolve dismiss escalate)
+  @disposition_statuses ~w(open blocked escalated)
+
+  def disposition_actions, do: @disposition_actions
+
+  def approve_finding(finding_or_id, opts \\ [])
+
+  def approve_finding(%Finding{} = finding, opts) when is_list(opts) do
+    metadata =
+      Map.merge(finding.metadata || %{}, %{
+        "approved_at" => DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+      })
+
+    case update_finding_with_audit(
+           finding,
+           %{status: "approved", metadata: metadata},
+           :approved,
+           opts
+         ) do
+      {:ok, updated} ->
+        Mission.emit_finding_event(:approved, updated)
+        Mission.record_finding_memory(:approved, updated)
+        Mission.emit_platform_finding_event("finding.approved", updated)
+        {:ok, updated}
+
+      other ->
+        other
+    end
+  end
+
+  def approve_finding(id, opts) when is_integer(id) and is_list(opts) do
+    case Mission.get_finding(id) do
+      nil -> {:error, :not_found}
+      finding -> approve_finding(finding, opts)
+    end
+  end
+
+  def reject_finding(finding_or_id, reason \\ nil, opts \\ [])
+
+  def reject_finding(%Finding{} = finding, reason, opts) when is_list(opts) do
+    metadata =
+      finding.metadata
+      |> Kernel.||(%{})
+      |> Map.merge(%{
+        "rejected_at" => DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+      })
+      |> maybe_put_metadata("rejection_reason", reason)
+
+    case update_finding_with_audit(
+           finding,
+           %{status: "rejected", metadata: metadata},
+           :rejected,
+           Keyword.put(opts, :reason, reason)
+         ) do
+      {:ok, updated} ->
+        Mission.emit_finding_event(:rejected, updated)
+        Mission.record_finding_memory(:rejected, updated)
+        Mission.emit_platform_finding_event("finding.rejected", updated)
+        {:ok, updated}
+
+      other ->
+        other
+    end
+  end
+
+  def reject_finding(id, reason, opts) when is_integer(id) and is_list(opts) do
+    case Mission.get_finding(id) do
+      nil -> {:error, :not_found}
+      finding -> reject_finding(finding, reason, opts)
+    end
+  end
+
+  def escalate_finding(finding_or_id, opts \\ [])
+
+  def escalate_finding(%Finding{} = finding, opts) when is_list(opts) do
+    metadata =
+      Map.merge(finding.metadata || %{}, %{
+        "escalated_at" =>
+          DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+      })
+
+    case update_finding_with_audit(
+           finding,
+           %{status: "escalated", metadata: metadata},
+           :escalated,
+           opts
+         ) do
+      {:ok, updated} ->
+        Mission.emit_finding_event(:escalated, updated)
+        Mission.record_finding_memory(:escalated, updated)
+        {:ok, updated}
+
+      other ->
+        other
+    end
+  end
+
+  def escalate_finding(id, opts) when is_integer(id) and is_list(opts) do
+    case Mission.get_finding(id) do
+      nil -> {:error, :not_found}
+      finding -> escalate_finding(finding, opts)
+    end
+  end
+
+  @doc """
+  Disposition a single finding via a high-level action so agents (and bulk paths) can
+  resolve the findings they create instead of only filing compensating records:
+
+    * `"resolve"`  -> approved
+    * `"dismiss"`  -> rejected (records `opts[:reason]`)
+    * `"escalate"` -> escalated
+
+  Accepts a `%Finding{}` or an integer id. Returns `{:ok, finding}` / `{:error, reason}`.
+  """
+  def dispose_finding(action, finding_or_id, opts \\ [])
+
+  def dispose_finding(action, %Finding{} = finding, opts),
+    do: do_dispose_finding(action, finding, opts)
+
+  def dispose_finding(action, id, opts) when is_integer(id) do
+    case Mission.get_finding(id) do
+      nil -> {:error, :not_found}
+      finding -> do_dispose_finding(action, finding, opts)
+    end
+  end
+
+  @doc """
+  Bulk-disposition findings in a session matching a filter map.
+
+  Filter keys: `:rule_id`, `:category`, `:statuses` (defaults to the active set
+  `~w(open blocked escalated)`), and `:reason` (recorded when dismissing). Only findings
+  currently in the matched statuses are touched, so the operation is idempotent. Returns
+  `{:ok, %{count: n, ids: [finding_id]}}`.
+  """
+  def dispose_session_findings(session_id, filter, action)
+      when is_integer(session_id) and action in @disposition_actions do
+    reason = Map.get(filter, :reason)
+    disposition_opts = Map.get(filter, :disposition_opts, [])
+
+    ids =
+      session_id
+      |> Mission.list_findings_for_session()
+      |> Enum.filter(&matches_disposition_filter?(&1, filter))
+      |> Enum.reduce([], fn finding, acc ->
+        case do_dispose_finding(action, finding, Keyword.put(disposition_opts, :reason, reason)) do
+          {:ok, updated} -> [updated.id | acc]
+          _ -> acc
+        end
+      end)
+      |> Enum.reverse()
+
+    {:ok, %{count: length(ids), ids: ids}}
+  end
+
+  def dispose_session_findings(_session_id, _filter, _action), do: {:error, :invalid_action}
+
+  @doc """
+  Bulk-disposition a list of finding ids via a single action (`resolve`,
+  `dismiss`, or `escalate`). Dismissals record `opts[:reason]` on the finding
+  metadata and audit event. Only findings currently in an active status
+  (`open`, `blocked`, `escalated`) are touched, so the operation is idempotent.
+  Returns `{:ok, %{count: n, ids: [finding_id]}}`.
+  """
+  def dispose_findings(ids, action, opts \\ []) when is_list(ids) do
+    if action in @disposition_actions do
+      disposition_opts = Keyword.put(opts, :reason, opts[:reason] && to_string(opts[:reason]))
+
+      ids =
+        Enum.reduce(ids, [], fn id, acc ->
+          with %Finding{status: status} <- Mission.get_finding(id),
+               true <- status in @disposition_statuses,
+               {:ok, updated} <- do_dispose_finding(action, id, disposition_opts) do
+            [updated.id | acc]
+          else
+            _ -> acc
+          end
+        end)
+        |> Enum.reverse()
+
+      {:ok, %{count: length(ids), ids: ids}}
+    else
+      {:error, :invalid_action}
+    end
+  end
+
+  @doc "List append-only audit events for a finding, oldest first."
+  @spec finding_audit_events(integer()) :: [FindingAuditEvent.t()]
+  def finding_audit_events(finding_id) when is_integer(finding_id) do
+    FindingAuditEvent
+    |> where([event], event.finding_id == ^finding_id)
+    |> order_by([event], asc: event.recorded_at, asc: event.id)
+    |> Repo.all()
+  end
+
+  # ─── Privates ────────────────────────────────────────────────────────────────
+
+  defp do_dispose_finding("resolve", finding, opts), do: approve_finding(finding, opts)
+
+  defp do_dispose_finding("dismiss", finding, opts),
+    do: reject_finding(finding, Keyword.get(opts, :reason), opts)
+
+  defp do_dispose_finding("escalate", finding, opts), do: escalate_finding(finding, opts)
+  defp do_dispose_finding(_action, _finding, _opts), do: {:error, :invalid_action}
+
+  defp matches_disposition_filter?(finding, filter) do
+    statuses = Map.get(filter, :statuses) || ~w(open blocked escalated)
+
+    finding.status in statuses and
+      disposition_filter_match?(finding.rule_id, Map.get(filter, :rule_id)) and
+      disposition_filter_match?(finding.category, Map.get(filter, :category))
+  end
+
+  defp disposition_filter_match?(_value, nil), do: true
+  defp disposition_filter_match?(value, expected), do: value == expected
+
+  # Atomically persist a finding status change and its append-only audit event.
+  # Mirrors the review-decision Multi in respond_review so the lineage guarantee
+  # holds even under a failed audit insert: the status update and the audit row
+  # commit together or roll back together (no status change without a trail).
+  defp update_finding_with_audit(finding, attrs, event_type, opts) do
+    Multi.new()
+    |> Multi.update(:finding, Finding.changeset(finding, attrs))
+    |> Multi.insert(:finding_audit_event, fn %{finding: updated} ->
+      FindingAuditEvent.changeset(
+        %FindingAuditEvent{},
+        finding_audit_attrs(event_type, finding, updated, opts)
+      )
+    end)
+    |> RepoRetry.transaction_with_busy_retry()
+    |> case do
+      {:ok, %{finding: updated}} -> {:ok, updated}
+      {:error, _step, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  defp finding_audit_attrs(event_type, previous, updated, opts) do
+    actor_source = Keyword.get(opts, :actor_source) || "unknown"
+
+    %{
+      finding_id: updated.id,
+      event_type: Atom.to_string(event_type),
+      previous_status: previous.status,
+      new_status: updated.status,
+      reason: Keyword.get(opts, :reason),
+      actor_user_id: Keyword.get(opts, :actor_user_id),
+      actor_source: actor_source,
+      actor_identifier: Keyword.get(opts, :actor_identifier) || actor_source,
+      recorded_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    }
+  end
+
+  defp maybe_put_metadata(metadata, _key, nil), do: metadata
+  defp maybe_put_metadata(metadata, key, value), do: Map.put(metadata, key, value)
+end

--- a/lib/controlkeel_web/controllers/api/finding_controller.ex
+++ b/lib/controlkeel_web/controllers/api/finding_controller.ex
@@ -1,0 +1,100 @@
+defmodule ControlKeelWeb.API.FindingController do
+  @moduledoc """
+  `/api/v1` finding endpoints, extracted from `ApiController` as the first
+  per-resource controller split. Authorization + shared rendering come from
+  `ControlKeelWeb.APIHelpers`.
+  """
+
+  use ControlKeelWeb, :controller
+
+  import ControlKeelWeb.APIHelpers
+
+  alias ControlKeel.MCP.Arguments
+  alias ControlKeel.Mission
+
+  def list_findings(conn, params) do
+    opts =
+      params
+      |> Map.take(
+        ~w(session_id severity status category finding_family patch_status disclosure_status maintainer_scope)
+      )
+      |> Enum.into(%{})
+      |> Map.put("workspace_id", current_workspace_id(conn))
+
+    page = Mission.browse_findings(opts)
+
+    json(conn, %{
+      findings: Enum.map(page.entries, &finding_summary/1),
+      security_summary: page.security_summary,
+      filters: page.filters,
+      total: page.total_count,
+      page: page.page,
+      total_pages: page.total_pages
+    })
+  end
+
+  def finding_action(conn, %{"id" => id, "action" => action} = params) do
+    case Mission.get_finding(id) do
+      nil ->
+        conn |> put_status(:not_found) |> json(%{error: "finding not found"})
+
+      finding ->
+        with :ok <- authorize_finding_access(conn, finding, "findings:write") do
+          case action do
+            "approve" ->
+              {:ok, updated} = Mission.approve_finding(finding)
+              json(conn, %{finding: finding_summary(updated)})
+
+            "reject" ->
+              reason = Map.get(params, "reason")
+              {:ok, updated} = Mission.reject_finding(finding, reason)
+              json(conn, %{finding: finding_summary(updated)})
+
+            "escalate" ->
+              {:ok, updated} = Mission.escalate_finding(finding)
+              json(conn, %{finding: finding_summary(updated)})
+
+            _ ->
+              conn
+              |> put_status(:unprocessable_entity)
+              |> json(%{error: "unknown action", valid_actions: ~w(approve reject escalate)})
+          end
+        else
+          {:error, :forbidden} -> conn |> put_status(:forbidden) |> json(%{error: "forbidden"})
+        end
+    end
+  end
+
+  def create_finding(conn, params) do
+    session_id = Arguments.parse_integer(params["session_id"])
+
+    decision = Map.get(params, "decision", "warn")
+    status = if decision == "block", do: "blocked", else: "open"
+
+    attrs = %{
+      "session_id" => session_id,
+      "task_id" => Arguments.parse_integer(params["task_id"]),
+      "category" => Map.get(params, "category", "security"),
+      "severity" => Map.get(params, "severity", "medium"),
+      "rule_id" => Map.get(params, "rule_id", "agent.manual_review"),
+      "plain_message" => Map.get(params, "plain_message", ""),
+      "title" => Map.get(params, "title", Map.get(params, "rule_id", "Finding")),
+      "status" => status,
+      "auto_resolved" => false,
+      "metadata" => Map.get(params, "metadata", %{})
+    }
+
+    with :ok <- authorize_session_access(conn, session_id, "findings:write"),
+         {:ok, finding} <- Mission.create_finding(attrs) do
+      conn |> put_status(:created) |> json(%{finding: finding_summary(finding)})
+    else
+      {:error, :forbidden} ->
+        conn |> put_status(:forbidden) |> json(%{error: "forbidden"})
+
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "invalid finding", details: changeset_errors(changeset)})
+    end
+  end
+end

--- a/lib/controlkeel_web/controllers/api_controller.ex
+++ b/lib/controlkeel_web/controllers/api_controller.ex
@@ -1,6 +1,8 @@
 defmodule ControlKeelWeb.ApiController do
   use ControlKeelWeb, :controller
 
+  import ControlKeelWeb.APIHelpers
+
   alias ControlKeel.Agent.ACPRegistry
   alias ControlKeel.Agent.Execution
   alias ControlKeel.Agent.Router
@@ -361,92 +363,6 @@ defmodule ControlKeelWeb.ApiController do
   end
 
   # ─── Findings ────────────────────────────────────────────────────────────────
-
-  def list_findings(conn, params) do
-    opts =
-      params
-      |> Map.take(
-        ~w(session_id severity status category finding_family patch_status disclosure_status maintainer_scope)
-      )
-      |> Enum.into(%{})
-      |> Map.put("workspace_id", current_workspace_id(conn))
-
-    page = Mission.browse_findings(opts)
-
-    json(conn, %{
-      findings: Enum.map(page.entries, &finding_summary/1),
-      security_summary: page.security_summary,
-      filters: page.filters,
-      total: page.total_count,
-      page: page.page,
-      total_pages: page.total_pages
-    })
-  end
-
-  def finding_action(conn, %{"id" => id, "action" => action} = params) do
-    case Mission.get_finding(id) do
-      nil ->
-        conn |> put_status(:not_found) |> json(%{error: "finding not found"})
-
-      finding ->
-        with :ok <- authorize_finding_access(conn, finding, "findings:write") do
-          case action do
-            "approve" ->
-              {:ok, updated} = Mission.approve_finding(finding)
-              json(conn, %{finding: finding_summary(updated)})
-
-            "reject" ->
-              reason = Map.get(params, "reason")
-              {:ok, updated} = Mission.reject_finding(finding, reason)
-              json(conn, %{finding: finding_summary(updated)})
-
-            "escalate" ->
-              {:ok, updated} = Mission.escalate_finding(finding)
-              json(conn, %{finding: finding_summary(updated)})
-
-            _ ->
-              conn
-              |> put_status(:unprocessable_entity)
-              |> json(%{error: "unknown action", valid_actions: ~w(approve reject escalate)})
-          end
-        else
-          {:error, :forbidden} -> conn |> put_status(:forbidden) |> json(%{error: "forbidden"})
-        end
-    end
-  end
-
-  def create_finding(conn, params) do
-    session_id = Arguments.parse_integer(params["session_id"])
-
-    decision = Map.get(params, "decision", "warn")
-    status = if decision == "block", do: "blocked", else: "open"
-
-    attrs = %{
-      "session_id" => session_id,
-      "task_id" => Arguments.parse_integer(params["task_id"]),
-      "category" => Map.get(params, "category", "security"),
-      "severity" => Map.get(params, "severity", "medium"),
-      "rule_id" => Map.get(params, "rule_id", "agent.manual_review"),
-      "plain_message" => Map.get(params, "plain_message", ""),
-      "title" => Map.get(params, "title", Map.get(params, "rule_id", "Finding")),
-      "status" => status,
-      "auto_resolved" => false,
-      "metadata" => Map.get(params, "metadata", %{})
-    }
-
-    with :ok <- authorize_session_access(conn, session_id, "findings:write"),
-         {:ok, finding} <- Mission.create_finding(attrs) do
-      conn |> put_status(:created) |> json(%{finding: finding_summary(finding)})
-    else
-      {:error, :forbidden} ->
-        conn |> put_status(:forbidden) |> json(%{error: "forbidden"})
-
-      {:error, changeset} ->
-        conn
-        |> put_status(:unprocessable_entity)
-        |> json(%{error: "invalid finding", details: changeset_errors(changeset)})
-    end
-  end
 
   # ─── Budget ──────────────────────────────────────────────────────────────────
 
@@ -1828,28 +1744,6 @@ defmodule ControlKeelWeb.ApiController do
     }
   end
 
-  defp finding_summary(finding) do
-    summary = %{
-      id: Map.get(finding, :id),
-      rule_id: finding.rule_id,
-      category: finding.category,
-      severity: finding.severity,
-      status: Map.get(finding, :status, "open"),
-      plain_message: finding.plain_message,
-      auto_fix_available: Map.get(finding, :auto_fix_available, false)
-    }
-
-    if ControlKeel.Governance.SecurityWorkflow.vulnerability_case?(finding) do
-      Map.put(
-        summary,
-        :security_lifecycle,
-        ControlKeel.Governance.SecurityWorkflow.vulnerability_case_summary(finding)
-      )
-    else
-      summary
-    end
-  end
-
   defp proof_summary(proof) do
     %{
       id: proof.id,
@@ -2164,33 +2058,6 @@ defmodule ControlKeelWeb.ApiController do
     |> to_string()
   end
 
-  defp changeset_errors(changeset) do
-    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
-      Enum.reduce(opts, msg, fn {key, value}, acc ->
-        String.replace(acc, "%{#{key}}", to_string(value))
-      end)
-    end)
-  end
-
-  defp current_workspace_id(conn) do
-    case conn.assigns[:api_auth] do
-      %{type: :service_account, service_account: %{workspace_id: ws_id}} when is_integer(ws_id) ->
-        ws_id
-
-      _ ->
-        nil
-    end
-  end
-
-  defp parse_integer_param(value) when is_integer(value), do: {:ok, value}
-
-  defp parse_integer_param(value) do
-    case Integer.parse(to_string(value)) do
-      {parsed, ""} -> {:ok, parsed}
-      _ -> {:error, :invalid_integer}
-    end
-  end
-
   defp require_param(params, key) do
     case Map.get(params, key) do
       value when is_binary(value) and value != "" -> {:ok, value}
@@ -2263,61 +2130,6 @@ defmodule ControlKeelWeb.ApiController do
         authorize_session_access(conn, session_id, "reviews:write")
 
       true ->
-        :ok
-    end
-  end
-
-  defp authorize_finding_access(conn, finding, scope) do
-    with %{} = session <- Mission.get_session(finding.session_id) do
-      authorize_workspace_for_conn(conn, session.workspace_id, scope)
-    else
-      nil -> {:error, :not_found}
-    end
-  end
-
-  defp authorize_session_access(conn, session_id, scope) do
-    with {:ok, parsed_id} <- parse_integer_param(session_id),
-         %{} = session <- Mission.get_session(parsed_id) do
-      authorize_workspace_for_conn(conn, session.workspace_id, scope)
-    else
-      {:error, :invalid_integer} -> {:error, :not_found}
-      nil -> {:error, :not_found}
-    end
-  end
-
-  defp authorize_task_access(conn, task_id, scope) do
-    with {:ok, parsed_id} <- parse_integer_param(task_id),
-         %{} = task <- Mission.get_task(parsed_id),
-         %{} = session <- Mission.get_session(task.session_id) do
-      authorize_workspace_for_conn(conn, session.workspace_id, scope)
-    else
-      {:error, :invalid_integer} -> {:error, :not_found}
-      nil -> {:error, :not_found}
-    end
-  end
-
-  defp authorize_workspace_access(conn, workspace_id, scope) do
-    with {:ok, parsed_id} <- parse_integer_param(workspace_id) do
-      authorize_workspace_for_conn(conn, parsed_id, scope)
-    else
-      {:error, :invalid_integer} -> {:error, :not_found}
-    end
-  end
-
-  defp authorize_workspace_for_conn(conn, workspace_id, scope) do
-    case conn.assigns[:api_auth] do
-      %{type: :bootstrap} ->
-        :ok
-
-      %{type: :service_account, service_account: service_account} ->
-        if service_account.workspace_id == workspace_id and
-             Platform.service_account_has_scope?(service_account, scope) do
-          :ok
-        else
-          {:error, :forbidden}
-        end
-
-      _ ->
         :ok
     end
   end

--- a/lib/controlkeel_web/controllers/api_helpers.ex
+++ b/lib/controlkeel_web/controllers/api_helpers.ex
@@ -1,0 +1,129 @@
+defmodule ControlKeelWeb.APIHelpers do
+  @moduledoc """
+  Shared helpers for `/api/v1` controllers: workspace-scoped authorization
+  (bootstrap vs service-account), integer param parsing, workspace resolution,
+  and changeset error rendering.
+
+  Extracted from `ApiController` so per-resource controllers (FindingController,
+  …) share one authorization surface instead of duplicating privates.
+  Controllers `import ControlKeel.Web.APIHelpers` — call sites stay unchanged.
+  """
+
+  alias ControlKeel.Mission
+  alias ControlKeel.Platform
+
+  @doc false
+  def authorize_session_access(conn, session_id, scope) do
+    with {:ok, parsed_id} <- parse_integer_param(session_id),
+         %{} = session <- Mission.get_session(parsed_id) do
+      authorize_workspace_for_conn(conn, session.workspace_id, scope)
+    else
+      {:error, :invalid_integer} -> {:error, :not_found}
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @doc false
+  def authorize_finding_access(conn, finding, scope) do
+    with %{} = session <- Mission.get_session(finding.session_id) do
+      authorize_workspace_for_conn(conn, session.workspace_id, scope)
+    else
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @doc false
+  def authorize_task_access(conn, task_id, scope) do
+    with {:ok, parsed_id} <- parse_integer_param(task_id),
+         %{} = task <- Mission.get_task(parsed_id),
+         %{} = session <- Mission.get_session(task.session_id) do
+      authorize_workspace_for_conn(conn, session.workspace_id, scope)
+    else
+      {:error, :invalid_integer} -> {:error, :not_found}
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @doc false
+  def authorize_workspace_access(conn, workspace_id, scope) do
+    with {:ok, parsed_id} <- parse_integer_param(workspace_id) do
+      authorize_workspace_for_conn(conn, parsed_id, scope)
+    else
+      {:error, :invalid_integer} -> {:error, :not_found}
+    end
+  end
+
+  @doc false
+  def authorize_workspace_for_conn(conn, workspace_id, scope) do
+    case conn.assigns[:api_auth] do
+      %{type: :bootstrap} ->
+        :ok
+
+      %{type: :service_account, service_account: service_account} ->
+        if service_account.workspace_id == workspace_id and
+             Platform.service_account_has_scope?(service_account, scope) do
+          :ok
+        else
+          {:error, :forbidden}
+        end
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc false
+  def current_workspace_id(conn) do
+    case conn.assigns[:api_auth] do
+      %{type: :service_account, service_account: %{workspace_id: ws_id}} when is_integer(ws_id) ->
+        ws_id
+
+      _ ->
+        nil
+    end
+  end
+
+  @doc false
+  def parse_integer_param(value) when is_integer(value), do: {:ok, value}
+
+  def parse_integer_param(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {parsed, ""} -> {:ok, parsed}
+      _ -> {:error, :invalid_integer}
+    end
+  end
+
+  def parse_integer_param(_), do: {:error, :invalid_integer}
+
+  @doc false
+  def finding_summary(finding) do
+    summary = %{
+      id: Map.get(finding, :id),
+      rule_id: finding.rule_id,
+      category: finding.category,
+      severity: finding.severity,
+      status: Map.get(finding, :status, "open"),
+      plain_message: finding.plain_message,
+      auto_fix_available: Map.get(finding, :auto_fix_available, false)
+    }
+
+    if ControlKeel.Governance.SecurityWorkflow.vulnerability_case?(finding) do
+      Map.put(
+        summary,
+        :security_lifecycle,
+        ControlKeel.Governance.SecurityWorkflow.vulnerability_case_summary(finding)
+      )
+    else
+      summary
+    end
+  end
+
+  @doc false
+  def changeset_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
+end

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -217,9 +217,9 @@ defmodule ControlKeelWeb.Router do
     post "/tasks/:id/checks", ApiController, :task_checks
     post "/tasks/:id/report", ApiController, :report_task
     post "/validate", ApiController, :validate
-    get "/findings", ApiController, :list_findings
-    post "/findings", ApiController, :create_finding
-    post "/findings/:id/action", ApiController, :finding_action
+    get "/findings", API.FindingController, :list_findings
+    post "/findings", API.FindingController, :create_finding
+    post "/findings/:id/action", API.FindingController, :finding_action
     get "/proofs", ApiController, :list_proofs
     get "/proofs/:id", ApiController, :get_proof
     get "/benchmarks", ApiController, :list_benchmarks


### PR DESCRIPTION
## Summary

Stacked on #128. First slice of the god-module decomposition (Mission 7014 / ApiController 2328) — establishes the non-breaking extraction pattern: move a coherent resource surface, delegate from the god module so every call site keeps working.

## Change

### `Mission.FindingOps` (Mission: 7014 → 6774)
- Owns `approve_finding` / `reject_finding` / `escalate_finding` / `dispose_finding` / `dispose_session_findings` / `dispose_findings` / `finding_audit_events` plus the atomic status+audit `Multi` and disposition-filter privates
- `Mission` `defdelegate`s to it; shared emitters (`emit_finding_event`, `record_finding_memory`, `emit_platform_finding_event`) became `@doc false` publics FindingOps calls back into

### `ControlKeelWeb.APIHelpers` + `API.FindingController` (ApiController: 2328 → 2140)
- `APIHelpers`: the `/api/v1` authorization surface (session/finding/task/workspace access, scope check, integer parsing, changeset errors, `finding_summary` serializer) — controllers `import` it, so existing call sites compile unchanged
- `API.FindingController`: `list_findings` / `create_finding` / `finding_action` moved out; router repointed (3 routes)

## Follow-ups (same pattern)

`ReviewOps` / `ProofOps` extraction + remaining per-resource controllers (`ReviewController`, `ProofController`, `ServiceAccountController`, …).

## Verification

- `mix compile --warnings-as-errors` clean
- `mix precommit`: **2242/0 (1 excluded), CI workflow guard passed**