### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and focus styles to sidebar

### DIFF
--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -16,6 +16,8 @@ defmodule ControlKeelWeb.Layouts do
 
   embed_templates "layouts/*"
 
+  @focus_ring "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+
   @doc """
   The dashboard sidebar: logo, primary nav, and external links.
 
@@ -202,11 +204,11 @@ defmodule ControlKeelWeb.Layouts do
   defp nav_active?(_current_path, _path, _exact), do: false
 
   defp sidebar_link_class(true) do
-    "group flex items-center gap-3 rounded-xl bg-muted px-3 py-2.5 font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+    "group flex items-center gap-3 rounded-xl bg-muted px-3 py-2.5 font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted #{@focus_ring}"
   end
 
   defp sidebar_link_class(false) do
-    "group flex items-center gap-3 rounded-xl px-3 py-2.5 font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+    "group flex items-center gap-3 rounded-xl px-3 py-2.5 font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground #{@focus_ring}"
   end
 
   defp sidebar_icon_class(true), do: "size-4 text-primary"
@@ -240,11 +242,11 @@ defmodule ControlKeelWeb.Layouts do
   end
 
   defp subnav_link_class(true) do
-    "group flex items-center gap-2.5 rounded-lg bg-muted px-2.5 py-1.5 text-sm font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+    "group flex items-center gap-2.5 rounded-lg bg-muted px-2.5 py-1.5 text-sm font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted #{@focus_ring}"
   end
 
   defp subnav_link_class(false) do
-    "group flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+    "group flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground #{@focus_ring}"
   end
 
   defp subnav_icon_class(true), do: "size-3.5 shrink-0 text-primary"

--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -62,6 +62,7 @@ defmodule ControlKeelWeb.Layouts do
                 data-sidebar-toggle
                 aria-expanded={(opened && "true") || "false"}
                 aria-controls={collapse_id}
+                aria-label={"Toggle #{item.label} menu"}
                 class={["w-full text-left cursor-pointer", sidebar_link_class(active)]}
               >
                 <.icon name={item.icon} class={sidebar_icon_class(active)} />
@@ -201,11 +202,11 @@ defmodule ControlKeelWeb.Layouts do
   defp nav_active?(_current_path, _path, _exact), do: false
 
   defp sidebar_link_class(true) do
-    "group flex items-center gap-3 rounded-xl bg-muted px-3 py-2.5 font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted"
+    "group flex items-center gap-3 rounded-xl bg-muted px-3 py-2.5 font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
   end
 
   defp sidebar_link_class(false) do
-    "group flex items-center gap-3 rounded-xl px-3 py-2.5 font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+    "group flex items-center gap-3 rounded-xl px-3 py-2.5 font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
   end
 
   defp sidebar_icon_class(true), do: "size-4 text-primary"
@@ -239,11 +240,11 @@ defmodule ControlKeelWeb.Layouts do
   end
 
   defp subnav_link_class(true) do
-    "group flex items-center gap-2.5 rounded-lg bg-muted px-2.5 py-1.5 text-sm font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted"
+    "group flex items-center gap-2.5 rounded-lg bg-muted px-2.5 py-1.5 text-sm font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
   end
 
   defp subnav_link_class(false) do
-    "group flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+    "group flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
   end
 
   defp subnav_icon_class(true), do: "size-3.5 shrink-0 text-primary"

--- a/test/controlkeel_web/components/layouts_test.exs
+++ b/test/controlkeel_web/components/layouts_test.exs
@@ -12,6 +12,7 @@ defmodule ControlKeelWeb.LayoutsTest do
     assert html =~ "sidebar-collapse-observability"
     assert html =~ "sidebar-chevron-observability"
     assert html =~ "aria-expanded=\"false\""
+    assert html =~ "aria-label=\"Toggle Observability menu\""
     assert html =~ "hidden"
     assert html =~ "Overview"
     assert html =~ "Learning loop"
@@ -24,6 +25,13 @@ defmodule ControlKeelWeb.LayoutsTest do
     assert html =~ "aria-expanded=\"true\""
     assert html =~ "rotate-90"
     assert anchor_for(html, "/observability") =~ "aria-current=\"page\""
+  end
+
+  test "sidebar links carry expected focus-visible styles" do
+    html = render_component(&Layouts.sidebar/1, current_path: "/dashboard")
+
+    assert html =~ "focus-visible:ring-offset-2"
+    assert html =~ "focus-visible:ring-offset-background"
   end
 
   test "sidebar highlights the matching child on deep observability paths" do


### PR DESCRIPTION
**💡 What:** 
Added unique `aria-label`s to the sidebar toggle buttons and introduced `focus-visible` styles to all sidebar and subnav links.

**🎯 Why:** 
Screen reader users previously received ambiguous announcements when encountering the dynamic sidebar toggles because they lacked distinct labels. Keyboard users could navigate to sidebar links, but without explicit focus styles, it was difficult to see which link was currently focused.

**📸 Before/After:** 
(Visual changes are limited to keyboard navigation focus outlines, not rendering changes.)

**♿ Accessibility:**
- Sidebar toggle button now reads out context: `Toggle <Label> menu`
- All sidebar and subnav links now use Tailwind's `focus-visible` utility classes to clearly ring focused elements without polluting the UI on mouse click.

---
*PR created automatically by Jules for task [5084217247193983222](https://jules.google.com/task/5084217247193983222) started by @aryaminus*