### PR TITLE
⚡ Bolt: [performance improvement] Optimize unique list operations with MapSet

### DIFF
--- a/lib/controlkeel/cloud/eval_runner.ex
+++ b/lib/controlkeel/cloud/eval_runner.ex
@@ -158,7 +158,7 @@ defmodule ControlKeel.Cloud.EvalRunner do
     }
 
     result = FastPath.scan(input)
-    actual_rule_ids = result.findings |> Enum.map(& &1.rule_id) |> Enum.uniq() |> Enum.sort()
+    actual_rule_ids = result.findings |> MapSet.new(& &1.rule_id) |> Enum.sort()
     expected_rule_ids = Map.get(c, :expected_rule_ids, []) |> Enum.sort()
     expected_decisions = Map.get(c, :expected_decisions, []) |> MapSet.new()
 

--- a/lib/controlkeel/governance/tech_debt_detector.ex
+++ b/lib/controlkeel/governance/tech_debt_detector.ex
@@ -84,10 +84,10 @@ defmodule ControlKeel.Governance.TechDebtDetector do
     |> Enum.reject(&tech_debt_rule?/1)
     |> Enum.group_by(& &1.rule_id)
     |> Enum.flat_map(fn {rule_id, items} ->
-      distinct_sessions = items |> Enum.map(& &1.session_id) |> Enum.uniq()
+      distinct_sessions = items |> MapSet.new(& &1.session_id)
 
-      if length(distinct_sessions) >= threshold do
-        [build_unresolved_pattern_signal(rule_id, items, distinct_sessions)]
+      if MapSet.size(distinct_sessions) >= threshold do
+        [build_unresolved_pattern_signal(rule_id, items, MapSet.to_list(distinct_sessions))]
       else
         []
       end
@@ -127,7 +127,7 @@ defmodule ControlKeel.Governance.TechDebtDetector do
   end
 
   defp build_repeated_patch_signal(path, items) do
-    session_ids = items |> Enum.map(& &1.session_id) |> Enum.uniq() |> Enum.sort()
+    session_ids = items |> MapSet.new(& &1.session_id) |> Enum.sort()
 
     %{
       rule_id: "CK-TECHDEBT-001",

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -2638,7 +2638,7 @@ defmodule ControlKeel.Mission do
     |> Enum.group_by(fn pattern -> {pattern["type"], pattern["code"]} end)
     |> Enum.map(fn {{type, code}, rows} ->
       severity = rows |> Enum.map(&(&1["severity"] || "low")) |> Enum.max_by(&severity_rank/1)
-      sessions = rows |> Enum.map(& &1["session_id"]) |> Enum.uniq()
+      session_count = rows |> MapSet.new(& &1["session_id"]) |> MapSet.size()
       titles = rows |> Enum.map(& &1["title"]) |> Enum.reject(&is_nil/1) |> Enum.uniq()
 
       %{
@@ -2646,7 +2646,7 @@ defmodule ControlKeel.Mission do
         "code" => code,
         "severity" => severity,
         "count" => length(rows),
-        "session_count" => length(sessions),
+        "session_count" => session_count,
         "titles" => Enum.take(titles, 3),
         "summary" => cluster_summary(rows),
         "examples" =>


### PR DESCRIPTION
💡 **What:** Optimized list uniqueness operations by replacing `Enum.map/2 |> Enum.uniq/1 |> length/1` and `Enum.map/2 |> Enum.uniq/1 |> Enum.sort/1` with `MapSet.new/2 |> MapSet.size/1` and `MapSet.new/2 |> Enum.sort/1`.

🎯 **Why:** Chaining `Enum.map` and `Enum.uniq` creates intermediate list allocations in memory before calculating the length or sorting. Using a `MapSet` directly computes uniqueness without those intermediate lists, avoiding unnecessary garbage collection (GC) overhead.

📊 **Impact:** Reduces memory overhead and GC pressure when processing large datasets by avoiding unnecessary list materialization.

🔬 **Measurement:** Memory profiling and GC tracking during heavy list processing workloads will show fewer garbage collections.

---
*PR created automatically by Jules for task [10352913783534547198](https://jules.google.com/task/10352913783534547198) started by @aryaminus*