### PR TITLE
refactor/proofs-web — Proofs web parity (release gate + audit export + proof visibility)

### DIFF
--- a/lib/controlkeel/governance.ex
+++ b/lib/controlkeel/governance.ex
@@ -237,7 +237,18 @@ defmodule ControlKeel.Governance do
           end
 
         telemetry =
-          record_release_event(session, status, latest_proof, smoke, provenance, reasons, opts)
+          if record_telemetry?(opts),
+            do:
+              record_release_event(
+                session,
+                status,
+                latest_proof,
+                smoke,
+                provenance,
+                reasons,
+                opts
+              ),
+            else: nil
 
         {:ok,
          %{
@@ -1006,6 +1017,13 @@ defmodule ControlKeel.Governance do
 
   defp maybe_add_reason(reasons, true, reason), do: reasons ++ [reason]
   defp maybe_add_reason(reasons, false, _reason), do: reasons
+
+  defp record_telemetry?(opts) do
+    case opts["record_telemetry"] || opts[:record_telemetry] do
+      nil -> true
+      value -> Utils.truthy?(value)
+    end
+  end
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/lib/controlkeel/observability.ex
+++ b/lib/controlkeel/observability.ex
@@ -3031,6 +3031,8 @@ defmodule ControlKeel.Observability do
   end
 
   defp timeline_event(event) do
+    payload = event_value(event, :payload) || %{}
+
     %{
       id: event_value(event, :id),
       event_type: event_value(event, :event_type) || "event",
@@ -3038,6 +3040,7 @@ defmodule ControlKeel.Observability do
       summary: event_value(event, :summary) || "No summary",
       body: event_value(event, :body),
       task_id: event_value(event, :task_id),
+      proof_id: payload["proof_id"],
       inserted_at: format_datetime(event_value(event, :inserted_at))
     }
   end

--- a/lib/controlkeel/platform.ex
+++ b/lib/controlkeel/platform.ex
@@ -6,7 +6,7 @@ defmodule ControlKeel.Platform do
   alias Ecto.Multi
   alias ControlKeel.{AuditExports, Budget, Mission, Repo}
   alias ControlKeel.Mission.Decomposition
-  alias ControlKeel.Mission.{ProofBundle, Session, Task}
+  alias ControlKeel.Mission.{ProofBundle, Session, SessionTranscript, Task}
 
   alias ControlKeel.Platform.{
     Export,
@@ -764,7 +764,9 @@ defmodule ControlKeel.Platform do
     end
   end
 
-  def export_audit_log(session_id, format) when format in ["json", "csv", "pdf"] do
+  def export_audit_log(session_id, format), do: export_audit_log(session_id, format, [])
+
+  def export_audit_log(session_id, format, opts) when format in ["json", "csv", "pdf"] do
     with %Session{} = session <- Mission.get_session_context(session_id),
          {:ok, audit_log} <- Mission.audit_log(session_id),
          graph <- ensure_session_graph(session_id),
@@ -784,11 +786,41 @@ defmodule ControlKeel.Platform do
         workspace_id: session.workspace_id
       )
 
+      record_audit_export_event(session, export, Keyword.get(opts, :actor, "platform"))
+
       {:ok, %{export: export, payload: payload}}
     else
       nil -> {:error, :not_found}
       {:error, _reason} = error -> error
     end
+  end
+
+  def list_audit_exports(session_id, limit \\ 5) when is_integer(session_id) do
+    Export
+    |> where([e], e.session_id == ^session_id)
+    |> order_by([e], desc: e.id)
+    |> limit(^limit)
+    |> Repo.all()
+  end
+
+  defp record_audit_export_event(%Session{} = session, %Export{} = export, actor) do
+    checksum_prefix = String.slice(export.checksum || "", 0, 12)
+
+    _ =
+      SessionTranscript.record(%{
+        "session_id" => session.id,
+        "event_type" => "audit.exported",
+        "actor" => actor,
+        "summary" => "Audit log exported (#{export.format}) — checksum #{checksum_prefix}",
+        "payload" => %{
+          "format" => export.format,
+          "checksum" => export.checksum,
+          "audit_export_id" => export.id
+        },
+        "metadata" => %{}
+      })
+
+    :ok
   end
 
   def persist_proof_generated(%ProofBundle{} = proof) do

--- a/lib/controlkeel_web/components/recent_sessions.ex
+++ b/lib/controlkeel_web/components/recent_sessions.ex
@@ -30,7 +30,7 @@ defmodule ControlKeelWeb.RecentSessions do
                 </p>
                 <span class={health_pill_class(run.health)}>{run.health}</span>
               </div>
-              <dl class="mt-4 grid grid-cols-3 gap-3 border-t border-border pt-3 text-xs">
+              <dl class="mt-4 grid grid-cols-4 gap-3 border-t border-border pt-3 text-xs">
                 <div>
                   <dt class="text-muted-foreground">Findings</dt>
                   <dd class="mt-0.5 font-medium text-foreground">
@@ -38,6 +38,16 @@ defmodule ControlKeelWeb.RecentSessions do
                     <span :if={run.blocked_findings > 0}>
                       · {run.blocked_findings} blocked
                     </span>
+                  </dd>
+                </div>
+                <div>
+                  <dt class="text-muted-foreground">Proofs</dt>
+                  <dd class="mt-0.5 font-medium text-foreground">
+                    <%= if (Map.get(run, :proof_bundles) || 0) > 0 do %>
+                      {run.proof_bundles} bundles
+                    <% else %>
+                      <span class="font-normal text-muted-foreground">No proofs yet</span>
+                    <% end %>
                   </dd>
                 </div>
                 <div>

--- a/lib/controlkeel_web/components/release_readiness.ex
+++ b/lib/controlkeel_web/components/release_readiness.ex
@@ -1,0 +1,185 @@
+defmodule ControlKeelWeb.ReleaseReadiness do
+  @moduledoc """
+  Renders the per-session release readiness gate in Mission Control: verdict
+  badge, release-candidate proof, findings breakdown, blocking reasons, and
+  the smoke/provenance evidence form. Events (`check_release_readiness`) are
+  handled by the parent LiveView.
+  """
+  use ControlKeelWeb, :html
+
+  attr :readiness, :map, default: nil, doc: "result map from Governance.release_readiness/1"
+  attr :form, Phoenix.HTML.Form, required: true
+  attr :session_id, :integer, required: true
+
+  def release_readiness(assigns) do
+    ~H"""
+    <section id="mission-release-readiness" class="rounded-2xl border bg-card p-5 shadow-card mt-6">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <.section_title>Release readiness</.section_title>
+        <span
+          :if={@readiness}
+          id="release-readiness-status"
+          class={status_badge_class(@readiness["status"])}
+        >
+          {status_label(@readiness["status"])}
+        </span>
+      </div>
+      <p class="text-sm text-muted-foreground mt-2">
+        Ship / no-ship gate over proof state, findings, smoke evidence, and artifact provenance —
+        the same gate behind <code class="font-mono bg-muted px-1.5 py-0.5 rounded text-xs">controlkeel release-ready</code>.
+      </p>
+
+      <%= if is_nil(@readiness) do %>
+        <p class="mt-4 text-sm text-muted-foreground" id="release-readiness-unavailable">
+          Release readiness could not be evaluated for this session yet. Submit the evidence below to run the gate.
+        </p>
+      <% else %>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+          <div class="rounded-2xl bg-muted p-4">
+            <p class="text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-muted-foreground mb-2">
+              Release-candidate proof
+            </p>
+            <%= if @readiness["proof"] do %>
+              <div class="flex flex-wrap items-center gap-2">
+                <.link
+                  navigate={~p"/proofs/#{@readiness["proof"]["id"]}"}
+                  class="text-sm font-medium text-primary transition hover:text-primary"
+                >
+                  Proof #{@readiness["proof"]["id"]} v{@readiness["proof"]["version"]}
+                </.link>
+                <span class={[
+                  "inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ring-1",
+                  if(@readiness["proof"]["deploy_ready"],
+                    do: "bg-success/10 text-success ring-success/20",
+                    else: "bg-warning/10 text-warning ring-warning/20"
+                  )
+                ]}>
+                  {if @readiness["proof"]["deploy_ready"], do: "deploy-ready", else: "review required"}
+                </span>
+                <span class="text-xs text-muted-foreground">
+                  risk {@readiness["proof"]["risk_score"]}
+                </span>
+              </div>
+            <% else %>
+              <p class="text-sm text-muted-foreground">
+                No proof bundle is available for release review yet.
+              </p>
+            <% end %>
+          </div>
+          <div class="rounded-2xl bg-muted p-4">
+            <p class="text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-muted-foreground mb-2">
+              Unresolved findings
+            </p>
+            <div class="flex flex-wrap items-center gap-1.5">
+              <span class="inline-flex rounded-full border bg-card px-2.5 py-1 text-xs text-muted-foreground">
+                {@readiness["findings"]["open"]} open
+              </span>
+              <span class="inline-flex rounded-full border bg-card px-2.5 py-1 text-xs text-muted-foreground">
+                {@readiness["findings"]["blocked"]} blocked
+              </span>
+              <span class="inline-flex rounded-full border bg-card px-2.5 py-1 text-xs text-muted-foreground">
+                {@readiness["findings"]["escalated"]} escalated
+              </span>
+              <span class="inline-flex rounded-full border bg-card px-2.5 py-1 text-xs text-muted-foreground">
+                {@readiness["findings"]["high_or_critical"]} high or critical
+              </span>
+              <span
+                :if={@readiness["findings"]["critical_vulnerability_cases"] > 0}
+                class="inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ring-1 bg-destructive/10 text-destructive ring-destructive/20"
+              >
+                {@readiness["findings"]["critical_vulnerability_cases"]} vulnerability case(s)
+              </span>
+            </div>
+            <.link
+              navigate={~p"/findings?#{%{"session_id" => @session_id, "status" => "open"}}"}
+              class="inline-flex items-center gap-1 mt-3 text-sm font-medium text-muted-foreground transition hover:text-primary"
+            >
+              View open findings <.icon name="hero-arrow-up-right" class="size-3" />
+            </.link>
+          </div>
+        </div>
+
+        <%= if @readiness["status"] == "ready" do %>
+          <p class="mt-4 text-sm text-success" id="release-readiness-summary">
+            {@readiness["summary"]}
+          </p>
+        <% else %>
+          <div class="mt-4" id="release-readiness-reasons">
+            <p class="text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-muted-foreground mb-2">
+              Unmet gate conditions
+            </p>
+            <ul class="space-y-1 text-sm text-muted-foreground list-disc ml-5">
+              <%= for reason <- @readiness["reasons"] do %>
+                <li>{reason}</li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+      <% end %>
+
+      <div class="mt-5 border-t pt-5">
+        <p class="text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-muted-foreground mb-3">
+          Release evidence
+        </p>
+        <.form
+          for={@form}
+          id="release-readiness-form"
+          phx-submit="check_release_readiness"
+          class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 items-start"
+        >
+          <.input
+            field={@form[:smoke_status]}
+            type="select"
+            label="Smoke status"
+            options={[{"Not run yet", ""}, {"Passed", "success"}, {"Failed", "failed"}]}
+          />
+          <.input
+            field={@form[:smoke_run]}
+            type="text"
+            label="Smoke run URL or note"
+            placeholder="https://ci.example.com/run/1234"
+          />
+          <.input
+            field={@form[:artifact_source]}
+            type="text"
+            label="Artifact source"
+            placeholder="github-actions"
+          />
+          <.input
+            field={@form[:sha]}
+            type="text"
+            label="Commit SHA"
+            placeholder="release commit (optional)"
+          />
+          <.input
+            field={@form[:provenance_verified]}
+            type="checkbox"
+            label="Artifact provenance verified"
+          />
+          <div>
+            <.button type="submit" variant="default">
+              <.icon name="hero-shield-check" class="size-4" /> Check release readiness
+            </.button>
+          </div>
+        </.form>
+      </div>
+    </section>
+    """
+  end
+
+  defp status_badge_class("ready"),
+    do:
+      "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] bg-success/15 text-success border-success/30"
+
+  defp status_badge_class("blocked"),
+    do:
+      "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] bg-destructive/15 text-destructive border-destructive/30"
+
+  defp status_badge_class(_status),
+    do:
+      "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] bg-warning/15 text-warning border-warning/30"
+
+  defp status_label("needs-review"), do: "needs review"
+  defp status_label(status) when is_binary(status), do: status
+  defp status_label(nil), do: "not checked"
+end

--- a/lib/controlkeel_web/controllers/observability_controller.ex
+++ b/lib/controlkeel_web/controllers/observability_controller.ex
@@ -56,6 +56,11 @@ defmodule ControlKeelWeb.ObservabilityController do
         |> put_status(:bad_request)
         |> json(%{error: "format must be json, csv, or pdf"})
 
+      {:error, :invalid_session_id} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "session id must be an integer"})
+
       {:error, :not_found} ->
         conn
         |> put_status(:not_found)
@@ -81,7 +86,7 @@ defmodule ControlKeelWeb.ObservabilityController do
   defp parse_session_id(id) do
     case Integer.parse(id) do
       {session_id, ""} -> {:ok, session_id}
-      _ -> {:error, :not_found}
+      _ -> {:error, :invalid_session_id}
     end
   end
 end

--- a/lib/controlkeel_web/controllers/observability_controller.ex
+++ b/lib/controlkeel_web/controllers/observability_controller.ex
@@ -1,6 +1,8 @@
 defmodule ControlKeelWeb.ObservabilityController do
   use ControlKeelWeb, :controller
 
+  require Logger
+
   # Mirrors LiveAuth.require_cloud_auth: passthrough in local mode, requires a
   # signed-in user in cloud/self_hosted, and verifies org ownership of the
   # session's workspace to prevent cross-org data leakage (CK-AUTH-001).
@@ -65,9 +67,11 @@ defmodule ControlKeelWeb.ObservabilityController do
         |> json(%{error: "pdf_export_unavailable"})
 
       {:error, reason} ->
+        Logger.error("audit export failed: #{inspect(reason)}")
+
         conn
         |> put_status(:unprocessable_entity)
-        |> json(%{error: inspect(reason)})
+        |> json(%{error: "audit export failed"})
     end
   end
 

--- a/lib/controlkeel_web/controllers/observability_controller.ex
+++ b/lib/controlkeel_web/controllers/observability_controller.ex
@@ -7,6 +7,14 @@ defmodule ControlKeelWeb.ObservabilityController do
   plug ControlKeelWeb.Plugs.RequireSessionAuth
 
   alias ControlKeel.Observability.Telemetry
+  alias ControlKeel.Platform
+
+  @audit_formats ~w(json csv pdf)
+  @audit_content_types %{
+    "json" => "application/json",
+    "csv" => "text/csv",
+    "pdf" => "application/pdf"
+  }
 
   def export_session(conn, %{"id" => id}) do
     case Telemetry.export_session(id) do
@@ -22,6 +30,54 @@ defmodule ControlKeelWeb.ObservabilityController do
         conn
         |> put_status(:unprocessable_entity)
         |> json(%{error: "session id must be an integer"})
+    end
+  end
+
+  # Thin wrapper over Platform.export_audit_log/3 — the payload is served
+  # verbatim (no re-rendering), with the same attachment disposition as the
+  # API-token route GET /api/v1/sessions/:id/audit-log.
+  def export_audit_log(conn, %{"id" => id, "format" => format}) do
+    with {:ok, format} <- validate_audit_format(format),
+         {:ok, session_id} <- parse_session_id(id),
+         {:ok, %{payload: payload}} <-
+           Platform.export_audit_log(session_id, format, actor: "web") do
+      conn
+      |> put_resp_content_type(@audit_content_types[format])
+      |> put_resp_header(
+        "content-disposition",
+        "attachment; filename=\"audit-log-#{session_id}.#{format}\""
+      )
+      |> send_resp(200, payload)
+    else
+      {:error, :unsupported_format} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: "format must be json, csv, or pdf"})
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "session not found"})
+
+      {:error, :renderer_unavailable} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: "pdf_export_unavailable"})
+
+      {:error, reason} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: inspect(reason)})
+    end
+  end
+
+  defp validate_audit_format(format) when format in @audit_formats, do: {:ok, format}
+  defp validate_audit_format(_format), do: {:error, :unsupported_format}
+
+  defp parse_session_id(id) do
+    case Integer.parse(id) do
+      {session_id, ""} -> {:ok, session_id}
+      _ -> {:error, :not_found}
     end
   end
 end

--- a/lib/controlkeel_web/live/mission_control_live.ex
+++ b/lib/controlkeel_web/live/mission_control_live.ex
@@ -72,13 +72,7 @@ defmodule ControlKeelWeb.MissionControlLive do
         {:noreply, socket}
 
       session ->
-        {:noreply,
-         socket
-         |> assign_session(session)
-         |> assign_release_readiness(
-           socket.assigns[:release_form_params] || release_form_defaults(),
-           false
-         )}
+        {:noreply, socket |> assign_session(session)}
     end
   end
 
@@ -132,7 +126,10 @@ defmodule ControlKeelWeb.MissionControlLive do
 
         session ->
           {:noreply,
-           socket |> put_flash(:info, "Finding approved.") |> safe_assign_session(session)}
+           socket
+           |> put_flash(:info, "Finding approved.")
+           |> safe_assign_session(session)
+           |> refresh_release_readiness()}
       end
     else
       _error -> {:noreply, put_flash(socket, :error, "Could not approve finding.")}
@@ -156,7 +153,10 @@ defmodule ControlKeelWeb.MissionControlLive do
 
         session ->
           {:noreply,
-           socket |> put_flash(:info, "Finding rejected.") |> safe_assign_session(session)}
+           socket
+           |> put_flash(:info, "Finding rejected.")
+           |> safe_assign_session(session)
+           |> refresh_release_readiness()}
       end
     else
       _error -> {:noreply, put_flash(socket, :error, "Could not reject finding.")}
@@ -170,7 +170,10 @@ defmodule ControlKeelWeb.MissionControlLive do
          session when not is_nil(session) <-
            Mission.get_session_context(socket.assigns.session.id) do
       {:noreply,
-       socket |> put_flash(:info, "Proof bundle generated.") |> safe_assign_session(session)}
+       socket
+       |> put_flash(:info, "Proof bundle generated.")
+       |> safe_assign_session(session)
+       |> refresh_release_readiness()}
     else
       _error -> {:noreply, put_flash(socket, :error, "Could not generate proof bundle.")}
     end
@@ -180,11 +183,16 @@ defmodule ControlKeelWeb.MissionControlLive do
   def handle_event("check_release_readiness", %{"release" => params}, socket) do
     form_params = Map.merge(release_form_defaults(), params)
 
+    socket =
+      socket
+      |> assign(:release_form_params, form_params)
+      |> assign_release_readiness(form_params, true)
+
     {:noreply,
-     socket
-     |> assign(:release_form_params, form_params)
-     |> assign_release_readiness(form_params, true)
-     |> put_flash(:info, "Release readiness checked.")}
+     case socket.assigns.release_readiness do
+       nil -> socket
+       _readiness -> put_flash(socket, :info, "Release readiness checked.")
+     end}
   end
 
   @impl true
@@ -221,7 +229,11 @@ defmodule ControlKeelWeb.MissionControlLive do
          {:ok, _result} <- Mission.pause_task(task_id, "mission_control"),
          session when not is_nil(session) <-
            Mission.get_session_context(socket.assigns.session.id) do
-      {:noreply, socket |> put_flash(:info, "Task paused.") |> safe_assign_session(session)}
+      {:noreply,
+       socket
+       |> put_flash(:info, "Task paused.")
+       |> safe_assign_session(session)
+       |> refresh_release_readiness()}
     else
       _error -> {:noreply, put_flash(socket, :error, "Could not pause task.")}
     end
@@ -233,7 +245,11 @@ defmodule ControlKeelWeb.MissionControlLive do
          {:ok, _result} <- Mission.resume_task(task_id, "mission_control"),
          session when not is_nil(session) <-
            Mission.get_session_context(socket.assigns.session.id) do
-      {:noreply, socket |> put_flash(:info, "Task resumed.") |> safe_assign_session(session)}
+      {:noreply,
+       socket
+       |> put_flash(:info, "Task resumed.")
+       |> safe_assign_session(session)
+       |> refresh_release_readiness()}
     else
       _error -> {:noreply, put_flash(socket, :error, "Could not resume task.")}
     end
@@ -241,8 +257,11 @@ defmodule ControlKeelWeb.MissionControlLive do
 
   defp refresh_session_after_mutation(socket) do
     case Mission.get_session_context(socket.assigns.session.id) do
-      nil -> socket
-      session -> safe_assign_session(socket, session)
+      nil ->
+        socket
+
+      session ->
+        socket |> safe_assign_session(session) |> refresh_release_readiness()
     end
   end
 
@@ -1258,8 +1277,8 @@ defmodule ControlKeelWeb.MissionControlLive do
   end
 
   # Release readiness is isolated (like safe_assign_session) so a gate failure
-  # can never take down the periodic refresh loop. Background refreshes pass
-  # `record_telemetry: false`; only explicit operator checks record telemetry.
+  # can never take down the periodic refresh loop. Mutation-triggered refreshes
+  # pass `record_telemetry: false`; only explicit operator checks record telemetry.
   defp assign_release_readiness(socket, form_params, record_telemetry) do
     readiness =
       socket.assigns.session.id
@@ -1282,6 +1301,14 @@ defmodule ControlKeelWeb.MissionControlLive do
       socket
       |> assign(:release_readiness, nil)
       |> assign(:release_form, to_form(form_params, as: :release))
+  end
+
+  defp refresh_release_readiness(socket) do
+    assign_release_readiness(
+      socket,
+      socket.assigns[:release_form_params] || release_form_defaults(),
+      false
+    )
   end
 
   defp release_readiness_opts(session_id, params) do

--- a/lib/controlkeel_web/live/mission_control_live.ex
+++ b/lib/controlkeel_web/live/mission_control_live.ex
@@ -121,6 +121,7 @@ defmodule ControlKeelWeb.MissionControlLive do
     {:noreply, socket |> assign(:selected_finding, nil) |> assign(:selected_fix, nil)}
   end
 
+  @impl true
   def handle_event("approve_finding", %{"id" => id}, socket) do
     with {:ok, finding_id} <- parse_id(id),
          %{} = finding <- Enum.find(socket.assigns.session.findings, &(&1.id == finding_id)),
@@ -214,13 +215,6 @@ defmodule ControlKeelWeb.MissionControlLive do
     end
   end
 
-  defp refresh_session_after_mutation(socket) do
-    case Mission.get_session_context(socket.assigns.session.id) do
-      nil -> socket
-      session -> safe_assign_session(socket, session)
-    end
-  end
-
   @impl true
   def handle_event("pause_task", %{"id" => id}, socket) do
     with {:ok, task_id} <- parse_id(id),
@@ -242,6 +236,13 @@ defmodule ControlKeelWeb.MissionControlLive do
       {:noreply, socket |> put_flash(:info, "Task resumed.") |> safe_assign_session(session)}
     else
       _error -> {:noreply, put_flash(socket, :error, "Could not resume task.")}
+    end
+  end
+
+  defp refresh_session_after_mutation(socket) do
+    case Mission.get_session_context(socket.assigns.session.id) do
+      nil -> socket
+      session -> safe_assign_session(socket, session)
     end
   end
 

--- a/lib/controlkeel_web/live/mission_control_live.ex
+++ b/lib/controlkeel_web/live/mission_control_live.ex
@@ -7,6 +7,7 @@ defmodule ControlKeelWeb.MissionControlLive do
   alias ControlKeel.Intent
   alias ControlKeel.Mission
   alias ControlKeel.Observability
+  alias ControlKeel.Platform
   alias ControlKeel.Proxy
   alias ControlKeelWeb.FindingComponents
   alias ControlKeelWeb.ReleaseReadiness
@@ -245,12 +246,31 @@ defmodule ControlKeelWeb.MissionControlLive do
             {@session.objective}
           </p>
         </div>
-        <.link
-          navigate={~p"/sessions/#{@session.id}/deploy-review"}
-          class="inline-flex shrink-0 items-center gap-2 rounded-3xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 cursor-pointer"
-        >
-          <.icon name="hero-cloud-arrow-up" class="size-4" /> Deployment Advisor
-        </.link>
+        <div class="flex flex-col sm:items-end gap-2 shrink-0">
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Audit log
+            </span>
+            <.link
+              :for={format <- ~w(json csv pdf)}
+              id={"mission-audit-export-#{format}"}
+              href={~p"/observability/sessions/#{@session.id}/audit-log/#{format}"}
+              class="rounded-lg px-2.5 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] border bg-muted/[0.03] text-muted-foreground hover:bg-muted/[0.08] hover:text-foreground transition"
+            >
+              {String.upcase(format)}
+            </.link>
+          </div>
+          <p :if={@latest_audit_export} class="text-xs text-muted-foreground">
+            Last export ({@latest_audit_export.format}):
+            <code class="font-mono break-all">{@latest_audit_export.checksum}</code>
+          </p>
+          <.link
+            navigate={~p"/sessions/#{@session.id}/deploy-review"}
+            class="inline-flex shrink-0 items-center gap-2 rounded-3xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 cursor-pointer"
+          >
+            <.icon name="hero-cloud-arrow-up" class="size-4" /> Deployment Advisor
+          </.link>
+        </div>
       </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mt-5">
@@ -1070,6 +1090,7 @@ defmodule ControlKeelWeb.MissionControlLive do
         :active_tasks,
         Enum.count(session.tasks || [], &(&1.status in ["queued", "in_progress"]))
       )
+      |> assign(:latest_audit_export, nil)
       |> assign(:task_graph, %{tasks: session.tasks || [], edges: []})
   end
 
@@ -1105,6 +1126,7 @@ defmodule ControlKeelWeb.MissionControlLive do
       active_tasks: Enum.count(session.tasks, &(&1.status in ["queued", "in_progress"])),
       compliance_score: compliance_score(session.findings),
       latest_proofs: Mission.latest_proof_bundles_for_session(session.id),
+      latest_audit_export: Platform.list_audit_exports(session.id, 1) |> List.first(),
       observability: Observability.session_run(session),
       current_proof_summary: current_task(session.tasks) |> Mission.proof_summary_for_task(),
       current_memory_hits: current_memory_hits(session),

--- a/lib/controlkeel_web/live/mission_control_live.ex
+++ b/lib/controlkeel_web/live/mission_control_live.ex
@@ -3,11 +3,13 @@ defmodule ControlKeelWeb.MissionControlLive do
 
   alias ControlKeel.Analytics
   alias ControlKeel.Agent.AutonomyLoop
+  alias ControlKeel.Governance
   alias ControlKeel.Intent
   alias ControlKeel.Mission
   alias ControlKeel.Observability
   alias ControlKeel.Proxy
   alias ControlKeelWeb.FindingComponents
+  alias ControlKeelWeb.ReleaseReadiness
   alias ControlKeelWeb.ShipReadiness
 
   @refresh_interval_ms 2_000
@@ -35,7 +37,8 @@ defmodule ControlKeelWeb.MissionControlLive do
            |> assign(:launched, Map.get(params, "launched") == "1")
            |> assign(:selected_finding, nil)
            |> assign(:selected_fix, nil)
-           |> safe_assign_session(session)}
+           |> safe_assign_session(session)
+           |> assign_release_readiness(release_form_defaults(), false)}
         else
           {:ok,
            socket
@@ -54,7 +57,8 @@ defmodule ControlKeelWeb.MissionControlLive do
          |> assign(:launched, Map.get(params, "launched") == "1")
          |> assign(:selected_finding, nil)
          |> assign(:selected_fix, nil)
-         |> safe_assign_session(session)}
+         |> safe_assign_session(session)
+         |> assign_release_readiness(release_form_defaults(), false)}
     end
   end
 
@@ -63,8 +67,17 @@ defmodule ControlKeelWeb.MissionControlLive do
     if connected?(socket), do: schedule_refresh()
 
     case Mission.get_session_context(socket.assigns.session.id) do
-      nil -> {:noreply, socket}
-      session -> {:noreply, assign_session(socket, session)}
+      nil ->
+        {:noreply, socket}
+
+      session ->
+        {:noreply,
+         socket
+         |> assign_session(session)
+         |> assign_release_readiness(
+           socket.assigns[:release_form_params] || release_form_defaults(),
+           false
+         )}
     end
   end
 
@@ -159,6 +172,17 @@ defmodule ControlKeelWeb.MissionControlLive do
     else
       _error -> {:noreply, put_flash(socket, :error, "Could not generate proof bundle.")}
     end
+  end
+
+  @impl true
+  def handle_event("check_release_readiness", %{"release" => params}, socket) do
+    form_params = Map.merge(release_form_defaults(), params)
+
+    {:noreply,
+     socket
+     |> assign(:release_form_params, form_params)
+     |> assign_release_readiness(form_params, true)
+     |> put_flash(:info, "Release readiness checked.")}
   end
 
   @impl true
@@ -425,6 +449,12 @@ defmodule ControlKeelWeb.MissionControlLive do
         autonomy_profile={@autonomy_profile}
         outcome_profile={@outcome_profile}
         agent_outcomes={@ship_agent_outcomes}
+      />
+
+      <ReleaseReadiness.release_readiness
+        readiness={@release_readiness}
+        form={@release_form}
+        session_id={@session.id}
       />
 
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">
@@ -1138,6 +1168,67 @@ defmodule ControlKeelWeb.MissionControlLive do
   end
 
   defp schedule_refresh, do: Process.send_after(self(), :refresh, @refresh_interval_ms)
+
+  defp release_form_defaults do
+    %{
+      "smoke_status" => "",
+      "smoke_run" => "",
+      "artifact_source" => "",
+      "sha" => "",
+      "provenance_verified" => "false"
+    }
+  end
+
+  # Release readiness is isolated (like safe_assign_session) so a gate failure
+  # can never take down the periodic refresh loop. Background refreshes pass
+  # `record_telemetry: false`; only explicit operator checks record telemetry.
+  defp assign_release_readiness(socket, form_params, record_telemetry) do
+    readiness =
+      socket.assigns.session.id
+      |> release_readiness_opts(form_params)
+      |> Map.put(:record_telemetry, record_telemetry)
+      |> Governance.release_readiness()
+      |> case do
+        {:ok, readiness} -> readiness
+        {:error, _reason} -> nil
+      end
+
+    socket
+    |> assign(:release_readiness, readiness)
+    |> assign(:release_form, to_form(form_params, as: :release))
+  rescue
+    e ->
+      require Logger
+      Logger.warning("MissionControlLive release readiness rescued: #{inspect(e)}")
+
+      socket
+      |> assign(:release_readiness, nil)
+      |> assign(:release_form, to_form(form_params, as: :release))
+  end
+
+  defp release_readiness_opts(session_id, params) do
+    %{
+      session_id: session_id,
+      sha: blank_to_nil(params["sha"]),
+      smoke: %{
+        "status" => blank_to_nil(params["smoke_status"]),
+        "run_id" => blank_to_nil(params["smoke_run"])
+      },
+      provenance: %{
+        "verified" => params["provenance_verified"] in [true, "true"],
+        "artifact_source" => blank_to_nil(params["artifact_source"])
+      }
+    }
+  end
+
+  defp blank_to_nil(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp blank_to_nil(_value), do: nil
 
   defp current_task(tasks) do
     Enum.find(tasks, &(&1.status == "in_progress")) ||

--- a/lib/controlkeel_web/live/mission_control_live.ex
+++ b/lib/controlkeel_web/live/mission_control_live.ex
@@ -187,6 +187,41 @@ defmodule ControlKeelWeb.MissionControlLive do
   end
 
   @impl true
+  def handle_event("complete_task", %{"id" => id}, socket) do
+    with {:ok, task_id} <- parse_id(id),
+         {:ok, task} <- Mission.complete_task(task_id) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Task completed: #{task.title}.")
+       |> refresh_session_after_mutation()}
+    else
+      {:error, :unresolved_findings, findings} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "#{length(findings)} unresolved finding(s) must be approved or resolved before marking this task done."
+         )}
+
+      {:error, :proof_not_ready, reason} when is_binary(reason) ->
+        {:noreply, put_flash(socket, :error, reason)}
+
+      {:error, :invalid_id} ->
+        {:noreply, put_flash(socket, :error, "ControlKeel could not complete that task.")}
+
+      _error ->
+        {:noreply, put_flash(socket, :error, "ControlKeel could not complete that task.")}
+    end
+  end
+
+  defp refresh_session_after_mutation(socket) do
+    case Mission.get_session_context(socket.assigns.session.id) do
+      nil -> socket
+      session -> safe_assign_session(socket, session)
+    end
+  end
+
+  @impl true
   def handle_event("pause_task", %{"id" => id}, socket) do
     with {:ok, task_id} <- parse_id(id),
          {:ok, _result} <- Mission.pause_task(task_id, "mission_control"),
@@ -603,6 +638,16 @@ defmodule ControlKeelWeb.MissionControlLive do
             <p class="text-sm text-muted-foreground mt-1">{@current_task.validation_gate}</p>
             <div class="flex flex-wrap items-center gap-x-5 gap-y-2 mt-4 pt-4 border-t">
               <button
+                :if={@current_task.status not in ["done", "verified"]}
+                id={"current-task-complete-#{@current_task.id}"}
+                type="button"
+                class="inline-flex items-center rounded-xl px-3.5 py-2 text-xs font-semibold uppercase tracking-[0.14em] transition bg-[var(--ck-success)]/15 text-[var(--ck-success)] border border-[var(--ck-success)]/30 hover:bg-[var(--ck-success)]/25 hover:text-[var(--ck-success)] cursor-pointer"
+                phx-click="complete_task"
+                phx-value-id={@current_task.id}
+              >
+                Complete
+              </button>
+              <button
                 id={"current-task-generate-proof-#{@current_task.id}"}
                 type="button"
                 class="inline-flex items-center rounded-xl px-3.5 py-2 text-xs font-semibold uppercase tracking-[0.14em] transition bg-primary/15 text-primary border border-primary/30 hover:bg-primary/25 hover:text-primary cursor-pointer"
@@ -769,6 +814,16 @@ defmodule ControlKeelWeb.MissionControlLive do
                         View proof
                       </.link>
                     <% end %>
+                    <button
+                      :if={task.status not in ["done", "verified"]}
+                      id={"task-complete-#{task.id}"}
+                      type="button"
+                      class="inline-flex items-center rounded-xl px-3.5 py-2 text-xs font-semibold uppercase tracking-[0.14em] transition bg-[var(--ck-success)]/15 text-[var(--ck-success)] border border-[var(--ck-success)]/30 hover:bg-[var(--ck-success)]/25 hover:text-[var(--ck-success)] cursor-pointer"
+                      phx-click="complete_task"
+                      phx-value-id={task.id}
+                    >
+                      Complete
+                    </button>
                     <button
                       id={"task-generate-proof-#{task.id}"}
                       type="button"

--- a/lib/controlkeel_web/live/observability_live.ex
+++ b/lib/controlkeel_web/live/observability_live.ex
@@ -3,6 +3,7 @@ defmodule ControlKeelWeb.ObservabilityLive do
 
   alias ControlKeel.Accounts
   alias ControlKeel.Observability
+  alias ControlKeel.Platform
   alias ControlKeelWeb.CommandPill
 
   on_mount ControlKeelWeb.CommandPill
@@ -20,7 +21,8 @@ defmodule ControlKeelWeb.ObservabilityLive do
            |> assign(:page_title, "Observability — #{run.session.title}")
            |> assign(:run, run)
            |> assign(:session_id, run.session.id)
-           |> assign(:session_title, run.session.title)}
+           |> assign(:session_title, run.session.title)
+           |> assign(:audit_exports, Platform.list_audit_exports(run.session.id))}
         else
           {:ok,
            socket
@@ -294,6 +296,44 @@ defmodule ControlKeelWeb.ObservabilityLive do
         </.link>
       </div>
 
+      <div
+        id="observability-audit-log-export"
+        class="rounded-xl px-4 py-3 border bg-[rgba(255,255,255,0.015)] space-y-2"
+      >
+        <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
+          Audit log export
+        </p>
+        <p class="text-muted-foreground text-sm leading-relaxed">
+          Checksummed audit artifact of record for this session, proofs embedded. The same export
+          behind <code class="text-primary font-semibold ml-1 text-xs">controlkeel audit-log</code>.
+        </p>
+        <div class="flex flex-wrap items-center gap-2">
+          <.link
+            :for={format <- ~w(json csv pdf)}
+            id={"observability-audit-export-#{format}"}
+            href={~p"/observability/sessions/#{@run.session.id}/audit-log/#{format}"}
+            class="rounded-lg px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] border bg-muted/[0.03] text-muted-foreground hover:bg-muted/[0.08] hover:text-foreground transition"
+          >
+            {String.upcase(format)}
+          </.link>
+        </div>
+        <%= if @audit_exports == [] do %>
+          <p class="text-muted-foreground text-xs">
+            No audit exports recorded yet — download one above and its checksum appears here.
+          </p>
+        <% else %>
+          <ul class="space-y-1 list-none p-0 m-0">
+            <%= for export <- @audit_exports do %>
+              <li class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                <span class="font-semibold uppercase">{export.format}</span>
+                <code class="font-mono break-all">{export.checksum}</code>
+                <span>{format_exported_at(export.generated_at)}</span>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
+
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div class="rounded-xl p-4 border bg-[rgba(255,255,255,0.015)] space-y-2">
           <p class="uppercase tracking-[0.14em] text-xs text-primary font-semibold">
@@ -358,6 +398,12 @@ defmodule ControlKeelWeb.ObservabilityLive do
 
   defp format_currency(cents) when is_integer(cents), do: (cents / 100) |> Float.round(2)
   defp format_currency(_cents), do: 0.0
+
+  defp format_exported_at(nil), do: "unknown time"
+
+  defp format_exported_at(%DateTime{} = at),
+    do: Calendar.strftime(at, "%Y-%m-%d %H:%M:%S UTC")
+
   defp format_frequency(map) when map == %{}, do: "none"
 
   defp format_frequency(map) when is_map(map) do

--- a/lib/controlkeel_web/live/observability_live.ex
+++ b/lib/controlkeel_web/live/observability_live.ex
@@ -244,7 +244,7 @@ defmodule ControlKeelWeb.ObservabilityLive do
                 </p>
                 <p class="text-base font-semibold">{@run.proofs.count}</p>
                 <.link
-                  navigate={~p"/proofs"}
+                  navigate={~p"/proofs?#{%{"session_id" => @run.session.id}}"}
                   class="text-xs text-primary font-semibold hover:opacity-80 transition-opacity"
                 >
                   Open →

--- a/lib/controlkeel_web/live/observability_live.ex
+++ b/lib/controlkeel_web/live/observability_live.ex
@@ -404,6 +404,9 @@ defmodule ControlKeelWeb.ObservabilityLive do
   defp format_exported_at(%DateTime{} = at),
     do: Calendar.strftime(at, "%Y-%m-%d %H:%M:%S UTC")
 
+  defp format_exported_at(%NaiveDateTime{} = at),
+    do: Calendar.strftime(at, "%Y-%m-%d %H:%M:%S UTC")
+
   defp format_frequency(map) when map == %{}, do: "none"
 
   defp format_frequency(map) when is_map(map) do

--- a/lib/controlkeel_web/live/observability_live.ex
+++ b/lib/controlkeel_web/live/observability_live.ex
@@ -319,7 +319,7 @@ defmodule ControlKeelWeb.ObservabilityLive do
         </div>
         <%= if @audit_exports == [] do %>
           <p class="text-muted-foreground text-xs">
-            No audit exports recorded yet — download one above and its checksum appears here.
+            No audit exports recorded yet — download one above, then reload to see its checksum here.
           </p>
         <% else %>
           <ul class="space-y-1 list-none p-0 m-0">

--- a/lib/controlkeel_web/live/observability_timeline_live.ex
+++ b/lib/controlkeel_web/live/observability_timeline_live.ex
@@ -96,9 +96,18 @@ defmodule ControlKeelWeb.ObservabilityTimelineLive do
                     </p>
                     <p class="text-sm font-semibold">{event.event_type}</p>
                   </div>
-                  <span class={neutral_pill_class()}>
-                    {format_datetime(event.inserted_at, "unknown time")}
-                  </span>
+                  <div class="flex items-center gap-3 shrink-0">
+                    <.link
+                      :if={event.proof_id}
+                      navigate={~p"/proofs/#{event.proof_id}"}
+                      class="text-xs text-primary font-semibold hover:opacity-80 transition-opacity"
+                    >
+                      Proof #{event.proof_id} →
+                    </.link>
+                    <span class={neutral_pill_class()}>
+                      {format_datetime(event.inserted_at, "unknown time")}
+                    </span>
+                  </div>
                 </div>
                 <p class="text-sm leading-relaxed">{event.summary}</p>
                 <%= if event.body not in [nil, ""] do %>

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -171,6 +171,11 @@ defmodule ControlKeelWeb.Router do
     # Session export is auth-gated via Plugs.RequireSessionAuth (mirrors
     # LiveAuth.require_cloud_auth plus org ownership of the session).
     get "/observability/sessions/:id/export.json", ObservabilityController, :export_session
+
+    # Audit-log artifact of record (json/csv/pdf), same auth gate as above.
+    get "/observability/sessions/:id/audit-log/:format",
+        ObservabilityController,
+        :export_audit_log
   end
 
   scope "/api/v1", ControlKeelWeb do

--- a/test/controlkeel/platform_test.exs
+++ b/test/controlkeel/platform_test.exs
@@ -5,7 +5,9 @@ defmodule ControlKeel.PlatformTest do
   import ControlKeel.PlatformFixtures
 
   alias ControlKeel.Mission
+  alias ControlKeel.Mission.SessionEvent
   alias ControlKeel.Platform
+  alias ControlKeel.Repo
   alias ControlKeel.Scanner.FastPath
 
   setup do
@@ -238,5 +240,32 @@ defmodule ControlKeel.PlatformTest do
     assert pdf_export.format == "pdf"
     assert pdf_export.artifact_path_or_ref
     assert pdf_payload =~ "%PDF-FAKE"
+  end
+
+  test "export records an audit.exported timeline event and lists exports newest first" do
+    session = session_fixture()
+    _finding = finding_fixture(%{session: session})
+
+    assert {:ok, %{export: json_export}} =
+             Platform.export_audit_log(session.id, "json", actor: "cli")
+
+    assert {:ok, %{export: csv_export}} = Platform.export_audit_log(session.id, "csv")
+
+    event =
+      Repo.one(
+        from e in SessionEvent,
+          where:
+            e.session_id == ^session.id and e.event_type == "audit.exported" and
+              e.payload["audit_export_id"] == ^json_export.id
+      )
+
+    assert event.actor == "cli"
+    assert event.payload["format"] == "json"
+    assert event.payload["checksum"] == json_export.checksum
+    assert event.payload["audit_export_id"] == json_export.id
+
+    exports = Platform.list_audit_exports(session.id)
+    assert Enum.map(exports, & &1.id) == [csv_export.id, json_export.id]
+    assert Enum.map(Platform.list_audit_exports(session.id, 1), & &1.id) == [csv_export.id]
   end
 end

--- a/test/controlkeel_web/components/recent_sessions_test.exs
+++ b/test/controlkeel_web/components/recent_sessions_test.exs
@@ -21,7 +21,8 @@ defmodule ControlKeelWeb.RecentSessionsTest do
         blocked_findings: 1,
         budget_spent_cents: 1250,
         budget_limit_cents: 10_000,
-        memory_records: 7
+        memory_records: 7,
+        proof_bundles: 3
       },
       %{
         id: 2,
@@ -31,7 +32,8 @@ defmodule ControlKeelWeb.RecentSessionsTest do
         blocked_findings: 0,
         budget_spent_cents: 0,
         budget_limit_cents: 5000,
-        memory_records: 2
+        memory_records: 2,
+        proof_bundles: 0
       }
     ]
 
@@ -42,7 +44,28 @@ defmodule ControlKeelWeb.RecentSessionsTest do
     assert html =~ "/observability/sessions/2"
     assert html =~ "3 active"
     assert html =~ "1 blocked"
+    assert html =~ "3 bundles"
+    assert html =~ "No proofs yet"
     assert html =~ "7 records"
     refute html =~ "No sessions available yet."
+  end
+
+  test "proof count is nil-safe for legacy runs" do
+    runs = [
+      %{
+        id: 3,
+        title: "Legacy session",
+        health: "green",
+        active_findings: 0,
+        blocked_findings: 0,
+        budget_spent_cents: 0,
+        budget_limit_cents: 5000,
+        memory_records: 1
+      }
+    ]
+
+    html = render_component(&RecentSessions.session_observability_section/1, runs: runs)
+    assert html =~ "Legacy session"
+    assert html =~ "No proofs yet"
   end
 end

--- a/test/controlkeel_web/controllers/observability_controller_test.exs
+++ b/test/controlkeel_web/controllers/observability_controller_test.exs
@@ -173,6 +173,12 @@ defmodule ControlKeelWeb.ObservabilityControllerTest do
       conn = get(conn, "/observability/sessions/999999/audit-log/json")
       assert json_response(conn, :not_found) == %{"error" => "session not found"}
     end
+
+    test "returns 422 for a non-integer session id", %{conn: conn} do
+      conn = get(conn, "/observability/sessions/not-a-number/audit-log/json")
+
+      assert json_response(conn, :unprocessable_entity) == %{"error" => "session id must be an integer"}
+    end
   end
 
   describe "GET /observability/sessions/:id/audit-log/:format (cloud mode)" do

--- a/test/controlkeel_web/controllers/observability_controller_test.exs
+++ b/test/controlkeel_web/controllers/observability_controller_test.exs
@@ -4,6 +4,8 @@ defmodule ControlKeelWeb.ObservabilityControllerTest do
   import ControlKeel.MissionFixtures
 
   alias ControlKeel.Accounts
+  alias ControlKeel.Mission.SessionEvent
+  alias ControlKeel.Platform
   alias ControlKeel.Repo
 
   describe "GET /observability/sessions/:id/export.json (local mode)" do
@@ -100,4 +102,164 @@ defmodule ControlKeelWeb.ObservabilityControllerTest do
       assert json_response(conn, :not_found) == %{"error" => "session not found"}
     end
   end
+
+  describe "GET /observability/sessions/:id/audit-log/:format (local mode)" do
+    test "downloads a JSON audit log byte-identical to the persisted export", %{conn: conn} do
+      session = session_fixture()
+      _finding = finding_fixture(%{session: session})
+
+      conn = get(conn, ~p"/observability/sessions/#{session.id}/audit-log/json")
+
+      assert get_resp_header(conn, "content-type") |> hd() =~ "application/json"
+
+      assert get_resp_header(conn, "content-disposition") |> hd() ==
+               "attachment; filename=\"audit-log-#{session.id}.json\""
+
+      body = response(conn, 200)
+      assert body =~ "\"audit_log\""
+
+      export = Platform.list_audit_exports(session.id, 1) |> List.first()
+      assert export.format == "json"
+      assert export.checksum == checksum(body)
+    end
+
+    test "downloads a CSV audit log with attachment disposition", %{conn: conn} do
+      session = session_fixture()
+
+      conn = get(conn, ~p"/observability/sessions/#{session.id}/audit-log/csv")
+
+      assert get_resp_header(conn, "content-type") |> hd() =~ "text/csv"
+
+      assert get_resp_header(conn, "content-disposition") |> hd() ==
+               "attachment; filename=\"audit-log-#{session.id}.csv\""
+
+      csv = response(conn, 200)
+      assert String.starts_with?(csv, "session_id,")
+    end
+
+    test "downloads a PDF audit log when a renderer is available", %{conn: conn} do
+      setup_fake_pdf_renderer()
+      session = session_fixture()
+
+      conn = get(conn, ~p"/observability/sessions/#{session.id}/audit-log/pdf")
+
+      assert get_resp_header(conn, "content-type") |> hd() =~ "application/pdf"
+      assert response(conn, 200) =~ "%PDF-FAKE"
+    end
+
+    test "records an audit.exported timeline event with the checksum", %{conn: conn} do
+      session = session_fixture()
+
+      conn = get(conn, ~p"/observability/sessions/#{session.id}/audit-log/json")
+      assert response(conn, 200)
+
+      event =
+        Repo.get_by(SessionEvent, session_id: session.id, event_type: "audit.exported")
+
+      assert event.actor == "web"
+      assert event.payload["format"] == "json"
+      assert is_binary(event.payload["checksum"])
+    end
+
+    test "rejects unsupported formats with 400", %{conn: conn} do
+      session = session_fixture()
+
+      conn = get(conn, "/observability/sessions/#{session.id}/audit-log/xml")
+
+      assert json_response(conn, :bad_request) == %{"error" => "format must be json, csv, or pdf"}
+    end
+
+    test "returns 404 for an unknown session", %{conn: conn} do
+      conn = get(conn, "/observability/sessions/999999/audit-log/json")
+      assert json_response(conn, :not_found) == %{"error" => "session not found"}
+    end
+  end
+
+  describe "GET /observability/sessions/:id/audit-log/:format (cloud mode)" do
+    setup :cloud_mode
+
+    setup %{conn: conn} do
+      {:ok, org} =
+        Accounts.create_org(%{
+          name: "Audit Co",
+          slug: "audit-#{System.unique_integer([:positive])}"
+        })
+
+      {:ok, user} =
+        Accounts.create_user(%{email: "audit-#{System.unique_integer([:positive])}@example.com"})
+
+      %Accounts.Membership{}
+      |> Accounts.Membership.changeset(%{
+        user_id: user.id,
+        org_id: org.id,
+        role: "admin",
+        status: "active"
+      })
+      |> Repo.insert!()
+
+      workspace = workspace_fixture(%{org_id: org.id})
+      session = session_fixture(%{workspace: workspace})
+
+      conn = init_test_session(conn, %{current_user_id: user.id, current_org_id: org.id})
+
+      {:ok, conn: conn, session: session}
+    end
+
+    test "own-org operators can download the audit log", %{conn: conn, session: session} do
+      conn = get(conn, ~p"/observability/sessions/#{session.id}/audit-log/json")
+      assert response(conn, 200) =~ "\"audit_log\""
+    end
+
+    test "unauthenticated requests are rejected with 401", %{session: session} do
+      conn = build_conn()
+      conn = get(conn, ~p"/observability/sessions/#{session.id}/audit-log/json")
+
+      assert json_response(conn, :unauthorized) == %{"error" => "sign in required"}
+    end
+
+    test "sessions from another org are not exportable", %{conn: conn} do
+      {:ok, outsider_org} =
+        Accounts.create_org(%{
+          name: "Outsider Audit",
+          slug: "outsider-audit-#{System.unique_integer([:positive])}"
+        })
+
+      outsider_workspace = workspace_fixture(%{org_id: outsider_org.id})
+      outsider_session = session_fixture(%{workspace: outsider_workspace})
+
+      conn = get(conn, ~p"/observability/sessions/#{outsider_session.id}/audit-log/json")
+
+      assert json_response(conn, :not_found) == %{"error" => "session not found"}
+    end
+  end
+
+  defp cloud_mode(_context) do
+    original = Application.get_env(:controlkeel, :runtime_mode)
+    Application.put_env(:controlkeel, :runtime_mode, :cloud)
+
+    on_exit(fn ->
+      if is_nil(original) do
+        Application.delete_env(:controlkeel, :runtime_mode)
+      else
+        Application.put_env(:controlkeel, :runtime_mode, original)
+      end
+    end)
+
+    :ok
+  end
+
+  defp setup_fake_pdf_renderer do
+    previous_renderer = Application.get_env(:controlkeel, :pdf_renderer)
+    Application.put_env(:controlkeel, :pdf_renderer, ControlKeel.TestSupport.FakePdfRenderer)
+
+    on_exit(fn ->
+      if previous_renderer do
+        Application.put_env(:controlkeel, :pdf_renderer, previous_renderer)
+      else
+        Application.delete_env(:controlkeel, :pdf_renderer)
+      end
+    end)
+  end
+
+  defp checksum(binary), do: :crypto.hash(:sha256, binary) |> Base.encode16(case: :lower)
 end

--- a/test/controlkeel_web/live/mission_control_live_test.exs
+++ b/test/controlkeel_web/live/mission_control_live_test.exs
@@ -4,10 +4,12 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
   import ControlKeel.IntentFixtures
   import Phoenix.LiveViewTest
   import ControlKeel.MissionFixtures
+  import Ecto.Query
 
   alias ControlKeel.Analytics
   alias ControlKeel.MCP.Tools.CkValidate
   alias ControlKeel.Mission
+  alias ControlKeel.Repo
 
   test "mission control shows task dependencies and checklist when graph edges exist", %{
     conn: conn
@@ -293,5 +295,156 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
     assert html =~ "Autonomy posture"
     assert html =~ "Outcome alignment"
     assert html =~ "Ship verdict session"
+  end
+
+  describe "release readiness gate" do
+    defp approved_done_task_with_proof(session) do
+      task = task_fixture(%{session: session, status: "done", title: "Release candidate work"})
+
+      assert {:ok, plan_review} =
+               Mission.submit_review(%{
+                 "task_id" => task.id,
+                 "review_type" => "plan",
+                 "plan_phase" => "implementation_plan",
+                 "research_summary" => "Reviewed the release-readiness and proof flow.",
+                 "codebase_findings" => ["Governance reads the latest proof bundle."],
+                 "alignment_context" => [
+                   "Release managers require smoke evidence and provenance before calling work ready."
+                 ],
+                 "options_considered" => ["Reuse proof bundles", "Add release-only state"],
+                 "selected_option" => "Reuse proof bundles",
+                 "rejected_options" => ["Add release-only state"],
+                 "implementation_steps" => ["Generate proof", "Require smoke and provenance"],
+                 "validation_plan" => ["mix test", "mix precommit"],
+                 "submission_body" => "Implementation-ready release readiness plan"
+               })
+
+      assert {:ok, _approved} =
+               Mission.respond_review(plan_review, %{
+                 "decision" => "approved",
+                 "feedback_notes" => "Approved plan"
+               })
+
+      proof = proof_bundle_fixture(%{task: task})
+      assert proof.deploy_ready
+      %{task: task, proof: proof}
+    end
+
+    defp release_readiness_event_count(session_id) do
+      Repo.aggregate(
+        from(e in Analytics.Event,
+          where: e.session_id == ^session_id and e.event == "release_readiness_checked"
+        ),
+        :count
+      )
+    end
+
+    test "renders the gate with every unmet condition before any evidence is submitted", %{
+      conn: conn
+    } do
+      session = session_fixture()
+      approved_done_task_with_proof(session)
+
+      {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}")
+
+      assert html =~ "mission-release-readiness"
+      assert html =~ "release-readiness-status"
+      assert html =~ "needs review"
+      assert html =~ "release-readiness-reasons"
+      assert html =~ "Release smoke evidence is missing or not green."
+      assert html =~ "Artifact provenance is missing or unverified."
+    end
+
+    test "submitting smoke and provenance evidence flips the verdict to ready in place", %{
+      conn: conn
+    } do
+      session = session_fixture()
+      %{proof: proof} = approved_done_task_with_proof(session)
+
+      {:ok, view, html} = live(conn, ~p"/sessions/#{session.id}")
+      assert html =~ "needs review"
+
+      updated_html =
+        view
+        |> element("#release-readiness-form")
+        |> render_submit(%{
+          "release" => %{
+            "smoke_status" => "success",
+            "smoke_run" => "https://ci.example.com/run/1",
+            "artifact_source" => "github-actions",
+            "sha" => "abc123def",
+            "provenance_verified" => "true"
+          }
+        })
+
+      assert updated_html =~ "Release readiness checked."
+      assert updated_html =~ "Release is backed by proof, smoke, and provenance evidence."
+      assert updated_html =~ ~s(/proofs/#{proof.id})
+
+      status_html = view |> element("#release-readiness-status") |> render()
+      assert status_html =~ "ready"
+    end
+
+    test "blocked verdict renders every applicable reason alongside green evidence", %{conn: conn} do
+      session = session_fixture()
+      approved_done_task_with_proof(session)
+
+      finding_fixture(%{
+        session: session,
+        title: "Blocking release finding",
+        severity: "high",
+        status: "open"
+      })
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{session.id}")
+
+      updated_html =
+        view
+        |> element("#release-readiness-form")
+        |> render_submit(%{
+          "release" => %{
+            "smoke_status" => "success",
+            "smoke_run" => "https://ci.example.com/run/2",
+            "artifact_source" => "github-actions",
+            "provenance_verified" => "true"
+          }
+        })
+
+      status_html = view |> element("#release-readiness-status") |> render()
+      assert status_html =~ "blocked"
+
+      assert updated_html =~ "1 blocking finding(s) remain unresolved."
+      assert updated_html =~ "findings?session_id=#{session.id}&amp;status=open"
+    end
+
+    test "records telemetry only for explicit checks, not mount or auto-refresh", %{conn: conn} do
+      session = session_fixture()
+      approved_done_task_with_proof(session)
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{session.id}")
+      assert release_readiness_event_count(session.id) == 0
+
+      send(view.pid, :refresh)
+      _ = render(view)
+      assert release_readiness_event_count(session.id) == 0
+
+      view
+      |> element("#release-readiness-form")
+      |> render_submit(%{
+        "release" => %{"smoke_status" => "success", "provenance_verified" => "true"}
+      })
+
+      assert release_readiness_event_count(session.id) == 1
+    end
+
+    test "shows a neutral empty state when no proof bundle exists", %{conn: conn} do
+      session = session_fixture()
+      task_fixture(%{session: session, status: "in_progress"})
+
+      {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}")
+
+      assert html =~ "No proof bundle is available for release review yet."
+      assert html =~ "needs review"
+    end
   end
 end

--- a/test/controlkeel_web/live/mission_control_live_test.exs
+++ b/test/controlkeel_web/live/mission_control_live_test.exs
@@ -437,6 +437,44 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
       assert release_readiness_event_count(session.id) == 1
     end
 
+    test "auto-refresh keeps the cached verdict and explicit check re-evaluates it", %{
+      conn: conn
+    } do
+      session = session_fixture()
+      approved_done_task_with_proof(session)
+
+      {:ok, view, html} = live(conn, ~p"/sessions/#{session.id}")
+      assert html =~ "needs review"
+
+      finding_fixture(%{
+        session: session,
+        title: "Late-breaking blocking finding",
+        severity: "high",
+        status: "open"
+      })
+
+      send(view.pid, :refresh)
+      refreshed_html = render(view)
+      refute refreshed_html =~ "1 blocking finding(s) remain unresolved."
+
+      updated_html =
+        view
+        |> element("#release-readiness-form")
+        |> render_submit(%{
+          "release" => %{
+            "smoke_status" => "success",
+            "smoke_run" => "https://ci.example.com/run/3",
+            "artifact_source" => "github-actions",
+            "provenance_verified" => "true"
+          }
+        })
+
+      assert updated_html =~ "1 blocking finding(s) remain unresolved."
+
+      status_html = view |> element("#release-readiness-status") |> render()
+      assert status_html =~ "blocked"
+    end
+
     test "shows a neutral empty state when no proof bundle exists", %{conn: conn} do
       session = session_fixture()
       task_fixture(%{session: session, status: "in_progress"})

--- a/test/controlkeel_web/live/mission_control_live_test.exs
+++ b/test/controlkeel_web/live/mission_control_live_test.exs
@@ -447,4 +447,70 @@ defmodule ControlKeelWeb.MissionControlLiveTest do
       assert html =~ "needs review"
     end
   end
+
+  describe "complete task" do
+    test "completes an eligible task and surfaces the new proof", %{conn: conn} do
+      session = session_fixture(%{risk_tier: "low", title: "Complete success session"})
+      task = task_fixture(%{session: session, status: "in_progress", title: "Do the work"})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{session.id}")
+      assert has_element?(view, "#task-complete-#{task.id}")
+      assert has_element?(view, "#current-task-complete-#{task.id}")
+
+      updated_html =
+        view
+        |> element("#task-complete-#{task.id}")
+        |> render_click()
+
+      assert updated_html =~ "Task completed:"
+      assert updated_html =~ "Do the work"
+
+      assert ControlKeel.Mission.get_task!(task.id).status in ["done", "verified"]
+
+      proof = ControlKeel.Mission.latest_proof_bundle_for_task(task.id)
+      assert proof
+      assert updated_html =~ "/proofs/#{proof.id}"
+    end
+
+    test "surfaces unresolved findings when completion is blocked", %{conn: conn} do
+      session = session_fixture(%{risk_tier: "low"})
+      task = task_fixture(%{session: session, status: "in_progress"})
+
+      finding_fixture(%{session: session, status: "open", title: "Blocking finding"})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{session.id}")
+
+      updated_html =
+        view
+        |> element("#task-complete-#{task.id}")
+        |> render_click()
+
+      assert updated_html =~ "unresolved finding"
+      assert ControlKeel.Mission.get_task!(task.id).status == "blocked"
+    end
+
+    test "surfaces the proof-not-ready reason for high-risk sessions", %{conn: conn} do
+      session = session_fixture(%{risk_tier: "high", title: "Proof gate session"})
+      task = task_fixture(%{session: session, status: "in_progress"})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{session.id}")
+
+      updated_html =
+        view
+        |> element("#task-complete-#{task.id}")
+        |> render_click()
+
+      assert updated_html =~ "not deploy-ready"
+      assert ControlKeel.Mission.get_task!(task.id).status == "in_progress"
+    end
+
+    test "completed tasks do not show a Complete button", %{conn: conn} do
+      session = session_fixture()
+      done_task = task_fixture(%{session: session, status: "done", title: "Already done"})
+
+      {:ok, view, _html} = live(conn, ~p"/sessions/#{session.id}")
+
+      refute has_element?(view, "#task-complete-#{done_task.id}")
+    end
+  end
 end

--- a/test/controlkeel_web/live/observability_live_test.exs
+++ b/test/controlkeel_web/live/observability_live_test.exs
@@ -5,6 +5,7 @@ defmodule ControlKeelWeb.ObservabilityLiveTest do
   import Phoenix.LiveViewTest
 
   alias ControlKeel.Mission
+  alias ControlKeel.Platform
 
   test "dedicated observability page renders session run details", %{conn: conn} do
     session = session_fixture(%{budget_cents: 2_000, daily_budget_cents: 2_000, spent_cents: 300})
@@ -85,5 +86,47 @@ defmodule ControlKeelWeb.ObservabilityLiveTest do
     assert html =~ "mission-observability-open"
     assert html =~ "Open run observability"
     assert html =~ "/observability/sessions/#{session.id}"
+  end
+
+  test "observability page renders audit log export controls and checksums", %{conn: conn} do
+    session = session_fixture()
+    _finding = finding_fixture(%{session: session})
+
+    {:ok, view, html} = live(conn, ~p"/observability/sessions/#{session.id}")
+
+    assert has_element?(view, "#observability-audit-log-export")
+    assert has_element?(view, "#observability-audit-export-json")
+    assert has_element?(view, "#observability-audit-export-csv")
+    assert has_element?(view, "#observability-audit-export-pdf")
+    assert html =~ "/observability/sessions/#{session.id}/audit-log/json"
+    assert html =~ "No audit exports recorded yet"
+
+    assert {:ok, %{export: export}} = Platform.export_audit_log(session.id, "json")
+
+    {:ok, view, html} = live(conn, ~p"/observability/sessions/#{session.id}")
+
+    assert html =~ export.checksum
+    assert html =~ export.format
+  end
+
+  test "mission control header shows audit log export controls and latest checksum", %{
+    conn: conn
+  } do
+    session = session_fixture()
+
+    {:ok, view, html} = live(conn, ~p"/sessions/#{session.id}")
+
+    assert has_element?(view, "#mission-audit-export-json")
+    assert has_element?(view, "#mission-audit-export-csv")
+    assert has_element?(view, "#mission-audit-export-pdf")
+    assert html =~ "/observability/sessions/#{session.id}/audit-log/csv"
+    refute html =~ "Last export"
+
+    assert {:ok, %{export: export}} = Platform.export_audit_log(session.id, "csv")
+
+    {:ok, _view, html} = live(conn, ~p"/sessions/#{session.id}")
+
+    assert html =~ "Last export (csv)"
+    assert html =~ export.checksum
   end
 end

--- a/test/controlkeel_web/live/observability_live_test.exs
+++ b/test/controlkeel_web/live/observability_live_test.exs
@@ -50,6 +50,15 @@ defmodule ControlKeelWeb.ObservabilityLiveTest do
     assert html =~ "Observation review"
   end
 
+  test "observability page links the proofs card pre-filtered to the session", %{conn: conn} do
+    session = session_fixture()
+    task_fixture(%{session: session})
+
+    {:ok, _view, html} = live(conn, ~p"/observability/sessions/#{session.id}")
+
+    assert html =~ "/proofs?session_id=#{session.id}"
+  end
+
   test "dedicated observability page redirects missing sessions", %{conn: conn} do
     assert {:error,
             {:live_redirect, %{to: "/", flash: %{"error" => "Session observability not found."}}}} =

--- a/test/controlkeel_web/live/observability_live_test.exs
+++ b/test/controlkeel_web/live/observability_live_test.exs
@@ -116,6 +116,8 @@ defmodule ControlKeelWeb.ObservabilityLiveTest do
 
     assert html =~ export.checksum
     assert html =~ export.format
+    assert html =~ Calendar.strftime(export.generated_at, "%Y-%m-%d %H:%M:%S UTC")
+    refute html =~ "unknown time"
   end
 
   test "mission control header shows audit log export controls and latest checksum", %{

--- a/test/controlkeel_web/live/observability_timeline_live_test.exs
+++ b/test/controlkeel_web/live/observability_timeline_live_test.exs
@@ -1,0 +1,33 @@
+defmodule ControlKeelWeb.ObservabilityTimelineLiveTest do
+  use ControlKeelWeb.ConnCase, async: false
+
+  import ControlKeel.MissionFixtures
+  import Phoenix.LiveViewTest
+
+  alias ControlKeel.Mission
+
+  test "timeline links task-completion events to their proof bundle", %{conn: conn} do
+    session = session_fixture(%{risk_tier: "low", title: "Timeline proof session"})
+    task = task_fixture(%{session: session, status: "in_progress", title: "Shippable task"})
+
+    assert {:ok, _completed} = Mission.complete_task(task.id)
+    proof = Mission.latest_proof_bundle_for_task(task.id)
+    assert proof
+
+    {:ok, _view, html} = live(conn, ~p"/observability/sessions/#{session.id}/timeline")
+
+    assert html =~ "Timeline"
+    assert html =~ "task.completed"
+    assert html =~ "Proof ##{proof.id}"
+    assert html =~ ~s(href="/proofs/#{proof.id}")
+  end
+
+  test "timeline renders events without proof ids without a proof link", %{conn: conn} do
+    session = session_fixture()
+
+    {:ok, _view, html} = live(conn, ~p"/observability/sessions/#{session.id}/timeline")
+
+    assert html =~ "Timeline"
+    refute html =~ "Proof #"
+  end
+end


### PR DESCRIPTION
## Summary
Closes the browser gap for the two highest-value proof-system actions — **release readiness** and **audit-log export** — plus a batch of proof-visibility fixes. Previously CLI/API-only; now operable from Mission Control and Observability without an API token.

Related issue: #123 

## What changed

### 1. Release readiness gate — Mission Control (`/sessions/:id`)
- New Release Readiness component — verdict badge (`ready`/`blocked`/`needs-review`), release-candidate proof link (`/proofs/:id vN` + `deploy_ready`/`risk_score`), findings breakdown (open/blocked/escalated/high_or_critical/vuln), unmet-reasons list, smoke+provenance form.
- Mission Control Live — `check_release_readiness` and `complete_task` handlers, isolated/rescued `assign_release_readiness` (`record_telemetry: false` on mount/refresh, `true` only on explicit check), session refresh after mutation.
- Governance — `record_telemetry?` opt so background refreshes don’t emit `release_readiness_checked` analytics.

### 2. Audit-log export — web download
- Platform — `export_audit_log` with `actor` opt, `list_audit_exports`, `record_audit_export_event` (`audit.exported` → `SessionTranscript` with `format`/`checksum`/`audit_export_id`).
- Observability Controller — `export_audit_log` thin wrapper over Platform (verbatim payload, `attachment` disposition, `json`/`csv`/`pdf` content-types, `400`/`404`/`422` handling).
- Router — `GET /observability/sessions/:id/audit-log/:format` under `RequireSessionAuth` (same gate as `/export.json`).
- UI: Mission Control header (json/csv/pdf pill links + last-export checksum) and Observability Live audit-export card with recent exports list.

### 3. Proof visibility batch
- (a) Session-scoped proofs link → `/proofs?session_id=<id>` (was `/proofs`).
- (b) Timeline proof links — extracts `payload["proof_id"]` and renders `Proof #id →`.
- (c) Run-card proof counts — 4-col grid, `proof_bundles` chip + nil-safe `No proofs yet` zero state.
- (d) Complete task from UI — `complete_task` (gates on findings/proof-ready, surfaces `unresolved_findings`/`proof_not_ready` flash, refreshes session + new final proof appears).

## Files touched
`governance.ex`, `observability.ex`, `platform.ex`, `recent_sessions.ex`, `release_readiness.ex` (new), `observability_controller.ex`, `mission_control_live.ex`, `observability_live.ex`, `observability_timeline_live.ex`, `router.ex` + 6 test files.

## Testing
- `mix precommit` clean.
- New coverage:
  - Platform tests — `audit.exported` event + `list_audit_exports` ordering.
  - Observability Controller tests — json/csv/pdf download, byte-identical checksum, cloud 401/404, unsupported format 400.
  - Recent Sessions tests — bundles chip + nil-safe legacy run.
  - Mission Control Live tests — gate renders reasons/ready/blocked, telemetry only on explicit check, neutral empty state, `complete_task` success/blocked/proof-gate.
  - Observability Live + Timeline Live tests — session-scoped link + timeline proof link.

## Out of scope / notes
- No change to `GET /api/v1/proof/:task_id` side-effect pattern; cloud sync UI, `controlkeel doctor`, proof diffing deferred per plan.
- Cloud mode org-scoping preserved via `RequireSessionAuth`/`session_accessible?`; local mode passthrough.

