### PR TITLE
🎨 Palette: Add dynamic ARIA labels to sidebar toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-08-31 - Dynamic ARIA labels in HEEx loops
+**Learning:** When adding ARIA labels to elements within dynamically rendered loops in HEEx templates, static strings cause ambiguous or duplicate announcements for screen readers.
+**Action:** Always interpolate unique context from the loop variable (e.g., `aria-label={"Toggle #{item.label} menu"}`) instead of using a static string.

--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -60,6 +60,7 @@ defmodule ControlKeelWeb.Layouts do
                 type="button"
                 id={"sidebar-toggle-#{label_id}"}
                 data-sidebar-toggle
+                aria-label={"Toggle #{item.label} menu"}
                 aria-expanded={(opened && "true") || "false"}
                 aria-controls={collapse_id}
                 class={["w-full text-left cursor-pointer", sidebar_link_class(active)]}


### PR DESCRIPTION
**💡 What:** Added dynamic `aria-label`s to the sidebar section toggle buttons in `layouts.ex` based on the section name.

**🎯 Why:** The icon-only toggle buttons (chevron) previously had no descriptive names, leading to ambiguous or missing announcements for screen reader users trying to interact with the sidebar sections.

**📸 Before/After:** N/A - Visuals are unchanged.

**♿ Accessibility:** Screen readers will now distinctly announce the functionality of each sidebar toggle (e.g., "Toggle Dashboard menu", "Toggle Sessions menu") instead of a generic button announcement, improving navigational clarity.

---
*PR created automatically by Jules for task [6707980632129972843](https://jules.google.com/task/6707980632129972843) started by @aryaminus*