### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label and focus styling to sidebar nav buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-09-01 - Adding ARIA labels to loop buttons in LiveView
+**Learning:** When adding ARIA labels to buttons inside `nav_items()` or other dynamically rendered loops (e.g., in HEEx templates), statically defining `aria-label="Toggle menu"` results in duplicate ARIA labels that are ambiguous for screen readers.
+**Action:** Always interpolate unique context from the loop variable (e.g., `aria-label={"Toggle #{item.label} menu"}`) instead of using a static string to prevent ambiguous/duplicate announcements for screen readers.

--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -62,7 +62,8 @@ defmodule ControlKeelWeb.Layouts do
                 data-sidebar-toggle
                 aria-expanded={(opened && "true") || "false"}
                 aria-controls={collapse_id}
-                class={["w-full text-left cursor-pointer", sidebar_link_class(active)]}
+                aria-label={"Toggle #{item.label} menu"}
+                class={["w-full text-left cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl", sidebar_link_class(active)]}
               >
                 <.icon name={item.icon} class={sidebar_icon_class(active)} />
                 <span class="flex-1">{item.label}</span>


### PR DESCRIPTION
## What
Added `aria-label` and `focus-visible` ring/outline Tailwind CSS classes to the sidebar toggle button within the `nav_items` loop in `lib/controlkeel_web/components/layouts.ex`.

## Why
This improvement addresses a minor accessibility oversight. Without the `aria-label`, screen readers may not read a meaningful description for the toggle behavior of the sidebar, making it ambiguous. Also, keyboard users need to see clear focus states. Without them, it's hard to tell what element is currently selected.

## Before/After
*   **Before:** `<button ... class={["w-full text-left cursor-pointer", sidebar_link_class(active)]}>`
*   **After:** `<button ... aria-label={"Toggle #{item.label} menu"} class={["w-full text-left cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl", sidebar_link_class(active)]}>`

## Accessibility
*   **Keyboard Navigation:** Adds clear `focus-visible` styles to help keyboard-only users orient themselves.
*   **Screen Readers:** Replaces generic implicit labels with explicit `aria-label` attributes derived from `item.label` (e.g. "Toggle Dashboard menu"), avoiding ambiguous button labeling.

---
*PR created automatically by Jules for task [4409708405503827460](https://jules.google.com/task/4409708405503827460) started by @aryaminus*