### PR TITLE
fix(sandbox): harden sub-worker child-process execution (timeout, kill-on-result, heartbeat)

### DIFF
--- a/lib/controlkeel/agent/execution.ex
+++ b/lib/controlkeel/agent/execution.ex
@@ -434,14 +434,20 @@ defmodule ControlKeel.Agent.Execution do
     sandbox_choice = Process.get(:ck_execution_sandbox)
     _ = maybe_flag_host_execution(task, session, sandbox_choice)
 
+    result_path = Path.join(package_root, "result.json")
+    heartbeat_path = Path.join(package_root, "progress.json")
+
     with {:ok, command, args} <- direct_command(integration.id),
-         result_path = Path.join(package_root, "result.json"),
          sandbox_opts = direct_run_env(task, session, integration, package_root, result_path),
-         {:ok, %{output: output, exit_status: exit_status}} <-
+         {:ok, run_result} <-
            ExecutionSandbox.run(command, args,
              env: sandbox_opts,
-             sandbox: sandbox_choice
-           ) do
+             sandbox: sandbox_choice,
+             timeout_ms: executor_timeout_ms(),
+             result_path: result_path,
+             heartbeat_path: heartbeat_path
+           ),
+         %{output: output, exit_status: exit_status} = run_result do
       payload = direct_result_payload(output, result_path)
       validation = validate_result_payload(payload, session, task)
       status = direct_result_status(exit_status, validation)
@@ -460,7 +466,10 @@ defmodule ControlKeel.Agent.Execution do
                 "args" => args,
                 "output" => String.slice(output, 0, 4_000)
               },
-              metadata: %{"transport" => "embedded"}
+              metadata:
+                %{"transport" => "embedded"}
+                |> Map.put("timed_out", Map.get(run_result, :timed_out, false))
+                |> Map.put("killed_on_result", Map.get(run_result, :killed_on_result, false))
             }
           ] ++ validation_checks(validation)
         )
@@ -476,6 +485,9 @@ defmodule ControlKeel.Agent.Execution do
                "command" => [command | args],
                "validation" => validation,
                "result_ref" => result_ref,
+               "heartbeat_path" => heartbeat_path,
+               "timed_out" => Map.get(run_result, :timed_out, false),
+               "killed_on_result" => Map.get(run_result, :killed_on_result, false),
                "execution_sandbox" =>
                  ExecutionSandbox.adapter_name(sandbox: Process.get(:ck_execution_sandbox))
              }
@@ -848,6 +860,23 @@ defmodule ControlKeel.Agent.Execution do
   end
 
   defp build_input_refs_env(_task), do: "[]"
+
+  # Hard deadline for headless agent-CLI sub-workers (agy -p, claude -p, codex
+  # exec, …). These CLIs can idle after delivering their result; the streaming
+  # Local adapter kills on result delivery and enforces this deadline as a
+  # backstop. Override per deployment with CONTROLKEEL_EXECUTOR_TIMEOUT_MS.
+  defp executor_timeout_ms do
+    case System.get_env("CONTROLKEEL_EXECUTOR_TIMEOUT_MS") do
+      nil ->
+        600_000
+
+      raw ->
+        case Integer.parse(raw) do
+          {ms, ""} when ms > 0 -> ms
+          _ -> 600_000
+        end
+    end
+  end
 
   defp direct_command_available?(agent_id) do
     configured_command(agent_id) != nil

--- a/lib/controlkeel/execution_sandbox/local.ex
+++ b/lib/controlkeel/execution_sandbox/local.ex
@@ -3,19 +3,31 @@ defmodule ControlKeel.ExecutionSandbox.Local do
 
   @behaviour ControlKeel.ExecutionSandbox
 
+  @default_timeout_ms 600_000
+  @result_grace_ms 2_000
+
   @impl true
   def run(command, args, opts) do
-    env = Keyword.get(opts, :env, [])
+    env = Keyword.get(opts, env_key(), [])
     cwd = Keyword.get(opts, :cwd)
+    timeout = Keyword.get(opts, :timeout_ms, @default_timeout_ms)
+    result_path = Keyword.get(opts, :result_path)
+    heartbeat_path = Keyword.get(opts, :heartbeat_path)
 
-    run_opts = [stderr_to_stdout: true]
-    run_opts = if cwd, do: Keyword.put(run_opts, :cd, cwd), else: run_opts
+    command
+    |> resolve_executable()
+    |> case do
+      {:ok, executable} ->
+        stream_run(executable, args,
+          env: env,
+          cwd: cwd,
+          timeout_ms: timeout,
+          result_path: result_path,
+          heartbeat_path: heartbeat_path
+        )
 
-    try do
-      {output, exit_status} = System.cmd(command, args, run_opts ++ [env: env])
-      {:ok, %{output: output, exit_status: exit_status}}
-    rescue
-      e -> {:error, {:execution_failed, Exception.message(e)}}
+      {:error, _} = error ->
+        error
     end
   end
 
@@ -24,4 +36,221 @@ defmodule ControlKeel.ExecutionSandbox.Local do
 
   @impl true
   def adapter_name, do: "local"
+
+  # ─── Streaming runner ────────────────────────────────────────────────────────
+  #
+  # Headless agent CLIs (agy -p, claude -p, codex exec, …) emit their structured
+  # result and then may idle waiting for further input instead of exiting. A bare
+  # blocking System.cmd hangs forever in that case. This runner:
+  #
+  #   * streams stdout (heartbeat file touched on every chunk)
+  #   * kills the child promptly once the executor's result file appears
+  #     (kill-on-result, with a short natural-exit grace window)
+  #   * enforces a hard deadline and reports exit status 124 (timeout(1)
+  #     convention) when the child never delivered a result
+  #
+  # All outcomes stay within the adapter contract `{:ok, %{output, exit_status}}`
+  # with extra diagnostic keys (`timed_out`, `killed_on_result`).
+
+  defp stream_run(executable, args, opts) do
+    env = Keyword.get(opts, :env, [])
+    cwd = Keyword.get(opts, :cwd)
+    timeout_ms = Keyword.get(opts, :timeout_ms, @default_timeout_ms)
+    result_path = Keyword.get(opts, :result_path)
+    heartbeat_path = Keyword.get(opts, :heartbeat_path)
+
+    port_opts =
+      [
+        :binary,
+        :stream,
+        :use_stdio,
+        :stderr_to_stdout,
+        :exit_status,
+        {:args, args},
+        {:env, port_env(env)}
+      ] ++ list_opt(:cd, cwd)
+
+    port = Port.open({:spawn_executable, executable}, port_opts)
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+
+    result =
+      receive_loop(port, %{
+        buffer: [],
+        deadline: deadline,
+        result_path: result_path,
+        heartbeat_path: heartbeat_path,
+        result_seen_at: nil,
+        grace_deadline: nil
+      })
+
+    case result do
+      {:ok, %{exit_status: _} = run} -> {:ok, run}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp receive_loop(port, state) do
+    now = System.monotonic_time(:millisecond)
+
+    cond do
+      state.grace_deadline != nil and now >= state.grace_deadline ->
+        # Result delivered; the child idled past the grace window — kill it.
+        kill_port(port)
+        {:ok, finish(state, exit_status: 0, killed_on_result: true)}
+
+      now >= state.deadline ->
+        kill_port(port)
+        {:ok, finish(state, exit_status: 124, timed_out: true)}
+
+      true ->
+        state = maybe_touch_heartbeat(state)
+
+        receive do
+          {^port, {:data, chunk}} ->
+            state
+            |> Map.update!(:buffer, &[chunk | &1])
+            |> touch_heartbeat()
+            |> detect_result_file()
+            |> then(&receive_loop(port, &1))
+
+          {^port, {:exit_status, status}} ->
+            {:ok, finish(state, exit_status: status)}
+
+          {^port, :closed} ->
+            # The exit_status message is the authoritative terminator; a bare
+            # close (without :exit_status semantics) should not end the run.
+            receive_loop(port, state)
+
+          {:DOWN, ^port, :port, _pid, reason} ->
+            {:ok, finish(state, exit_status: down_exit_status(reason))}
+        after
+          50 ->
+            state
+            |> detect_result_file()
+            |> then(&receive_loop(port, &1))
+        end
+    end
+  end
+
+  # Once the executor's result file exists, allow a short grace window for a
+  # natural exit before killing (mirrors Antigravity Bridge's kill-on-result
+  # guard against WaitForConversationFullyIdle hangs).
+  defp detect_result_file(%{result_path: nil} = state), do: state
+
+  defp detect_result_file(%{result_path: path, grace_deadline: nil} = state)
+       when is_binary(path) do
+    if File.exists?(path) do
+      %{
+        state
+        | result_seen_at: System.monotonic_time(:millisecond),
+          grace_deadline: System.monotonic_time(:millisecond) + @result_grace_ms
+      }
+    else
+      state
+    end
+  end
+
+  defp detect_result_file(state), do: state
+
+  defp maybe_touch_heartbeat(%{heartbeat_path: path} = state) do
+    if is_binary(path) and rem(System.monotonic_time(:millisecond), 8) == 0 do
+      write_heartbeat(path)
+    end
+
+    state
+  end
+
+  defp touch_heartbeat(%{heartbeat_path: nil} = state), do: state
+
+  defp touch_heartbeat(%{heartbeat_path: path} = state) do
+    write_heartbeat(path)
+    state
+  end
+
+  defp write_heartbeat(path) do
+    payload =
+      %{
+        "ts" => DateTime.utc_now() |> DateTime.to_iso8601(),
+        "pid" => System.get_env("CONTROLKEEL_SESSION_ID")
+      }
+      |> Jason.encode!()
+
+    path |> Path.dirname() |> File.mkdir_p!()
+    File.write!(path, payload)
+  rescue
+    _ -> :ok
+  end
+
+  defp finish(state, overrides) do
+    output =
+      state.buffer
+      |> Enum.reverse()
+      |> Enum.join()
+
+    run =
+      %{output: output, exit_status: nil}
+      |> Map.merge(Map.new(overrides))
+
+    run =
+      if Map.get(run, :killed_on_result, false) or Map.get(run, :timed_out, false) do
+        note =
+          if Map.get(run, :killed_on_result) do
+            "\n[controlkeel] child terminated after result delivery (idle-wait guard)\n"
+          else
+            "\n[controlkeel] child terminated on deadline (#{Map.get(run, :exit_status)})\n"
+          end
+
+        %{run | output: output <> note}
+      else
+        run
+      end
+
+    Map.take(run, [:output, :exit_status, :timed_out, :killed_on_result])
+  end
+
+  defp kill_port(port) do
+    # Port.close sends SIGTERM to the child on Unix.
+    Port.close(port)
+    # Drain the exit message so the mailbox stays clean.
+    receive do
+      {^port, {:exit_status, _}} -> :ok
+    after
+      1_000 -> :ok
+    end
+  rescue
+    _ -> :ok
+  end
+
+  defp down_exit_status(:normal), do: 0
+  defp down_exit_status(:killed), do: 143
+  defp down_exit_status(_), do: 1
+
+  defp resolve_executable(command) do
+    case System.find_executable(command) do
+      nil -> {:error, {:command_not_found, command}}
+      path -> {:ok, path}
+    end
+  end
+
+  defp list_opt(_key, nil), do: []
+  defp list_opt(key, value), do: [{key, value}]
+
+  # Ports accept only "KEY=value" binaries (System.cmd-style {k, v} tuples
+  # must be normalized).
+  defp port_env(env) do
+    Enum.map(env, fn
+      {key, value} when is_binary(key) and is_binary(value) ->
+        {String.to_charlist(key), String.to_charlist(value)}
+
+      {key, value} when is_list(key) and is_list(value) ->
+        {key, value}
+
+      entry when is_binary(entry) ->
+        [key, value] = String.split(entry, "=", parts: 2)
+        {String.to_charlist(key), String.to_charlist(value)}
+    end)
+  end
+
+  # Tests may pass charlist env (System.cmd style) or binary pairs.
+  defp env_key, do: :env
 end

--- a/test/controlkeel/execution_sandbox/local_stream_test.exs
+++ b/test/controlkeel/execution_sandbox/local_stream_test.exs
@@ -1,0 +1,105 @@
+defmodule ControlKeel.ExecutionSandbox.LocalStreamTest do
+  # Port-based streaming, timeout, kill-on-result, and heartbeat — the
+  # liveness disciplines headless agent-CLI sub-workers need (Antigravity
+  # Bridge-style idle-wait protection).
+  use ExUnit.Case, async: true
+
+  alias ControlKeel.ExecutionSandbox.Local
+
+  defp tmp_dir do
+    dir = Path.join(System.tmp_dir!(), "ck-local-stream-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    dir
+  end
+
+  defp sh_script(body) do
+    dir = tmp_dir()
+    script = Path.join(dir, "run.sh")
+    File.write!(script, "#!/bin/sh\n" <> body)
+    File.chmod!(script, 0o755)
+    script
+  end
+
+  test "runs to natural completion and captures output" do
+    script = sh_script("echo hello-from-child")
+
+    assert {:ok, run} = Local.run(script, [], timeout_ms: 5_000)
+    assert run.exit_status == 0
+    assert run.output =~ "hello-from-child"
+    refute run[:timed_out]
+    refute run[:killed_on_result]
+  end
+
+  test "captures non-zero exit status" do
+    script = sh_script("echo boom >&2; exit 3")
+
+    assert {:ok, run} = Local.run(script, [], timeout_ms: 5_000)
+    assert run.exit_status == 3
+    assert run.output =~ "boom"
+  end
+
+  test "kill-on-result: terminates an idle child once the result file appears" do
+    dir = tmp_dir()
+    result_path = Path.join(dir, "result.json")
+
+    script =
+      sh_script(
+        "echo working; sleep 1; echo '{\"done\":true}' > " <> result_path <> "; sleep 300"
+      )
+
+    started = System.monotonic_time(:millisecond)
+
+    assert {:ok, run} =
+             Local.run(script, [], timeout_ms: 30_000, result_path: result_path)
+
+    elapsed = System.monotonic_time(:millisecond) - started
+
+    # Result delivered then child idled: killed within the grace window, well
+    # before the 300s sleep (and the 30s deadline).
+    assert run[:killed_on_result] == true
+    assert run.exit_status == 0
+    assert run.output =~ "idle-wait guard"
+    assert File.exists?(result_path)
+    assert elapsed < 15_000
+    refute run[:timed_out]
+  end
+
+  test "hard deadline: reports exit 124 when no result is ever delivered" do
+    script = sh_script("echo spinning; sleep 60")
+
+    assert {:ok, run} = Local.run(script, [], timeout_ms: 1_500)
+
+    assert run[:timed_out] == true
+    assert run.exit_status == 124
+    assert run.output =~ "spinning"
+    assert run.output =~ "terminated on deadline"
+  end
+
+  test "heartbeat file is written and kept fresh during execution" do
+    dir = tmp_dir()
+    heartbeat = Path.join(dir, "progress.json")
+    # Emit output for a while so the heartbeat gets touched repeatedly.
+    script = sh_script("for i in 1 2 3 4 5; do echo tick-$i; sleep 0.15; done")
+
+    assert {:ok, run} = Local.run(script, [], timeout_ms: 10_000, heartbeat_path: heartbeat)
+    assert run.exit_status == 0
+
+    assert File.exists?(heartbeat)
+    {:ok, payload} = Jason.decode(File.read!(heartbeat))
+    assert is_binary(payload["ts"])
+  end
+
+  test "returns command_not_found for a missing executable" do
+    assert {:error, {:command_not_found, "definitely-not-a-real-cmd-xyz"}} =
+             Local.run("definitely-not-a-real-cmd-xyz", [], timeout_ms: 1_000)
+  end
+
+  test "cwd option is honored" do
+    dir = tmp_dir()
+    script = sh_script("pwd")
+
+    assert {:ok, run} = Local.run(script, [], cwd: dir, timeout_ms: 5_000)
+    assert run.exit_status == 0
+    assert run.output =~ Path.basename(dir)
+  end
+end


### PR DESCRIPTION
## Summary

Applies the only sensible Bridge-inspired change to ControlKeel: the **child-process liveness discipline** (timeout, kill-on-result, heartbeat) — not an agy-specific clone.

Bridge lets orchestrators delegate heavy work to a headless Antigravity CLI (`agy -p`) via MCP (`agy_run`, conversation tracking, heartbeat `/tmp/agy-job.progress`, kill-on-`result` to avoid `WaitForConversationFullyIdle` hangs). ControlKeel already covers the rest via governance:

- **Bridge lacks:** policy preflight, sandbox adapters, `ck_validate` on outputs, `ck_finding`/`ck_review_submit` gates, budget (`claim_task` gate), proof/`deploy_ready` gates, rollback/file-safety.
- **ControlKeel lacks:** hardened child-process execution for headless CLIs. `ExecutionSandbox.Local` used a bare blocking `System.cmd` with **no timeout and no streaming** — a headless agent CLI that idles after emitting its structured result hangs the embedded delegate forever (Docker had the timeout, Local had none). This is exactly the bug class Bridge was designed to solve.

CK's `CONTROLKEEL_EXECUTOR_<AGENT>_CMD` contract already makes **any** headless CLI pluggable as a sub-worker (`agy`, `claude -p`, `codex exec`, `grok` etc.) — no agy-specific tool is needed.

## Change

- **`ExecutionSandbox.Local`**: Port-based streaming runner with:
  - Hard deadline (`CONTROLKEEL_EXECUTOR_TIMEOUT_MS`, default 600s, exit `124` — `timeout(1)` convention — on miss)
  - **Kill-on-result**: watches `CONTROLKEEL_RESULT_PATH` (`result.json` per the embedded contract), grace window (`2s`), terminates the idle child and notes `idle-wait guard` in output (mirrors Bridge's kill-on-`result` event)
  - **Heartbeat**: `controlkeel/runs/task-*/progress.json` touched on every output chunk (Bridge's `/tmp/agy-job.progress` equivalent, but run-scoped)
  - All outcomes stay within `{:ok, %{output, exit_status}}` + diagnostic keys `timed_out` / `killed_on_result`
  - Env normalized to `{charlist, charlist}` tuples for the Port
- **`dispatch_run(embedded)`**: pass `timeout_ms`, `result_path`, `heartbeat_path` through to the sandbox; record `timed_out`/`killed_on_result` flags in the executor check payload and run metadata

## Verification

- `mix compile --warnings-as-errors` clean
- Existing suites: `execution_sandbox/sandbox_test`, `execution_sandbox/preflight_test`, `execution_sandbox_test`, `agent/execution_test` — 34/0
- New: `execution_sandbox/local_stream_test` — 7/0 (natural completion, non-zero exit, hang-after-result → `killed_on_result`, hard-deadline → 124, heartbeat freshness, cwd, missing executable)
- Full: `mix precommit` `2266/1 flake` (bin_wrapper context WAL race, passes isolated `3/0` — pre-existing)