### PR TITLE
⚡ Bolt: Use Enum.frequencies_by/2 to optimize count allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-08-19 - Elixir List Allocation Overhead
 **Learning:** Chaining `Enum.map/2` into `Enum.uniq/1` then `length/1` (or `Enum.filter/2` into `length/1`) forces unnecessary intermediate list allocations in Elixir, adding hidden overhead.
 **Action:** Use `MapSet.new/2 |> MapSet.size()` and `Enum.count/2` to skip intermediate lists and reduce GC pressure.
+## 2026-08-19 - Elixir List Allocation Overhead - frequencies_by
+**Learning:** Chaining `Enum.group_by/2` and then transforming the grouped values into counts with `length/1` forces unnecessary intermediate list allocations in Elixir, adding hidden overhead, particularly when grouping large collections.
+**Action:** Use `Enum.frequencies_by/2` which computes the frequency map directly without allocating intermediate lists.

--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -1454,9 +1454,9 @@ defmodule ControlKeel.Benchmark do
 
   defp count_by(values, mapper) do
     values
-    |> Enum.group_by(mapper)
-    |> Enum.reject(fn {key, _rows} -> is_nil(key) end)
-    |> Enum.into(%{}, fn {key, rows} -> {key, length(rows)} end)
+    # Bolt: Use Enum.frequencies_by/2 and Map.drop/2 to avoid intermediate list allocations for each group
+    |> Enum.frequencies_by(mapper)
+    |> Map.drop([nil])
   end
 
   defp maybe_channel(channels, true, channel), do: [channel | channels]

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -3210,8 +3210,8 @@ defmodule ControlKeel.Mission do
 
     engines =
       regression_runs
-      |> Enum.group_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
-      |> Enum.into(%{}, fn {engine, rows} -> {engine, length(rows)} end)
+      # Bolt: Use Enum.frequencies_by/2 to avoid intermediate list allocations for each group
+      |> Enum.frequencies_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
 
     latest_failures =
       regression_runs
@@ -4396,12 +4396,12 @@ defmodule ControlKeel.Mission do
       "total" => length(invocations),
       "providers" =>
         invocations
-        |> Enum.group_by(&(&1.provider || "unknown"))
-        |> Enum.into(%{}, fn {provider, rows} -> {provider, length(rows)} end),
+        # Bolt: Use Enum.frequencies_by/2 to avoid intermediate list allocations for each group
+        |> Enum.frequencies_by(&(&1.provider || "unknown")),
       "tools" =>
         invocations
-        |> Enum.group_by(&(&1.tool || "unknown"))
-        |> Enum.into(%{}, fn {tool, rows} -> {tool, length(rows)} end),
+        # Bolt: Use Enum.frequencies_by/2 to avoid intermediate list allocations for each group
+        |> Enum.frequencies_by(&(&1.tool || "unknown")),
       "cost_cents" => total_cost,
       "latest_run_at" =>
         invocations

--- a/lib/controlkeel/mission/decomposition.ex
+++ b/lib/controlkeel/mission/decomposition.ex
@@ -227,9 +227,9 @@ defmodule ControlKeel.Mission.Decomposition do
 
   defp count_by(entries, key) do
     entries
-    |> Enum.group_by(&Map.get(&1, key))
-    |> Enum.reject(fn {value, _rows} -> is_nil(value) end)
-    |> Enum.into(%{}, fn {value, rows} -> {value, length(rows)} end)
+    # Bolt: Use Enum.frequencies_by/2 and Map.drop/2 to avoid intermediate list allocations for each group
+    |> Enum.frequencies_by(&Map.get(&1, key))
+    |> Map.drop([nil])
   end
 
   defp normalize_string(value) when is_binary(value) do


### PR DESCRIPTION
**What:** Replaced instances of `Enum.group_by/2 |> Enum.into(%{}, fn {k, v} -> {k, length(v)} end)` with `Enum.frequencies_by/2` in `lib/controlkeel/mission.ex`, `lib/controlkeel/mission/decomposition.ex`, and `lib/controlkeel/benchmark.ex`.
**Why:** To avoid intermediate list allocations for each grouping, reducing memory usage and garbage collection overhead.
**Impact:** Reduces memory allocations for grouping list counts significantly.
**Measurement:** Check if intermediate list sizes are eliminated and GC overhead is reduced.

---
*PR created automatically by Jules for task [7024554408986795086](https://jules.google.com/task/7024554408986795086) started by @aryaminus*