### PR TITLE
Refactor skills page: cli-only skills features to the web

### DIFF
--- a/lib/controlkeel/cli/dispatch/skills_plugins_hooks.ex
+++ b/lib/controlkeel/cli/dispatch/skills_plugins_hooks.ex
@@ -239,7 +239,7 @@ defmodule ControlKeel.CLI.Dispatch.SkillsPluginsHooks do
 
     prune_result =
       if options[:prune_duplicates] == true and duplicate_copy_count > 0 do
-        prune_duplicate_skills(root, analysis)
+        prune_duplicate_skills(root)
       else
         []
       end
@@ -347,83 +347,31 @@ defmodule ControlKeel.CLI.Dispatch.SkillsPluginsHooks do
   # Finds duplicate skill copies and removes user-level copies (always redundant).
   # Project-level host-specific copies are listed but not removed — the user's
   # primary host directory is kept, compat .agents/skills/ is kept.
-  defp prune_duplicate_skills(project_root, analysis) do
-    user_home =
-      System.get_env("CONTROLKEEL_HOME") || System.get_env("HOME") || System.user_home!()
+  defp prune_duplicate_skills(project_root) do
+    {:ok, %{removed: removed, kept_project_groups: groups}} =
+      Skills.prune_duplicate_skills(project_root)
 
-    # Collect all skill locations from diagnostics
-    duplicate_diagnostics =
-      analysis.diagnostics
-      |> Enum.filter(&(&1.code == "duplicate_skill_copy"))
+    user_lines =
+      if removed != [] do
+        ["", "✓ Pruned #{length(removed)} user-level duplicate skill copy(s):"] ++
+          Enum.map(removed, &"  rm -rf #{&1}")
+      else
+        []
+      end
 
-    if duplicate_diagnostics == [] do
+    project_lines =
+      if groups != [] do
+        ["", "ℹ️  Project-level host-specific copies (kept — your primary host needs these):"] ++
+          Enum.flat_map(groups, &["  #{&1.host_dir}/skills/: #{Enum.join(&1.skills, ", ")}"]) ++
+          ["  # To remove extras: keep only your primary host dir + .agents/skills/"]
+      else
+        []
+      end
+
+    if user_lines == [] and project_lines == [] do
       ["No duplicate skill copies found."]
     else
-      # Group by skill name from the path
-      grouped =
-        duplicate_diagnostics
-        |> Enum.map(fn diag ->
-          skill_path = diag.path || ""
-          skill_name = skill_path |> Path.split() |> List.last()
-          {skill_name, skill_path}
-        end)
-        |> Enum.group_by(fn {name, _path} -> name end, fn {_name, path} -> path end)
-
-      # Separate user-level (always waste) from project-level
-      {user_paths, project_paths} =
-        grouped
-        |> Enum.flat_map(fn {_name, paths} -> paths end)
-        |> Enum.split_with(&String.starts_with?(&1, user_home))
-
-      # Remove user-level copies (always redundant — hosts load project-level)
-      pruned_user =
-        if user_paths != [] do
-          removed =
-            user_paths
-            |> Enum.reject(&(File.exists?(Path.join(&1, "SKILL.md")) == false))
-            |> Enum.map(fn path ->
-              File.rm_rf!(path)
-              path
-            end)
-
-          if removed != [] do
-            count = length(removed)
-
-            ["", "✓ Pruned #{count} user-level duplicate skill copy(s):"] ++
-              Enum.map(removed, &"  rm -rf #{&1}")
-          else
-            []
-          end
-        else
-          []
-        end
-
-      # List project-level duplicates (not auto-removed)
-      pruned_project =
-        if project_paths != [] do
-          grouped_project =
-            project_paths
-            |> Enum.group_by(fn path ->
-              # Extract the host dir (e.g., .claude, .codex)
-              relative = Path.relative_to(path, project_root)
-              relative |> Path.split() |> List.first()
-            end)
-
-          lines =
-            grouped_project
-            |> Enum.flat_map(fn {host_dir, paths} ->
-              skill_names = Enum.map(paths, &Path.basename/1) |> Enum.join(", ")
-              ["  #{host_dir}/skills/: #{skill_names}"]
-            end)
-
-          ["", "ℹ️  Project-level host-specific copies (kept — your primary host needs these):"] ++
-            lines ++
-            ["  # To remove extras: keep only your primary host dir + .agents/skills/"]
-        else
-          []
-        end
-
-      pruned_user ++ pruned_project
+      user_lines ++ project_lines
     end
   end
 end

--- a/lib/controlkeel/skills.ex
+++ b/lib/controlkeel/skills.ex
@@ -7,6 +7,7 @@ defmodule ControlKeel.Skills do
   alias ControlKeel.Skills.Exporter
   alias ControlKeel.Skills.Installer
   alias ControlKeel.Skills.Manifest
+  alias ControlKeel.Skills.Pruner
   alias ControlKeel.Skills.Registry
   alias ControlKeel.Skills.SkillTarget
 
@@ -45,4 +46,10 @@ defmodule ControlKeel.Skills do
   def install(target, project_root \\ File.cwd!(), opts \\ []) do
     Installer.install(target, project_root, opts)
   end
+
+  def prune_duplicate_skills_preview(project_root \\ File.cwd!()),
+    do: Pruner.preview(project_root)
+
+  def prune_duplicate_skills(project_root \\ File.cwd!()),
+    do: Pruner.prune(project_root)
 end

--- a/lib/controlkeel/skills/exporter.ex
+++ b/lib/controlkeel/skills/exporter.ex
@@ -34,7 +34,8 @@ defmodule ControlKeel.Skills.Exporter do
           root,
           target.id,
           Keyword.get(opts, :scope, target.default_scope),
-          writes
+          writes,
+          instructions
         )
 
       {:ok,
@@ -53,7 +54,7 @@ defmodule ControlKeel.Skills.Exporter do
     end
   end
 
-  def write_export_manifest(root, target_id, scope, writes) do
+  def write_export_manifest(root, target_id, scope, writes, instructions \\ []) do
     manifest_path = Path.join(root, ".controlkeel-manifest.json")
 
     payload = %{
@@ -69,7 +70,8 @@ defmodule ControlKeel.Skills.Exporter do
             "path" => Map.get(write, "path"),
             "kind" => Map.get(write, "kind")
           }
-        end)
+        end),
+      "instructions" => List.wrap(instructions)
     }
 
     File.write!(manifest_path, Jason.encode!(payload, pretty: true) <> "\n")

--- a/lib/controlkeel/skills/pruner.ex
+++ b/lib/controlkeel/skills/pruner.ex
@@ -1,0 +1,90 @@
+defmodule ControlKeel.Skills.Pruner do
+  @moduledoc """
+  Collapses redundant duplicate skill copies.
+
+  Only identical user-level copies (under CONTROLKEEL_HOME/HOME and outside the
+  project root) are auto-removed; they are always redundant because hosts load
+  project-level copies. Project host-specific copies are listed but kept — the
+  user's primary host directory needs them. Shadowed copies (differing content)
+  are never removed automatically.
+  """
+
+  alias ControlKeel.Skills.Registry
+
+  def preview(project_root) do
+    root = expand_root(project_root)
+    analysis = Registry.analyze(root, report_identical_duplicates: true)
+
+    duplicates =
+      analysis.diagnostics
+      |> Enum.filter(&(&1.code == "duplicate_skill_copy"))
+      |> Enum.map(&duplicate_dir/1)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    user_level =
+      duplicates
+      |> Enum.filter(&user_level_dir?(&1, root))
+      |> Enum.sort()
+
+    project_groups =
+      duplicates
+      |> Enum.reject(&user_level_dir?(&1, root))
+      |> Enum.group_by(&host_dir(&1, root))
+      |> Enum.map(fn {host, dirs} ->
+        %{host_dir: host, skills: dirs |> Enum.map(&Path.basename/1) |> Enum.sort()}
+      end)
+      |> Enum.sort_by(& &1.host_dir)
+
+    %{
+      user_level: user_level,
+      user_level_count: length(user_level),
+      project_groups: project_groups,
+      identical_count: length(duplicates),
+      shadowed_count: Enum.count(analysis.diagnostics, &(&1.code == "shadowed_skill"))
+    }
+  end
+
+  def prune(project_root) do
+    result = preview(project_root)
+
+    removed =
+      result.user_level
+      |> Enum.filter(&removable?/1)
+      |> Enum.map(fn dir ->
+        File.rm_rf!(dir)
+        dir
+      end)
+
+    {:ok, %{removed: removed, kept_project_groups: result.project_groups}}
+  end
+
+  defp duplicate_dir(%{path: path}) when is_binary(path),
+    do: path |> Path.expand() |> Path.dirname()
+
+  defp duplicate_dir(_diagnostic), do: nil
+
+  defp user_level_dir?(dir, root) do
+    path_within?(user_home(), dir) and not path_within?(root, dir)
+  end
+
+  defp host_dir(dir, root), do: dir |> Path.relative_to(root) |> Path.split() |> List.first()
+
+  defp removable?(dir) do
+    File.dir?(dir) and File.exists?(Path.join(dir, "SKILL.md")) and
+      path_within?(user_home(), dir)
+  end
+
+  defp expand_root(project_root) when is_binary(project_root) and project_root != "",
+    do: Path.expand(project_root)
+
+  defp expand_root(_), do: File.cwd!()
+
+  defp path_within?(root, candidate),
+    do: String.starts_with?(candidate, Path.expand(root) <> "/")
+
+  defp user_home do
+    (System.get_env("CONTROLKEEL_HOME") || System.get_env("HOME") || System.user_home!())
+    |> Path.expand()
+  end
+end

--- a/lib/controlkeel_web/controllers/api_controller.ex
+++ b/lib/controlkeel_web/controllers/api_controller.ex
@@ -26,6 +26,7 @@ defmodule ControlKeelWeb.ApiController do
   alias ControlKeel.Scanner.FastPath
   alias ControlKeel.Skills
   alias ControlKeel.Skills.Registry
+  alias ControlKeel.Skills.SkillTarget
 
   def action(conn, _opts) do
     agent_json? = agent_json_requested?(conn)
@@ -1586,6 +1587,9 @@ defmodule ControlKeelWeb.ApiController do
     cond do
       is_nil(target) or target == "" ->
         conn |> put_status(:unprocessable_entity) |> json(%{error: "`target` is required"})
+
+      is_nil(SkillTarget.get(target)) ->
+        conn |> put_status(:unprocessable_entity) |> json(%{error: "unknown skill target"})
 
       not File.dir?(dist_dir) ->
         conn

--- a/lib/controlkeel_web/controllers/api_controller.ex
+++ b/lib/controlkeel_web/controllers/api_controller.ex
@@ -1386,13 +1386,13 @@ defmodule ControlKeelWeb.ApiController do
     project_root = Map.get(params, "project_root")
     format = Map.get(params, "format", "json")
     target = Map.get(params, "target")
-    analysis = Registry.analyze(project_root)
+    validation = Skills.validate(project_root, report_identical_duplicates: true)
 
     skills =
       if is_binary(target) and target != "" do
-        Enum.filter(analysis.skills, &(target in (&1.compatibility_targets || [])))
+        Enum.filter(validation.skills, &(target in (&1.compatibility_targets || [])))
       else
-        analysis.skills
+        validation.skills
       end
 
     entries =
@@ -1416,11 +1416,22 @@ defmodule ControlKeelWeb.ApiController do
         }
       end)
 
+    identical_count =
+      Enum.count(validation.diagnostics, &(&1.code == "duplicate_skill_copy"))
+
+    shadowed_count =
+      Enum.count(validation.diagnostics, &(&1.code == "shadowed_skill"))
+
     result = %{
       skills: entries,
       total: length(entries),
-      trusted_project_skills: analysis.trusted_project?,
-      diagnostics: Enum.map(analysis.diagnostics, &diagnostic_summary/1)
+      trusted_project_skills: validation.trusted_project?,
+      diagnostics: Enum.map(validation.diagnostics, &diagnostic_summary/1),
+      valid?: validation.valid?,
+      identical_count: identical_count,
+      shadowed_count: shadowed_count,
+      warning_count: validation.warning_count,
+      error_count: validation.error_count
     }
 
     result =

--- a/lib/controlkeel_web/controllers/api_controller.ex
+++ b/lib/controlkeel_web/controllers/api_controller.ex
@@ -1540,7 +1540,7 @@ defmodule ControlKeelWeb.ApiController do
   def prune_skill_duplicates(conn, params) do
     project_root = Map.get(params, "project_root", File.cwd!())
 
-    if params["confirm"] == true do
+    if ControlKeel.Utils.truthy?(Map.get(params, "confirm")) do
       {:ok, %{removed: removed, kept_project_groups: groups}} =
         Skills.prune_duplicate_skills(project_root)
 

--- a/lib/controlkeel_web/controllers/api_controller.ex
+++ b/lib/controlkeel_web/controllers/api_controller.ex
@@ -17,6 +17,7 @@ defmodule ControlKeelWeb.ApiController do
   alias ControlKeel.Mission.Decomposition
   alias ControlKeel.MCP.Arguments
   alias ControlKeel.MCP.Tools.CkContext
+  alias ControlKeel.MCP.Tools.CkTokenAudit
   alias ControlKeel.Mission
   alias ControlKeel.Platform
   alias ControlKeel.ProviderBroker
@@ -1562,6 +1563,21 @@ defmodule ControlKeelWeb.ApiController do
     end
   end
 
+  def token_audit(conn, params) do
+    project_root = Map.get(params, "project_root", File.cwd!())
+    mode = Map.get(params, "mode", "full")
+
+    case CkTokenAudit.call(%{"project_root" => project_root, "mode" => mode}) do
+      {:ok, result} ->
+        conn
+        |> maybe_token_audit_download(params, mode)
+        |> json(result)
+
+      {:error, {:invalid_arguments, message}} ->
+        conn |> put_status(:unprocessable_entity) |> json(%{error: message})
+    end
+  end
+
   # ─── Agent Router ─────────────────────────────────────────────────────────────
 
   def route_agent(conn, params) do
@@ -1615,6 +1631,17 @@ defmodule ControlKeelWeb.ApiController do
   defp skill_prune_group_summary(group) do
     %{host_dir: group.host_dir, skills: group.skills}
   end
+
+  defp maybe_token_audit_download(conn, %{"download" => download}, mode)
+       when download in [true, "1", "true"],
+       do:
+         put_resp_header(
+           conn,
+           "content-disposition",
+           ~s(attachment; filename="token-audit-#{mode}.json")
+         )
+
+  defp maybe_token_audit_download(conn, _params, _mode), do: conn
 
   defp fetch_review(review_id) do
     case Mission.get_review(review_id) do

--- a/lib/controlkeel_web/controllers/api_controller.ex
+++ b/lib/controlkeel_web/controllers/api_controller.ex
@@ -1578,6 +1578,42 @@ defmodule ControlKeelWeb.ApiController do
     end
   end
 
+  def download_skill_bundle(conn, params) do
+    target = Map.get(params, "target")
+    project_root = Path.expand(Map.get(params, "project_root", File.cwd!()))
+    dist_dir = Path.join([project_root, "controlkeel", "dist", to_string(target || "")])
+
+    cond do
+      is_nil(target) or target == "" ->
+        conn |> put_status(:unprocessable_entity) |> json(%{error: "`target` is required"})
+
+      not File.dir?(dist_dir) ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "bundle not found — export it first"})
+
+      true ->
+        entries =
+          dist_dir
+          |> Path.join("**/*")
+          |> Path.wildcard(match_dot: true)
+          |> Enum.filter(&File.regular?/1)
+          |> Enum.map(fn file ->
+            {Path.relative_to(file, dist_dir) |> to_charlist(), File.read!(file)}
+          end)
+
+        {:ok, {_zip_name, zip_bin}} = :zip.create(~c"#{target}.zip", entries, [:memory])
+
+        conn
+        |> put_resp_content_type("application/zip")
+        |> put_resp_header(
+          "content-disposition",
+          ~s(attachment; filename="controlkeel-#{target}.zip")
+        )
+        |> send_resp(200, zip_bin)
+    end
+  end
+
   # ─── Agent Router ─────────────────────────────────────────────────────────────
 
   def route_agent(conn, params) do

--- a/lib/controlkeel_web/controllers/api_controller.ex
+++ b/lib/controlkeel_web/controllers/api_controller.ex
@@ -1535,6 +1535,33 @@ defmodule ControlKeelWeb.ApiController do
     end
   end
 
+  def prune_skill_duplicates(conn, params) do
+    project_root = Map.get(params, "project_root", File.cwd!())
+
+    if params["confirm"] == true do
+      {:ok, %{removed: removed, kept_project_groups: groups}} =
+        Skills.prune_duplicate_skills(project_root)
+
+      json(conn, %{
+        pruned: true,
+        removed_count: length(removed),
+        removed: removed,
+        kept_project_groups: Enum.map(groups, &skill_prune_group_summary/1)
+      })
+    else
+      preview = Skills.prune_duplicate_skills_preview(project_root)
+
+      json(conn, %{
+        pruned: false,
+        user_level: preview.user_level,
+        user_level_count: preview.user_level_count,
+        kept_project_groups: Enum.map(preview.project_groups, &skill_prune_group_summary/1),
+        identical_count: preview.identical_count,
+        shadowed_count: preview.shadowed_count
+      })
+    end
+  end
+
   # ─── Agent Router ─────────────────────────────────────────────────────────────
 
   def route_agent(conn, params) do
@@ -1583,6 +1610,10 @@ defmodule ControlKeelWeb.ApiController do
       supported_scopes: target.supported_scopes,
       release_bundle: target.release_bundle
     }
+  end
+
+  defp skill_prune_group_summary(group) do
+    %{host_dir: group.host_dir, skills: group.skills}
   end
 
   defp fetch_review(review_id) do

--- a/lib/controlkeel_web/live/skills_live.ex
+++ b/lib/controlkeel_web/live/skills_live.ex
@@ -987,7 +987,7 @@ defmodule ControlKeelWeb.SkillsLive do
                     <td class="py-2 pr-4">{target.default_scope}</td>
                     <td class="py-2 pr-4">{if target.native, do: "yes", else: "fallback"}</td>
                     <td class="py-2 pr-4">
-                      <span class="border rounded-full px-3 py-[0.45rem] text-[0.8rem] #{bundle_pill_class(target.id)}">
+                      <span class={"border rounded-full px-3 py-[0.45rem] text-[0.8rem] #{bundle_pill_class(target.id)}"}>
                         {bundle_type(target.id)}
                       </span>
                     </td>

--- a/lib/controlkeel_web/live/skills_live.ex
+++ b/lib/controlkeel_web/live/skills_live.ex
@@ -1,8 +1,11 @@
 defmodule ControlKeelWeb.SkillsLive do
   use ControlKeelWeb, :live_view
 
+  alias ControlKeel.MCP.Tools.CkTokenAudit
   alias ControlKeel.ProviderBroker
   alias ControlKeel.Skills
+
+  @audit_modes ~w(full skills rules tools)
 
   @impl true
   def mount(_params, _session, socket) do
@@ -20,6 +23,11 @@ defmodule ControlKeelWeb.SkillsLive do
      |> assign(:project_form, project_form(project_root))
      |> assign(:action_form, action_form())
      |> assign(:prune_preview, nil)
+     |> assign(:audit_mode, "full")
+     |> assign(:audit_mode_options, @audit_modes)
+     |> assign(:audit_result, nil)
+     |> assign(:audit_error, nil)
+     |> assign(:audit_sort, %{})
      |> assign(:skill_search, "")
      |> assign(:target_search, "")}
   end
@@ -125,6 +133,41 @@ defmodule ControlKeelWeb.SkillsLive do
      )
      |> assign_analysis(project_root)
      |> assign_doctor(project_root)}
+  end
+
+  def handle_event("run_audit", %{"mode" => mode}, socket) do
+    mode = if mode in @audit_modes, do: mode, else: "full"
+
+    case CkTokenAudit.call(%{"project_root" => socket.assigns.project_root, "mode" => mode}) do
+      {:ok, result} ->
+        {:noreply,
+         socket
+         |> assign(:audit_mode, mode)
+         |> assign(:audit_result, result)
+         |> assign(:audit_error, nil)
+         |> assign(:audit_sort, %{})}
+
+      {:error, {:invalid_arguments, message}} ->
+        {:noreply,
+         socket
+         |> assign(:audit_mode, mode)
+         |> assign(:audit_result, nil)
+         |> assign(:audit_error, message)}
+    end
+  end
+
+  def handle_event("sort_audit", %{"table" => table, "key" => key}, socket) do
+    {current_key, current_dir} =
+      Map.get(socket.assigns.audit_sort, table, {"estimated_tokens", :desc})
+
+    {key, dir} =
+      cond do
+        current_key == key and current_dir == :desc -> {key, :asc}
+        current_key == key and current_dir == :asc -> {key, :desc}
+        true -> {key, :desc}
+      end
+
+    {:noreply, assign(socket, :audit_sort, Map.put(socket.assigns.audit_sort, table, {key, dir}))}
   end
 
   def handle_event("export", params, socket) do
@@ -425,6 +468,251 @@ defmodule ControlKeelWeb.SkillsLive do
               </button>
             </div>
           </.form>
+        </div>
+
+        <div
+          class="border rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6"
+          id="token-audit-section"
+        >
+          <p class="text-lg font-semibold text-primary tracking-[0.14em] uppercase">
+            Token Audit
+          </p>
+          <p class="text-muted-foreground text-sm mt-1">
+            Rule-file, skill, and tool-schema token overhead for this project root.
+          </p>
+
+          <div class="flex flex-wrap items-center gap-2 mt-4 mb-4">
+            <%= for mode <- @audit_mode_options do %>
+              <button
+                type="button"
+                id={"audit-mode-#{mode}"}
+                phx-click="run_audit"
+                phx-value-mode={mode}
+                class={
+                  if @audit_mode == mode do
+                    "rounded-full bg-primary px-4 py-2 text-sm font-bold text-[#11170d] transition hover:-translate-y-px cursor-pointer"
+                  else
+                    "rounded-full border bg-transparent px-4 py-2 text-sm font-semibold transition hover:bg-card cursor-pointer"
+                  end
+                }
+              >
+                {String.capitalize(mode)}
+              </button>
+            <% end %>
+            <%= if @audit_result do %>
+              <a
+                href={"/api/v1/skills/token-audit?project_root=#{URI.encode_www_form(@project_root)}&mode=#{@audit_mode}&download=1"}
+                download={"token-audit-#{@audit_mode}.json"}
+                id="audit-download-link"
+                class="rounded-full border bg-transparent px-4 py-2 text-sm font-semibold transition hover:bg-card cursor-pointer"
+              >
+                Download JSON
+              </a>
+            <% end %>
+          </div>
+
+          <div :if={@audit_error} class="text-[#ffd6cb] text-sm mb-4">
+            {@audit_error}
+          </div>
+
+          <div :if={is_nil(@audit_result)} class="text-muted-foreground text-sm">
+            Run an audit to see the token breakdown. Click a column header to sort a table.
+          </div>
+
+          <%= if @audit_result do %>
+            <div class="flex flex-wrap gap-2 mb-4">
+              <%= for chip <- audit_summary_chips(@audit_mode, @audit_result) do %>
+                <span class="border rounded-full px-3 py-[0.45rem] text-xs bg-[rgba(255,255,255,0.05)]">
+                  {chip}
+                </span>
+              <% end %>
+            </div>
+
+            <%= if @audit_mode in ~w(full rules) and @audit_result["rule_files"] not in [nil, []] do %>
+              <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase mb-2">
+                Rule files ({length(@audit_result["rule_files"])})
+              </p>
+              <div class="overflow-x-auto mb-6">
+                <table class="min-w-full text-sm" id="audit-rules-table">
+                  <thead>
+                    <tr class="text-foreground">
+                      <.audit_th table="rules" key="path" sort={@audit_sort} label="File" />
+                      <.audit_th table="rules" key="word_count" sort={@audit_sort} label="Words" />
+                      <.audit_th table="rules" key="char_count" sort={@audit_sort} label="Chars" />
+                      <.audit_th
+                        table="rules"
+                        key="estimated_tokens"
+                        sort={@audit_sort}
+                        label="Tokens"
+                      />
+                      <th class="text-left py-2 pr-4">Oversized</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <%= for rule <- audit_sorted(@audit_result["rule_files"], "rules", @audit_sort) do %>
+                      <tr>
+                        <td class="py-2 pr-4 font-mono text-xs">
+                          {Path.relative_to(rule["path"], @project_root)}
+                        </td>
+                        <td class="py-2 pr-4">{rule["word_count"]}</td>
+                        <td class="py-2 pr-4">{rule["char_count"]}</td>
+                        <td class="py-2 pr-4">{rule["estimated_tokens"]}</td>
+                        <td class="py-2 pr-4">
+                          {if rule["oversized"], do: "yes", else: "no"}
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            <% end %>
+
+            <%= if @audit_mode in ~w(full skills) do %>
+              <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase mb-2">
+                Skills ({audit_skill_rows(@audit_result) |> length()} effective of {@audit_result[
+                  "installed_skill_copies"
+                ] || 0} copies)
+              </p>
+              <div class="overflow-x-auto mb-6">
+                <table class="min-w-full text-sm" id="audit-skills-table">
+                  <thead>
+                    <tr class="text-foreground">
+                      <.audit_th
+                        table="skills"
+                        key="name"
+                        sort={@audit_sort}
+                        label="Skill"
+                        id="audit-skills-sort-name"
+                      />
+                      <.audit_th table="skills" key="location" sort={@audit_sort} label="Location" />
+                      <.audit_th table="skills" key="word_count" sort={@audit_sort} label="Words" />
+                      <.audit_th
+                        table="skills"
+                        key="estimated_tokens"
+                        sort={@audit_sort}
+                        label="Tokens"
+                      />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <%= for skill <- audit_sorted(audit_skill_rows(@audit_result), "skills", @audit_sort) do %>
+                      <tr>
+                        <td class="py-2 pr-4">{skill["name"]}</td>
+                        <td class="py-2 pr-4 font-mono text-xs">{skill["location"]}</td>
+                        <td class="py-2 pr-4">{skill["word_count"]}</td>
+                        <td class="py-2 pr-4">{skill["estimated_tokens"]}</td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+
+              <%= if audit_duplicates(@audit_result) != [] do %>
+                <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase mb-2">
+                  Duplicate skill groups ({length(audit_duplicates(@audit_result))})
+                </p>
+                <div class="overflow-x-auto mb-6">
+                  <table class="min-w-full text-sm" id="audit-duplicates-table">
+                    <thead>
+                      <tr class="text-foreground">
+                        <th class="text-left py-2 pr-4">Skill</th>
+                        <th class="text-left py-2 pr-4">Copies</th>
+                        <th class="text-left py-2 pr-4">Wasted tokens</th>
+                        <th class="text-left py-2 pr-4">Locations</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <%= for dup <- audit_duplicates(@audit_result) do %>
+                        <tr>
+                          <td class="py-2 pr-4">{dup["name"]}</td>
+                          <td class="py-2 pr-4">{dup["count"]}</td>
+                          <td class="py-2 pr-4 text-[#ffd6cb]">{dup["duplicate_tokens"]}</td>
+                          <td class="py-2 pr-4 font-mono text-xs">
+                            {Enum.join(dup["locations"] || [], ", ")}
+                          </td>
+                        </tr>
+                      <% end %>
+                    </tbody>
+                  </table>
+                </div>
+              <% end %>
+            <% end %>
+
+            <%= if @audit_mode == "tools" do %>
+              <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase mb-2">
+                Tool schemas ({@audit_result["tool_count"]} tools · {@audit_result["total_tokens"]} tokens)
+              </p>
+              <div class="overflow-x-auto mb-6">
+                <table class="min-w-full text-sm" id="audit-tools-table">
+                  <thead>
+                    <tr class="text-foreground">
+                      <.audit_th table="tools" key="name" sort={@audit_sort} label="Tool" />
+                      <.audit_th table="tools" key="char_count" sort={@audit_sort} label="Chars" />
+                      <.audit_th
+                        table="tools"
+                        key="estimated_tokens"
+                        sort={@audit_sort}
+                        label="Tokens"
+                      />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <%= for tool <- audit_sorted(@audit_result["tools"], "tools", @audit_sort) do %>
+                      <tr>
+                        <td class="py-2 pr-4 font-mono text-xs">{tool["name"]}</td>
+                        <td class="py-2 pr-4">{tool["char_count"]}</td>
+                        <td class="py-2 pr-4">{tool["estimated_tokens"]}</td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+
+              <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase mb-2">
+                Group savings
+              </p>
+              <div class="overflow-x-auto mb-2">
+                <table class="min-w-full text-sm" id="audit-groups-table">
+                  <thead>
+                    <tr class="text-foreground">
+                      <th class="text-left py-2 pr-4">Groups</th>
+                      <th class="text-left py-2 pr-4">Tools</th>
+                      <th class="text-left py-2 pr-4">Group tokens</th>
+                      <th class="text-left py-2 pr-4">Savings</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <%= for {name, group} <- audit_group_savings(@audit_result) do %>
+                      <tr>
+                        <td class="py-2 pr-4">
+                          <span class="font-mono text-xs">
+                            CK_TOOL_GROUPS={Enum.join(group["groups"], ",")}
+                          </span>
+                          <span class="text-muted-foreground text-xs">({name})</span>
+                        </td>
+                        <td class="py-2 pr-4">{group["tool_count"]}</td>
+                        <td class="py-2 pr-4">{group["group_tokens"]}</td>
+                        <td class="py-2 pr-4 text-[#d2ffe7]">
+                          {group["savings_tokens"]} tokens ({group["savings_percent"]}%)
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            <% end %>
+
+            <%= if audit_recommendations(@audit_result) != [] do %>
+              <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase mb-2">
+                Recommendations
+              </p>
+              <ul class="text-muted-foreground text-sm list-disc px-4 grid gap-1">
+                <%= for recommendation <- audit_recommendations(@audit_result) do %>
+                  <li>{recommendation}</li>
+                <% end %>
+              </ul>
+            <% end %>
+          <% end %>
         </div>
 
         <%= if @selected do %>
@@ -788,4 +1076,93 @@ defmodule ControlKeelWeb.SkillsLive do
 
   defp pluralize(word, 1), do: word
   defp pluralize(word, _), do: word <> "s"
+
+  attr :table, :string, required: true
+  attr :key, :string, required: true
+  attr :sort, :map, required: true
+  attr :label, :string, required: true
+  attr :id, :string, default: nil
+
+  defp audit_th(assigns) do
+    ~H"""
+    <th
+      class="text-left py-2 pr-4 cursor-pointer select-none hover:text-primary transition-colors"
+      id={@id}
+      phx-click="sort_audit"
+      phx-value-table={@table}
+      phx-value-key={@key}
+    >
+      {@label}{audit_sort_indicator(@sort, @table, @key)}
+    </th>
+    """
+  end
+
+  defp audit_sorted(rows, table, sort_state, default_key \\ "estimated_tokens") do
+    {key, dir} = Map.get(sort_state, table, {default_key, :desc})
+    Enum.sort_by(rows || [], &audit_sort_value(&1, key), dir)
+  end
+
+  defp audit_sort_value(row, key) do
+    case Map.get(row, key) do
+      value when is_number(value) -> {0, value}
+      value when is_binary(value) -> {1, String.downcase(value)}
+      _ -> {2, ""}
+    end
+  end
+
+  defp audit_sort_indicator(sort_state, table, key) do
+    case Map.get(sort_state, table) do
+      {^key, :desc} -> " ↓"
+      {^key, :asc} -> " ↑"
+      _ -> ""
+    end
+  end
+
+  defp audit_skill_rows(result),
+    do: result["effective_skills"] || result["skills"] || []
+
+  defp audit_duplicates(result),
+    do: result["skill_duplicates"] || result["duplicates"] || []
+
+  defp audit_recommendations(result),
+    do: List.wrap(result["recommendations"]) ++ List.wrap(result["skill_recommendations"])
+
+  defp audit_group_savings(result) do
+    result["group_savings"]
+    |> Kernel.||(%{})
+    |> Enum.sort_by(fn {_name, group} -> -group["savings_tokens"] end)
+  end
+
+  defp audit_summary_chips(mode, result) do
+    case mode do
+      "rules" ->
+        [
+          "status: #{result["status"]}",
+          "#{result["total_words"]} words",
+          "#{result["estimated_tokens"]} tokens"
+        ]
+
+      "skills" ->
+        [
+          "#{result["installed_skill_copies"]} copies → #{result["effective_skill_count"]} effective",
+          "#{result["total_skill_tokens"]} skill tokens",
+          "#{result["duplicate_token_count"]} wasted tokens"
+        ]
+
+      "tools" ->
+        [
+          "#{result["tool_count"]} tools",
+          "#{result["total_tokens"]} tokens",
+          "avg #{result["avg_tokens_per_tool"]}/tool"
+        ]
+
+      _ ->
+        [
+          "#{result["estimated_tokens"]} total tokens",
+          "#{result["rule_tokens"]} rule tokens",
+          "#{result["total_skill_tokens"]} skill tokens",
+          "#{result["duplicate_token_count"]} wasted tokens"
+        ]
+    end
+  end
 end

--- a/lib/controlkeel_web/live/skills_live.ex
+++ b/lib/controlkeel_web/live/skills_live.ex
@@ -19,6 +19,7 @@ defmodule ControlKeelWeb.SkillsLive do
      |> assign_doctor(project_root)
      |> assign(:project_form, project_form(project_root))
      |> assign(:action_form, action_form())
+     |> assign(:prune_preview, nil)
      |> assign(:skill_search, "")
      |> assign(:target_search, "")}
   end
@@ -89,6 +90,41 @@ defmodule ControlKeelWeb.SkillsLive do
      socket
      |> push_event("copy-to-clipboard", %{text: command})
      |> put_flash(:info, "Copied command to clipboard.")}
+  end
+
+  def handle_event("preview_prune", _params, socket) do
+    preview = Skills.prune_duplicate_skills_preview(socket.assigns.project_root)
+
+    socket =
+      if preview.user_level == [] do
+        socket
+        |> assign(:prune_preview, nil)
+        |> put_flash(:info, "No user-level duplicate skill copies to prune.")
+      else
+        assign(socket, :prune_preview, preview)
+      end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("cancel_prune", _params, socket) do
+    {:noreply, assign(socket, :prune_preview, nil)}
+  end
+
+  def handle_event("confirm_prune", _params, socket) do
+    project_root = socket.assigns.project_root
+    {:ok, %{removed: removed}} = Skills.prune_duplicate_skills(project_root)
+    count = length(removed)
+
+    {:noreply,
+     socket
+     |> assign(:prune_preview, nil)
+     |> put_flash(
+       :info,
+       "Pruned #{count} user-level duplicate skill #{pluralize("copy", count)}."
+     )
+     |> assign_analysis(project_root)
+     |> assign_doctor(project_root)}
   end
 
   def handle_event("export", params, socket) do
@@ -293,6 +329,15 @@ defmodule ControlKeelWeb.SkillsLive do
             <p class="text-xs text-muted-foreground">
               {@identical_count} identical · {@shadowed_count} shadowed
             </p>
+            <button
+              :if={@identical_count > 0}
+              type="button"
+              id="skills-prune-button"
+              phx-click="preview_prune"
+              class="mt-3 inline-flex items-center justify-center gap-[0.4rem] px-4 py-2 rounded-full border bg-transparent text-sm font-semibold transition-[transform,background] duration-150 ease-in-out hover:bg-card hover:-translate-y-px cursor-pointer"
+            >
+              Prune user-level duplicates
+            </button>
           </div>
         </div>
 
@@ -583,6 +628,71 @@ defmodule ControlKeelWeb.SkillsLive do
                 </p>
               </article>
             <% end %>
+          </div>
+        </div>
+      </div>
+
+      <div :if={@prune_preview} id="prune-duplicates-modal" class="relative z-50">
+        <div
+          class="fixed inset-0 bg-overlay/70 backdrop-blur-sm transition-opacity"
+          phx-click="cancel_prune"
+          aria-label="Close modal"
+        />
+
+        <div class="fixed inset-0 flex items-center justify-center p-4">
+          <div class="w-full max-w-lg rounded-2xl border bg-card/95 p-6 shadow-card max-h-[80vh] overflow-y-auto">
+            <h2 class="text-lg font-semibold text-foreground mb-1">Prune user-level duplicates</h2>
+            <p class="text-sm text-muted-foreground mb-4">
+              Only identical copies under your home directory are removed automatically.
+              Shadowed copies with differing content are never removed.
+            </p>
+
+            <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase mb-2">
+              Will be removed ({@prune_preview.user_level_count})
+            </p>
+            <ul class="grid gap-1 mb-4">
+              <li
+                :for={dir <- @prune_preview.user_level}
+                class="text-xs font-mono text-[#ffd6cb] break-all"
+              >
+                {dir}
+              </li>
+            </ul>
+
+            <%= if @prune_preview.project_groups != [] do %>
+              <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase mb-2">
+                Kept (project host-specific)
+              </p>
+              <ul class="grid gap-1 mb-2">
+                <li
+                  :for={group <- @prune_preview.project_groups}
+                  class="text-xs text-muted-foreground"
+                >
+                  {group.host_dir}/skills/: {Enum.join(group.skills, ", ")}
+                </li>
+              </ul>
+              <p class="text-xs text-muted-foreground mb-4">
+                Keep your primary host + .agents/skills/.
+              </p>
+            <% end %>
+
+            <div class="flex justify-end gap-3 mt-2">
+              <button
+                type="button"
+                phx-click="cancel_prune"
+                class="rounded-full border bg-transparent px-5 py-2 text-sm font-semibold transition hover:bg-card cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                id="skills-prune-confirm"
+                phx-click="confirm_prune"
+                class="rounded-full bg-primary px-5 py-2 text-sm font-bold text-[#11170d] transition hover:-translate-y-px cursor-pointer"
+              >
+                Remove {@prune_preview.user_level_count} user-level copies
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/lib/controlkeel_web/live/skills_live.ex
+++ b/lib/controlkeel_web/live/skills_live.ex
@@ -211,20 +211,64 @@ defmodule ControlKeelWeb.SkillsLive do
             <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase">
               Total skills
             </p>
-            <strong>{length(@skills)}</strong>
+            <strong>{@total_skills || length(@skills)}</strong>
           </div>
           <div class="border rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
             <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase">
               Skill warnings
             </p>
-            <strong>{Enum.count(@diagnostics, &(&1.level == "warn"))}</strong>
+            <strong>{@warning_count || Enum.count(@diagnostics, &(&1.level == "warn"))}</strong>
           </div>
           <div class="border rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
             <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase">
               Skill errors
             </p>
-            <strong>{Enum.count(@diagnostics, &(&1.level == "error"))}</strong>
+            <strong>{@error_count || Enum.count(@diagnostics, &(&1.level == "error"))}</strong>
           </div>
+          <div class="border rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase">
+              Health
+            </p>
+            <div class="flex items-center gap-2 mt-1">
+              <span class={
+                if @valid?,
+                  do:
+                    "border rounded-full px-3 py-[0.45rem] text-[0.8rem] bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]",
+                  else:
+                    "border rounded-full px-3 py-[0.45rem] text-[0.8rem] bg-[rgba(255,143,107,0.12)] text-[#ffd6cb]"
+              }>
+                {if @valid?, do: "✓ valid", else: "✗ needs fix"}
+              </span>
+            </div>
+            <p class="text-xs text-muted-foreground mt-2">
+              {@total_skills || length(@skills)} total · {@warning_count || 0} warnings · {@error_count ||
+                0} errors
+            </p>
+            <p :if={@validated_at} class="text-xs text-muted-foreground">
+              validated {Calendar.strftime(@validated_at, "%H:%M:%S UTC")}
+            </p>
+          </div>
+
+          <div class="border rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase">
+              Identical copies
+            </p>
+            <strong class={if @identical_count > 0, do: "text-[#fff0bf]", else: "text-[#d2ffe7]"}>
+              {@identical_count}
+            </strong>
+            <p class="text-xs text-muted-foreground">expected distribution</p>
+          </div>
+
+          <div class="border rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
+            <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase">
+              Shadowed copies
+            </p>
+            <strong class={if @shadowed_count > 0, do: "text-[#ffd6cb]", else: "text-[#d2ffe7]"}>
+              {@shadowed_count}
+            </strong>
+            <p class="text-xs text-muted-foreground">needs fix</p>
+          </div>
+
           <div class="border rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
             <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase">
               Local skills
@@ -246,6 +290,9 @@ defmodule ControlKeelWeb.SkillsLive do
             <strong class={if @duplicate_copy_count > 0, do: "text-[#ffd6cb]", else: ""}>
               {@duplicate_copy_count}
             </strong>
+            <p class="text-xs text-muted-foreground">
+              {@identical_count} identical · {@shadowed_count} shadowed
+            </p>
           </div>
         </div>
 
@@ -494,9 +541,26 @@ defmodule ControlKeelWeb.SkillsLive do
         </div>
 
         <div class="border rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
-          <p class="text-lg font-semibold text-primary tracking-[0.14em] uppercase mb-4">
+          <p class="text-lg font-semibold text-primary tracking-[0.14em] uppercase mb-2">
             Skill diagnostics
           </p>
+          <div class="flex flex-wrap gap-2 mb-4">
+            <span class="border rounded-full px-3 py-[0.45rem] text-xs bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]">
+              valid? {if @valid?, do: "✓ yes", else: "✗ no"} · {@total_skills} total · {@warning_count} warnings · {@error_count} errors
+            </span>
+            <span class="border rounded-full px-3 py-[0.45rem] text-xs bg-[rgba(255,207,107,0.12)] text-[#fff0bf]">
+              shadowed_skill: {@shadowed_count}
+            </span>
+            <span class="border rounded-full px-3 py-[0.45rem] text-xs bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]">
+              duplicate_skill_copy: {@identical_count} identical
+            </span>
+            <span
+              :if={@validated_at}
+              class="border rounded-full px-3 py-[0.45rem] text-xs text-muted-foreground"
+            >
+              validated {Calendar.strftime(@validated_at, "%H:%M:%S UTC")}
+            </span>
+          </div>
           <div :if={@diagnostics == []} class="text-muted-foreground">
             No skill diagnostics were recorded.
           </div>
@@ -527,16 +591,21 @@ defmodule ControlKeelWeb.SkillsLive do
   end
 
   defp assign_analysis(socket, project_root) do
-    analysis = Skills.analyze(project_root, report_identical_duplicates: true)
+    validation = Skills.validate(project_root, report_identical_duplicates: true)
 
     socket
     |> assign(:project_root, project_root)
-    |> assign(:skills, analysis.skills)
-    |> assign(:filtered_skills, analysis.skills)
-    |> assign(:diagnostics, analysis.diagnostics)
+    |> assign(:skills, validation.skills)
+    |> assign(:filtered_skills, validation.skills)
+    |> assign(:diagnostics, validation.diagnostics)
     |> assign(:targets, Skills.targets())
     |> assign(:filtered_targets, Skills.targets())
-    |> assign(:trusted_project?, analysis.trusted_project?)
+    |> assign(:trusted_project?, validation.trusted_project?)
+    |> assign(:valid?, validation.valid?)
+    |> assign(:total_skills, validation.total)
+    |> assign(:warning_count, validation.warning_count)
+    |> assign(:error_count, validation.error_count)
+    |> assign(:validated_at, DateTime.utc_now())
     |> assign(:skill_search, "")
     |> assign(:target_search, "")
   end
@@ -560,12 +629,19 @@ defmodule ControlKeelWeb.SkillsLive do
     duplicate_copy_count =
       Enum.count(socket.assigns.diagnostics, &(&1.code == "duplicate_skill_copy"))
 
+    identical_count = duplicate_copy_count
+
+    shadowed_count =
+      Enum.count(socket.assigns.diagnostics, &(&1.code == "shadowed_skill"))
+
     socket
     |> assign(:provider_status, provider_status)
     |> assign(:bootstrap_mode, provider_status["bootstrap"]["mode"])
     |> assign(:attachable_clients, attachable_clients)
     |> assign(:headless_runtimes, headless_runtimes)
     |> assign(:duplicate_copy_count, duplicate_copy_count)
+    |> assign(:identical_count, identical_count)
+    |> assign(:shadowed_count, shadowed_count)
     |> assign(:export_manifests, Skills.export_manifests(project_root))
   end
 

--- a/lib/controlkeel_web/live/skills_live.ex
+++ b/lib/controlkeel_web/live/skills_live.ex
@@ -2,10 +2,14 @@ defmodule ControlKeelWeb.SkillsLive do
   use ControlKeelWeb, :live_view
 
   alias ControlKeel.MCP.Tools.CkTokenAudit
+  alias ControlKeel.Project.Local
   alias ControlKeel.ProviderBroker
   alias ControlKeel.Skills
+  alias ControlKeel.Skills.SkillTarget
 
   @audit_modes ~w(full skills rules tools)
+  @all_scopes ["export", "user", "project"]
+  @scope_labels %{"export" => "Export", "user" => "User", "project" => "Project"}
 
   @impl true
   def mount(_params, _session, socket) do
@@ -16,8 +20,9 @@ defmodule ControlKeelWeb.SkillsLive do
      |> assign(:page_title, "Skills Studio")
      |> assign(:selected, nil)
      |> assign(:last_result, nil)
+     |> assign(:last_export_target, nil)
      |> assign(:target_options, target_options())
-     |> assign(:scope_options, [{"Export", "export"}, {"User", "user"}, {"Project", "project"}])
+     |> assign(:scope_options, scope_options("open-standard"))
      |> assign_analysis(project_root)
      |> assign_doctor(project_root)
      |> assign(:project_form, project_form(project_root))
@@ -90,7 +95,31 @@ defmodule ControlKeelWeb.SkillsLive do
   end
 
   def handle_event("update_action_form", %{"skill_action" => params}, socket) do
-    {:noreply, assign(socket, :action_form, action_form(params))}
+    params = normalize_action_params(params)
+
+    {:noreply,
+     socket
+     |> assign(:action_form, action_form(params))
+     |> assign(:scope_options, scope_options(params["target"]))}
+  end
+
+  def handle_event("bootstrap_project", _params, socket) do
+    project_root = socket.assigns.project_root
+
+    case Local.load_or_bootstrap(project_root, %{}, ephemeral_ok: true) do
+      {:ok, _binding, _session, mode} ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :info,
+           "Bootstrapped project (#{mode}). Project-local skills are allowed now."
+         )
+         |> assign_analysis(project_root)
+         |> assign_doctor(project_root)}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, "Failed to bootstrap project: #{inspect(reason)}")}
+    end
   end
 
   def handle_event("copy_command", %{"command" => command}, socket) do
@@ -172,6 +201,7 @@ defmodule ControlKeelWeb.SkillsLive do
 
   def handle_event("export", params, socket) do
     project_root = socket.assigns.project_root
+    params = normalize_action_params(params)
     target = params["target"]
     scope = params["scope"]
 
@@ -184,17 +214,23 @@ defmodule ControlKeelWeb.SkillsLive do
           {:error, "Failed to export skills: #{inspect(reason)}"}
       end
 
+    last_export_target =
+      if elem(result, 0) == :info, do: target, else: socket.assigns.last_export_target
+
     {:noreply,
      socket
      |> put_flash(elem(result, 0), elem(result, 1))
      |> assign(:last_result, result)
+     |> assign(:last_export_target, last_export_target)
      |> assign(:action_form, action_form(params))
+     |> assign(:scope_options, scope_options(target))
      |> assign_analysis(project_root)
      |> assign_doctor(project_root)}
   end
 
   def handle_event("install", params, socket) do
     project_root = socket.assigns.project_root
+    params = normalize_action_params(params)
     target = params["target"]
     scope = params["scope"]
 
@@ -208,7 +244,15 @@ defmodule ControlKeelWeb.SkillsLive do
               ""
             end
 
-          {:info, "Installed #{install.target} skills to #{destination}.#{agent_line}"}
+          marketplace_line =
+            if Map.has_key?(install, :marketplace_destination) do
+              " Marketplace: #{install.marketplace_destination}."
+            else
+              ""
+            end
+
+          {:info,
+           "Installed #{install.target} skills to #{destination}.#{agent_line}#{marketplace_line}"}
 
         {:ok, %ControlKeel.Skills.SkillExportPlan{} = plan} ->
           {:info, "Prepared #{plan.target} bundle at #{plan.output_dir}."}
@@ -222,6 +266,7 @@ defmodule ControlKeelWeb.SkillsLive do
      |> put_flash(elem(result, 0), elem(result, 1))
      |> assign(:last_result, result)
      |> assign(:action_form, action_form(params))
+     |> assign(:scope_options, scope_options(target))
      |> assign_analysis(project_root)
      |> assign_doctor(project_root)}
   end
@@ -353,6 +398,18 @@ defmodule ControlKeelWeb.SkillsLive do
               Local skills
             </p>
             <strong>{if @trusted_project?, do: "allowed", else: "gated"}</strong>
+            <p :if={not @trusted_project?} class="text-xs text-muted-foreground mt-2">
+              Project-local skills are skipped until ControlKeel trusts this project. Bootstrapping writes a project binding and allows them.
+            </p>
+            <button
+              :if={not @trusted_project?}
+              type="button"
+              id="skills-bootstrap-button"
+              phx-click="bootstrap_project"
+              class="mt-3 inline-flex items-center justify-center gap-[0.4rem] px-4 py-2 rounded-full border bg-transparent text-sm font-semibold transition-[transform,background] duration-150 ease-in-out hover:bg-card hover:-translate-y-px cursor-pointer"
+            >
+              Bootstrap project
+            </button>
           </div>
 
           <div class="border rounded-3xl backdrop-blur-[18px] shadow-[0_24px_80px_rgba(0,0,0,0.22)] p-6">
@@ -445,7 +502,16 @@ defmodule ControlKeelWeb.SkillsLive do
               </p>
             <% end %>
 
-            <div class="flex items-center justify-end gap-4 mt-4">
+            <div class="flex flex-wrap items-center justify-end gap-4 mt-4">
+              <a
+                :if={@last_export_target}
+                id="skills-download-bundle"
+                href={"/api/v1/skills/download-bundle?project_root=#{URI.encode_www_form(@project_root)}&target=#{@last_export_target}"}
+                download={"controlkeel-#{@last_export_target}.zip"}
+                class="inline-flex items-center justify-center gap-[0.4rem] px-5 py-[0.95rem] rounded-full border bg-transparent font-semibold transition-[transform,background] duration-150 ease-in-out hover:bg-card hover:-translate-y-px cursor-pointer"
+              >
+                Download bundle
+              </a>
               <button
                 type="button"
                 class="inline-flex items-center justify-center gap-[0.4rem] px-5 py-[0.95rem] rounded-full bg-primary text-[#11170d] font-bold transition-[transform,box-shadow] duration-150 ease-in-out hover:-translate-y-px hover:shadow-[0_12px_24px_rgba(196,240,66,0.24)] cursor-pointer"
@@ -731,12 +797,58 @@ defmodule ControlKeelWeb.SkillsLive do
             <p class="text-muted-foreground mb-2">
               Required CK MCP tools: {format_targets(@selected.required_mcp_tools)}
             </p>
-            <p class="text-muted-foreground mb-2">
-              Native locations: {format_paths(get_in(@selected.install_state, ["native_locations"]))}
-            </p>
+            <details class="mb-2">
+              <summary class="cursor-pointer text-muted-foreground select-none">
+                Locations ({length(selected_native_locations(@selected))})
+              </summary>
+              <ul class="grid gap-1 mt-2 pl-1 list-none">
+                <%= for location <- selected_native_locations(@selected) do %>
+                  <li class="flex gap-2 items-baseline">
+                    <span class="text-[#d2ffe7] text-xs">✓</span>
+                    <span class="text-muted-foreground font-mono text-xs break-all">{location}</span>
+                  </li>
+                <% end %>
+                <li
+                  :if={selected_native_locations(@selected) == []}
+                  class="text-muted-foreground text-xs"
+                >
+                  not installed
+                </li>
+              </ul>
+            </details>
             <p class="text-muted-foreground mb-2">
               Exported targets: {format_targets(get_in(@selected.install_state, ["exported_targets"]))}
             </p>
+            <%= if selected_export_manifests(@selected, @export_manifests) != [] do %>
+              <details class="mb-2">
+                <summary class="cursor-pointer text-muted-foreground select-none">
+                  Export manifests ({length(selected_export_manifests(@selected, @export_manifests))})
+                </summary>
+                <div class="grid gap-3 mt-2">
+                  <%= for %{manifest: manifest} <- selected_export_manifests(@selected, @export_manifests) do %>
+                    <article class="border border-[rgba(255,255,255,0.07)] rounded-[1.1rem] p-3 bg-[rgba(255,255,255,0.03)]">
+                      <p class="font-semibold text-sm">{manifest["target"]} ({manifest["scope"]})</p>
+                      <p class="text-muted-foreground text-xs mt-1">Writes:</p>
+                      <ul class="grid gap-[0.15rem] mt-1">
+                        <%= for write <- manifest["writes"] || [] do %>
+                          <li class="text-muted-foreground font-mono text-xs break-all">
+                            [{write["kind"]}] {write["path"]}
+                          </li>
+                        <% end %>
+                      </ul>
+                      <%= if manifest["instructions"] not in [nil, []] do %>
+                        <p class="text-muted-foreground text-xs mt-2">Instructions:</p>
+                        <ul class="grid gap-[0.15rem] mt-1">
+                          <%= for instruction <- manifest["instructions"] do %>
+                            <li class="text-muted-foreground text-xs break-all">{instruction}</li>
+                          <% end %>
+                        </ul>
+                      <% end %>
+                    </article>
+                  <% end %>
+                </div>
+              </details>
+            <% end %>
             <%= if @selected.resources != [] do %>
               <p class="text-xs font-semibold text-primary tracking-[0.14em] uppercase mt-4">
                 Resources
@@ -845,6 +957,7 @@ defmodule ControlKeelWeb.SkillsLive do
                   <th class="text-left py-2 pr-4">Target</th>
                   <th class="text-left py-2 pr-4">Default scope</th>
                   <th class="text-left py-2 pr-4">Native</th>
+                  <th class="text-left py-2 pr-4">Bundle</th>
                   <th class="text-left py-2 pr-4">Release asset</th>
                 </tr>
               </thead>
@@ -857,6 +970,11 @@ defmodule ControlKeelWeb.SkillsLive do
                     </td>
                     <td class="py-2 pr-4">{target.default_scope}</td>
                     <td class="py-2 pr-4">{if target.native, do: "yes", else: "fallback"}</td>
+                    <td class="py-2 pr-4">
+                      <span class="border rounded-full px-3 py-[0.45rem] text-[0.8rem] #{bundle_pill_class(target.id)}">
+                        {bundle_type(target.id)}
+                      </span>
+                    </td>
                     <td class="py-2 pr-4">
                       {if target.release_bundle, do: "published", else: "local only"}
                     </td>
@@ -1046,20 +1164,74 @@ defmodule ControlKeelWeb.SkillsLive do
   defp project_form(project_root), do: to_form(%{"project_root" => project_root}, as: :project)
 
   defp action_form(params \\ %{"target" => "open-standard", "scope" => "export"}) do
+    params = normalize_action_params(params)
     to_form(params, as: :skill_action)
   end
 
+  defp normalize_action_params(%{"target" => target} = params) when is_binary(target) do
+    case SkillTarget.get(target) do
+      %SkillTarget{supported_scopes: supported, default_scope: default} ->
+        scope = if params["scope"] in supported, do: params["scope"], else: default
+        Map.put(params, "scope", scope)
+
+      nil ->
+        params
+    end
+  end
+
+  defp normalize_action_params(params), do: params
+
+  defp scope_options(target_id) do
+    case SkillTarget.get(target_id) do
+      %SkillTarget{supported_scopes: supported} ->
+        Enum.map(@all_scopes, fn scope ->
+          label = Map.get(@scope_labels, scope, scope)
+
+          if scope in supported do
+            {label, scope}
+          else
+            [key: "#{label} (unsupported)", value: scope, disabled: true]
+          end
+        end)
+
+      nil ->
+        Enum.map(@all_scopes, &{Map.get(@scope_labels, &1, &1), &1})
+    end
+  end
+
   defp target_options do
-    Enum.map(Skills.targets(), fn target -> {target.label, target.id} end)
+    Enum.map(Skills.targets(), fn target ->
+      {target.label <> bundle_type_suffix(target.id), target.id}
+    end)
+  end
+
+  defp bundle_type_suffix(target_id) do
+    if String.ends_with?(target_id, "-plugin"),
+      do: " · Marketplace bundle",
+      else: " · Skills bundle"
+  end
+
+  defp bundle_type(target_id) do
+    if String.ends_with?(target_id, "-plugin"), do: "Marketplace", else: "Skills"
+  end
+
+  defp bundle_pill_class(target_id) do
+    if String.ends_with?(target_id, "-plugin"),
+      do: "bg-[rgba(255,207,107,0.12)] text-[#fff0bf]",
+      else: "bg-[rgba(125,226,174,0.1)] text-[#d2ffe7]"
+  end
+
+  defp selected_native_locations(selected),
+    do: get_in(selected.install_state, ["native_locations"]) || []
+
+  defp selected_export_manifests(selected, manifests) do
+    exported = get_in(selected.install_state, ["exported_targets"]) || []
+    Enum.filter(manifests, &(&1.manifest["target"] in exported))
   end
 
   defp format_targets([]), do: "none"
   defp format_targets(nil), do: "none"
   defp format_targets(values), do: Enum.join(values, ", ")
-
-  defp format_paths([]), do: "not installed"
-  defp format_paths(nil), do: "not installed"
-  defp format_paths(paths), do: Enum.join(paths, ", ")
 
   defp scope_pill_class("builtin"), do: "bg-[rgba(255,143,107,0.12)] text-[#ffd6cb]"
   defp scope_pill_class("user"), do: "bg-[rgba(255,207,107,0.12)] text-[#fff0bf]"

--- a/lib/controlkeel_web/live/skills_live.ex
+++ b/lib/controlkeel_web/live/skills_live.ex
@@ -138,6 +138,7 @@ defmodule ControlKeelWeb.SkillsLive do
         |> assign(:prune_preview, nil)
         |> put_flash(:info, "No user-level duplicate skill copies to prune.")
       else
+        preview = Map.put(preview, :project_root, socket.assigns.project_root)
         assign(socket, :prune_preview, preview)
       end
 
@@ -149,19 +150,34 @@ defmodule ControlKeelWeb.SkillsLive do
   end
 
   def handle_event("confirm_prune", _params, socket) do
-    project_root = socket.assigns.project_root
-    {:ok, %{removed: removed}} = Skills.prune_duplicate_skills(project_root)
-    count = length(removed)
+    case socket.assigns.prune_preview do
+      %{project_root: previewed_root} ->
+        if previewed_root != socket.assigns.project_root do
+          {:noreply,
+           socket
+           |> assign(:prune_preview, nil)
+           |> put_flash(
+             :error,
+             "Project root changed since the preview. Re-run the prune preview."
+           )}
+        else
+          {:ok, %{removed: removed}} = Skills.prune_duplicate_skills(previewed_root)
+          count = length(removed)
 
-    {:noreply,
-     socket
-     |> assign(:prune_preview, nil)
-     |> put_flash(
-       :info,
-       "Pruned #{count} user-level duplicate skill #{pluralize("copy", count)}."
-     )
-     |> assign_analysis(project_root)
-     |> assign_doctor(project_root)}
+          {:noreply,
+           socket
+           |> assign(:prune_preview, nil)
+           |> put_flash(
+             :info,
+             "Pruned #{count} user-level duplicate skill #{pluralize("copy", count)}."
+           )
+           |> assign_analysis(previewed_root)
+           |> assign_doctor(previewed_root)}
+        end
+
+      _preview_without_root ->
+        {:noreply, socket}
+    end
   end
 
   def handle_event("run_audit", %{"mode" => mode}, socket) do

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -247,6 +247,8 @@ defmodule ControlKeelWeb.Router do
     post "/route-agent", ApiController, :route_agent
     get "/skills", ApiController, :list_skills
     get "/skills/targets", ApiController, :list_skill_targets
+    get "/skills/token-audit", ApiController, :token_audit
+    post "/skills/token-audit", ApiController, :token_audit
     post "/skills/export", ApiController, :export_skills
     post "/skills/install", ApiController, :install_skills
     post "/skills/prune-duplicates", ApiController, :prune_skill_duplicates

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -249,6 +249,7 @@ defmodule ControlKeelWeb.Router do
     get "/skills/targets", ApiController, :list_skill_targets
     post "/skills/export", ApiController, :export_skills
     post "/skills/install", ApiController, :install_skills
+    post "/skills/prune-duplicates", ApiController, :prune_skill_duplicates
     get "/skills/:name", ApiController, :get_skill
   end
 

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -249,6 +249,7 @@ defmodule ControlKeelWeb.Router do
     get "/skills/targets", ApiController, :list_skill_targets
     get "/skills/token-audit", ApiController, :token_audit
     post "/skills/token-audit", ApiController, :token_audit
+    get "/skills/download-bundle", ApiController, :download_skill_bundle
     post "/skills/export", ApiController, :export_skills
     post "/skills/install", ApiController, :install_skills
     post "/skills/prune-duplicates", ApiController, :prune_skill_duplicates

--- a/test/controlkeel_web/controllers/api_controller_test.exs
+++ b/test/controlkeel_web/controllers/api_controller_test.exs
@@ -939,6 +939,65 @@ defmodule ControlKeelWeb.ApiControllerTest do
       assert install["target"] == "open-standard"
       assert File.exists?(Path.join(tmp_dir, ".agents/skills/controlkeel-governance/SKILL.md"))
     end
+
+    test "previews and prunes only user-level skill duplicates", %{conn: conn} do
+      tmp_dir = provider_tmp_dir("skills-prune")
+      home_dir = Path.join(tmp_dir, "home")
+      project_root = Path.join(tmp_dir, "project")
+
+      File.mkdir_p!(home_dir)
+      File.mkdir_p!(project_root)
+
+      restore_home = set_provider_home(home_dir)
+      previous_trust = System.get_env("CONTROLKEEL_TRUST_PROJECT_SKILLS")
+      System.put_env("CONTROLKEEL_TRUST_PROJECT_SKILLS", "1")
+
+      on_exit(fn ->
+        restore_home.()
+        restore_env("CONTROLKEEL_TRUST_PROJECT_SKILLS", previous_trust)
+        File.rm_rf!(tmp_dir)
+      end)
+
+      source =
+        :code.priv_dir(:controlkeel)
+        |> to_string()
+        |> Path.join("skills/controlkeel-governance/SKILL.md")
+        |> File.read!()
+
+      user_skill = Path.join(home_dir, ".agents/skills/controlkeel-governance/SKILL.md")
+      File.mkdir_p!(Path.dirname(user_skill))
+      File.write!(user_skill, source)
+
+      project_skill = Path.join(project_root, ".claude/skills/controlkeel-governance/SKILL.md")
+      File.mkdir_p!(Path.dirname(project_skill))
+      File.write!(project_skill, source)
+
+      conn =
+        post(conn, ~p"/api/v1/skills/prune-duplicates", %{project_root: project_root})
+
+      body = json_response(conn, 200)
+
+      assert body["pruned"] == false
+      assert body["user_level_count"] == 1
+      assert hd(body["user_level"]) =~ "controlkeel-governance"
+
+      assert [%{"host_dir" => ".claude", "skills" => ["controlkeel-governance"]}] =
+               body["kept_project_groups"]
+
+      assert File.exists?(user_skill)
+      assert File.exists?(project_skill)
+
+      conn =
+        build_conn()
+        |> post(~p"/api/v1/skills/prune-duplicates", %{project_root: project_root, confirm: true})
+
+      body = json_response(conn, 200)
+
+      assert body["pruned"] == true
+      assert body["removed_count"] == 1
+      refute File.exists?(Path.dirname(user_skill))
+      assert File.exists?(project_skill)
+    end
   end
 
   describe "benchmark API" do

--- a/test/controlkeel_web/controllers/api_controller_test.exs
+++ b/test/controlkeel_web/controllers/api_controller_test.exs
@@ -1061,6 +1061,46 @@ defmodule ControlKeelWeb.ApiControllerTest do
       conn = build_conn() |> get(~p"/api/v1/skills/token-audit?mode=bogus")
       assert %{"error" => _} = json_response(conn, 422)
     end
+
+    test "downloads a valid zip of an exported skill bundle", %{conn: conn} do
+      tmp_dir = provider_tmp_dir("skills-download-bundle")
+
+      on_exit(fn ->
+        File.rm_rf!(tmp_dir)
+      end)
+
+      conn =
+        post(conn, ~p"/api/v1/skills/export", %{
+          target: "open-standard",
+          project_root: tmp_dir,
+          scope: "export"
+        })
+
+      assert %{"plan" => %{"target" => "open-standard"}} = json_response(conn, 200)
+
+      conn =
+        build_conn()
+        |> get(~p"/api/v1/skills/download-bundle?target=open-standard&project_root=#{tmp_dir}")
+
+      assert ["attachment; filename=\"controlkeel-open-standard.zip\"" | _] =
+               get_resp_header(conn, "content-disposition")
+
+      zip = response(conn, 200)
+      assert byte_size(zip) > 0
+      assert {:ok, files} = :zip.unzip(zip, [:memory])
+      names = Enum.map(files, fn {name, _data} -> to_string(name) end)
+      assert ".controlkeel-manifest.json" in names
+      assert Enum.any?(names, &String.contains?(&1, "controlkeel-governance"))
+
+      conn =
+        build_conn()
+        |> get(~p"/api/v1/skills/download-bundle?target=missing-bundle&project_root=#{tmp_dir}")
+
+      assert %{"error" => "bundle not found — export it first"} = json_response(conn, 404)
+
+      conn = build_conn() |> get(~p"/api/v1/skills/download-bundle?project_root=#{tmp_dir}")
+      assert %{"error" => "`target` is required"} = json_response(conn, 422)
+    end
   end
 
   describe "benchmark API" do

--- a/test/controlkeel_web/controllers/api_controller_test.exs
+++ b/test/controlkeel_web/controllers/api_controller_test.exs
@@ -998,6 +998,69 @@ defmodule ControlKeelWeb.ApiControllerTest do
       refute File.exists?(Path.dirname(user_skill))
       assert File.exists?(project_skill)
     end
+
+    test "token audit returns per-mode payloads and download headers", %{conn: conn} do
+      tmp_dir = provider_tmp_dir("skills-token-audit")
+      home_dir = Path.join(tmp_dir, "home")
+      project_root = Path.join(tmp_dir, "project")
+
+      File.mkdir_p!(home_dir)
+      File.mkdir_p!(Path.join(project_root, ".agents/skills/demo-skill"))
+
+      restore = set_provider_home(home_dir)
+
+      on_exit(fn ->
+        restore.()
+        File.rm_rf!(tmp_dir)
+      end)
+
+      File.write!(Path.join(project_root, "AGENTS.md"), String.duplicate("word ", 60))
+
+      File.write!(
+        Path.join(project_root, ".agents/skills/demo-skill/SKILL.md"),
+        "---\nname: demo-skill\ndescription: Demo skill for audit fixture.\n---\n# Demo\nbody text\n"
+      )
+
+      conn = get(conn, ~p"/api/v1/skills/token-audit?project_root=#{project_root}&mode=rules")
+      body = json_response(conn, 200)
+
+      assert body["status"] in ["optimal", "oversized"]
+      assert body["estimated_tokens"] > 0
+      assert Enum.any?(body["rule_files"], &String.ends_with?(&1["path"], "AGENTS.md"))
+
+      conn =
+        build_conn()
+        |> post(~p"/api/v1/skills/token-audit", %{project_root: project_root, mode: "skills"})
+
+      body = json_response(conn, 200)
+      assert Enum.any?(body["skills"], &(&1["name"] == "demo-skill"))
+      assert body["effective_skill_count"] >= 1
+      assert is_list(body["recommendations"])
+
+      conn = build_conn() |> get(~p"/api/v1/skills/token-audit?mode=tools")
+      body = json_response(conn, 200)
+
+      assert body["tool_count"] > 0
+      assert is_map(body["group_savings"])
+      assert body["group_savings"]["core_governance"]["savings_tokens"] >= 0
+      assert is_list(body["tools"])
+
+      conn =
+        build_conn()
+        |> get(~p"/api/v1/skills/token-audit?project_root=#{project_root}&download=1")
+
+      body = json_response(conn, 200)
+
+      assert Map.has_key?(body, "rule_files")
+      assert Map.has_key?(body, "skills")
+      assert Map.has_key?(body, "total_skill_tokens")
+
+      assert ["attachment; filename=\"token-audit-full.json\"" | _] =
+               get_resp_header(conn, "content-disposition")
+
+      conn = build_conn() |> get(~p"/api/v1/skills/token-audit?mode=bogus")
+      assert %{"error" => _} = json_response(conn, 422)
+    end
   end
 
   describe "benchmark API" do

--- a/test/controlkeel_web/controllers/api_controller_test.exs
+++ b/test/controlkeel_web/controllers/api_controller_test.exs
@@ -1094,12 +1094,18 @@ defmodule ControlKeelWeb.ApiControllerTest do
 
       conn =
         build_conn()
-        |> get(~p"/api/v1/skills/download-bundle?target=missing-bundle&project_root=#{tmp_dir}")
+        |> get(~p"/api/v1/skills/download-bundle?target=claude-plugin&project_root=#{tmp_dir}")
 
       assert %{"error" => "bundle not found — export it first"} = json_response(conn, 404)
 
       conn = build_conn() |> get(~p"/api/v1/skills/download-bundle?project_root=#{tmp_dir}")
       assert %{"error" => "`target` is required"} = json_response(conn, 422)
+
+      conn =
+        build_conn()
+        |> get(~p"/api/v1/skills/download-bundle?target=../..&project_root=#{tmp_dir}")
+
+      assert %{"error" => "unknown skill target"} = json_response(conn, 422)
     end
   end
 

--- a/test/controlkeel_web/controllers/api_controller_test.exs
+++ b/test/controlkeel_web/controllers/api_controller_test.exs
@@ -997,6 +997,24 @@ defmodule ControlKeelWeb.ApiControllerTest do
       assert body["removed_count"] == 1
       refute File.exists?(Path.dirname(user_skill))
       assert File.exists?(project_skill)
+
+      # string confirm (form-encoded parity) also executes
+      File.mkdir_p!(Path.dirname(user_skill))
+      File.write!(user_skill, source)
+
+      conn =
+        build_conn()
+        |> post(~p"/api/v1/skills/prune-duplicates", %{
+          project_root: project_root,
+          confirm: "true"
+        })
+
+      body = json_response(conn, 200)
+
+      assert body["pruned"] == true
+      assert body["removed_count"] == 1
+      refute File.exists?(Path.dirname(user_skill))
+      assert File.exists?(project_skill)
     end
 
     test "token audit returns per-mode payloads and download headers", %{conn: conn} do

--- a/test/controlkeel_web/controllers/observability_controller_test.exs
+++ b/test/controlkeel_web/controllers/observability_controller_test.exs
@@ -177,7 +177,9 @@ defmodule ControlKeelWeb.ObservabilityControllerTest do
     test "returns 422 for a non-integer session id", %{conn: conn} do
       conn = get(conn, "/observability/sessions/not-a-number/audit-log/json")
 
-      assert json_response(conn, :unprocessable_entity) == %{"error" => "session id must be an integer"}
+      assert json_response(conn, :unprocessable_entity) == %{
+               "error" => "session id must be an integer"
+             }
     end
   end
 

--- a/test/controlkeel_web/live/skills_live_test.exs
+++ b/test/controlkeel_web/live/skills_live_test.exs
@@ -139,6 +139,87 @@ defmodule ControlKeelWeb.SkillsLiveTest do
     refute has_element?(view, "#prune-duplicates-modal")
   end
 
+  test "token audit renders sortable per-mode tables", %{conn: conn} do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "controlkeel-skills-audit-live-#{System.unique_integer([:positive])}"
+      )
+
+    home_dir = Path.join(tmp_dir, "home")
+    project_root = Path.join(tmp_dir, "project")
+
+    File.rm_rf!(tmp_dir)
+    File.mkdir_p!(home_dir)
+    File.mkdir_p!(Path.join(project_root, ".agents/skills/aaa-skill"))
+    File.mkdir_p!(Path.join(project_root, ".agents/skills/zzz-skill"))
+
+    previous_home = System.get_env("HOME")
+    previous_ck_home = System.get_env("CONTROLKEEL_HOME")
+
+    System.put_env("HOME", home_dir)
+    System.put_env("CONTROLKEEL_HOME", home_dir)
+
+    on_exit(fn ->
+      restore_env("HOME", previous_home)
+      restore_env("CONTROLKEEL_HOME", previous_ck_home)
+      File.rm_rf!(tmp_dir)
+    end)
+
+    File.write!(Path.join(project_root, "AGENTS.md"), String.duplicate("word ", 60))
+
+    File.write!(
+      Path.join(project_root, ".agents/skills/aaa-skill/SKILL.md"),
+      "---\nname: aaa-skill\ndescription: Small audit fixture skill.\n---\n# A\nbody\n"
+    )
+
+    File.write!(
+      Path.join(project_root, ".agents/skills/zzz-skill/SKILL.md"),
+      "---\nname: zzz-skill\ndescription: Larger audit fixture skill.\n---\n# Z\n" <>
+        String.duplicate("padding word ", 120)
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/skills")
+
+    render_submit(form(view, "#skills-project-form", project: %{"project_root" => project_root}))
+
+    rules_html = render_click(element(view, "#audit-mode-rules"))
+    assert has_element?(view, "#audit-rules-table tbody tr")
+    assert rules_html =~ "AGENTS.md"
+    assert rules_html =~ "Rule files"
+
+    render_click(element(view, "#audit-mode-skills"))
+    assert has_element?(view, "#audit-skills-table tbody tr")
+    skills_html = render(view)
+    assert skills_html =~ "aaa-skill"
+    assert skills_html =~ "zzz-skill"
+
+    default_sorted = element(view, "#audit-skills-table") |> render()
+    assert Regex.match?(~r/zzz-skill.*aaa-skill/s, default_sorted)
+
+    name_desc = render_click(element(view, "#audit-skills-sort-name"))
+    assert Regex.match?(~r/zzz-skill.*aaa-skill/s, name_desc)
+
+    name_asc = render_click(element(view, "#audit-skills-sort-name"))
+    assert Regex.match?(~r/aaa-skill.*zzz-skill/s, name_asc)
+
+    tools_html = render_click(element(view, "#audit-mode-tools"))
+    assert has_element?(view, "#audit-tools-table tbody tr")
+    assert has_element?(view, "#audit-groups-table tbody tr")
+    assert tools_html =~ "CK_TOOL_GROUPS"
+    assert tools_html =~ "Group savings"
+
+    full_html = render_click(element(view, "#audit-mode-full"))
+    assert has_element?(view, "#audit-rules-table tbody tr")
+    assert has_element?(view, "#audit-skills-table tbody tr")
+    assert has_element?(view, "#audit-download-link")
+    assert full_html =~ "Download JSON"
+
+    link_html = element(view, "#audit-download-link") |> render()
+    assert link_html =~ "download=1"
+    assert link_html =~ "mode=full"
+  end
+
   defp restore_env(key, nil), do: System.delete_env(key)
   defp restore_env(key, value), do: System.put_env(key, value)
 end

--- a/test/controlkeel_web/live/skills_live_test.exs
+++ b/test/controlkeel_web/live/skills_live_test.exs
@@ -220,6 +220,56 @@ defmodule ControlKeelWeb.SkillsLiveTest do
     assert link_html =~ "mode=full"
   end
 
+  test "scope selector follows target, download link appears, bootstrap allows gated project", %{
+    conn: conn
+  } do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "controlkeel-skills-ux-live-#{System.unique_integer([:positive])}"
+      )
+
+    File.rm_rf!(tmp_dir)
+    File.mkdir_p!(tmp_dir)
+
+    on_exit(fn ->
+      File.rm_rf!(tmp_dir)
+    end)
+
+    {:ok, view, html} = live(conn, ~p"/skills")
+
+    assert html =~ "Marketplace bundle"
+    assert html =~ "Skills bundle"
+
+    render_submit(form(view, "#skills-project-form", project: %{"project_root" => tmp_dir}))
+
+    gated_html = render(view)
+    assert gated_html =~ "gated"
+    assert has_element?(view, "#skills-bootstrap-button")
+
+    render_change(
+      form(view, "#skills-action-form",
+        skill_action: %{"target" => "claude-plugin", "scope" => "project"}
+      )
+    )
+
+    action_html = render(view)
+    assert action_html =~ "User (unsupported)"
+    assert action_html =~ "Project (unsupported)"
+    refute action_html =~ "Export (unsupported)"
+
+    export_html = render_click(element(view, "#skills-export-button"))
+    assert export_html =~ "Exported claude-plugin bundle"
+    assert has_element?(view, "#skills-download-bundle")
+
+    link_html = element(view, "#skills-download-bundle") |> render()
+    assert link_html =~ "target=claude-plugin"
+
+    boot_html = render_click(element(view, "#skills-bootstrap-button"))
+    assert boot_html =~ "Bootstrapped project"
+    assert render(view) =~ "allowed"
+  end
+
   defp restore_env(key, nil), do: System.delete_env(key)
   defp restore_env(key, value), do: System.put_env(key, value)
 end

--- a/test/controlkeel_web/live/skills_live_test.exs
+++ b/test/controlkeel_web/live/skills_live_test.exs
@@ -139,6 +139,61 @@ defmodule ControlKeelWeb.SkillsLiveTest do
     refute has_element?(view, "#prune-duplicates-modal")
   end
 
+  test "prune confirm refuses when project root changed since preview", %{conn: conn} do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "controlkeel-skills-prune-stale-#{System.unique_integer([:positive])}"
+      )
+
+    home_dir = Path.join(tmp_dir, "home")
+    project_root = Path.join(tmp_dir, "project")
+    other_root = Path.join(tmp_dir, "other-project")
+
+    File.rm_rf!(tmp_dir)
+    File.mkdir_p!(home_dir)
+    File.mkdir_p!(project_root)
+    File.mkdir_p!(other_root)
+
+    previous_home = System.get_env("HOME")
+    previous_ck_home = System.get_env("CONTROLKEEL_HOME")
+    previous_trust = System.get_env("CONTROLKEEL_TRUST_PROJECT_SKILLS")
+
+    System.put_env("HOME", home_dir)
+    System.put_env("CONTROLKEEL_HOME", home_dir)
+    System.put_env("CONTROLKEEL_TRUST_PROJECT_SKILLS", "1")
+
+    on_exit(fn ->
+      restore_env("HOME", previous_home)
+      restore_env("CONTROLKEEL_HOME", previous_ck_home)
+      restore_env("CONTROLKEEL_TRUST_PROJECT_SKILLS", previous_trust)
+      File.rm_rf!(tmp_dir)
+    end)
+
+    source =
+      :code.priv_dir(:controlkeel)
+      |> to_string()
+      |> Path.join("skills/controlkeel-governance/SKILL.md")
+      |> File.read!()
+
+    user_skill = Path.join(home_dir, ".agents/skills/controlkeel-governance/SKILL.md")
+    File.mkdir_p!(Path.dirname(user_skill))
+    File.write!(user_skill, source)
+
+    {:ok, view, _html} = live(conn, ~p"/skills")
+
+    render_submit(form(view, "#skills-project-form", project: %{"project_root" => project_root}))
+    render_click(element(view, "#skills-prune-button"))
+    assert has_element?(view, "#prune-duplicates-modal")
+
+    render_submit(form(view, "#skills-project-form", project: %{"project_root" => other_root}))
+
+    html = render_click(element(view, "#skills-prune-confirm"))
+    assert html =~ "Project root changed since the preview"
+    refute has_element?(view, "#prune-duplicates-modal")
+    assert File.exists?(user_skill)
+  end
+
   test "token audit renders sortable per-mode tables", %{conn: conn} do
     tmp_dir =
       Path.join(

--- a/test/controlkeel_web/live/skills_live_test.exs
+++ b/test/controlkeel_web/live/skills_live_test.exs
@@ -73,4 +73,72 @@ defmodule ControlKeelWeb.SkillsLiveTest do
     assert File.exists?(Path.join(tmp_dir, ".claude/skills/controlkeel-governance/SKILL.md"))
     assert File.exists?(Path.join(tmp_dir, ".claude/agents/controlkeel-operator.md"))
   end
+
+  test "prune flow previews and removes only user-level duplicates", %{conn: conn} do
+    tmp_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "controlkeel-skills-prune-live-#{System.unique_integer([:positive])}"
+      )
+
+    home_dir = Path.join(tmp_dir, "home")
+    project_root = Path.join(tmp_dir, "project")
+
+    File.rm_rf!(tmp_dir)
+    File.mkdir_p!(home_dir)
+    File.mkdir_p!(project_root)
+
+    previous_home = System.get_env("HOME")
+    previous_ck_home = System.get_env("CONTROLKEEL_HOME")
+    previous_trust = System.get_env("CONTROLKEEL_TRUST_PROJECT_SKILLS")
+
+    System.put_env("HOME", home_dir)
+    System.put_env("CONTROLKEEL_HOME", home_dir)
+    System.put_env("CONTROLKEEL_TRUST_PROJECT_SKILLS", "1")
+
+    on_exit(fn ->
+      restore_env("HOME", previous_home)
+      restore_env("CONTROLKEEL_HOME", previous_ck_home)
+      restore_env("CONTROLKEEL_TRUST_PROJECT_SKILLS", previous_trust)
+      File.rm_rf!(tmp_dir)
+    end)
+
+    source =
+      :code.priv_dir(:controlkeel)
+      |> to_string()
+      |> Path.join("skills/controlkeel-governance/SKILL.md")
+      |> File.read!()
+
+    user_skill = Path.join(home_dir, ".agents/skills/controlkeel-governance/SKILL.md")
+    File.mkdir_p!(Path.dirname(user_skill))
+    File.write!(user_skill, source)
+
+    project_skill = Path.join(project_root, ".claude/skills/controlkeel-governance/SKILL.md")
+    File.mkdir_p!(Path.dirname(project_skill))
+    File.write!(project_skill, source)
+
+    {:ok, view, _html} = live(conn, ~p"/skills")
+
+    render_submit(form(view, "#skills-project-form", project: %{"project_root" => project_root}))
+
+    assert has_element?(view, "#skills-prune-button")
+
+    render_click(element(view, "#skills-prune-button"))
+
+    assert has_element?(view, "#prune-duplicates-modal")
+    modal_html = element(view, "#prune-duplicates-modal") |> render()
+    assert modal_html =~ "Will be removed"
+    assert modal_html =~ ".claude/skills/"
+    assert File.exists?(user_skill)
+
+    result_html = render_click(element(view, "#skills-prune-confirm"))
+
+    assert result_html =~ "Pruned 1 user-level duplicate skill copy"
+    refute File.exists?(Path.dirname(user_skill))
+    assert File.exists?(project_skill)
+    refute has_element?(view, "#prune-duplicates-modal")
+  end
+
+  defp restore_env(key, nil), do: System.delete_env(key)
+  defp restore_env(key, value), do: System.put_env(key, value)
 end


### PR DESCRIPTION
## Summary

Promotes the CLI-only Skills capabilities that pass the _user value_ filter into the web Skills Studio (`/skills`). A browser operator can now (a) see project skill health at a glance, (b) distinguish expected duplicate distribution from real drift, (c) measure rule-file / skill / tool-schema token overhead, (d) remove user-level duplicate skill copies with a previewed, confirmed flow, and (e) bootstrap an untrusted project — all without a terminal.

Implements all four slices from the issue as independently reviewable commits. No new Hex deps (zip streaming uses the stdlib `:zip`). No policy pack changes.

**Related issue: #151** 

## What changed

### Slice 1 — Health insight

- `SkillsLive` calls `Skills.validate/1` and renders a **Health** card: `✓ valid` / `✗ needs fix` badge, `total / warnings / errors`, and a last-validated timestamp.
- `duplicate_copy_count` is split into **Identical copies** (`duplicate_skill_copy`, info — expected distribution) vs **Shadowed copies** (`shadowed_skill`, warn — needs fix), with distinct cards, colors, and diagnostic-card pills.
- `GET /api/v1/skills` now also returns `valid?`, `identical_count`, `shadowed_count`, `warning_count`, `error_count`.

### Slice 2 — Prune user-level duplicates

- New **`ControlKeel.Skills.Pruner`**: classifies identical duplicates into user-level (under `CONTROLKEEL_HOME`/`HOME`, outside the project root) vs project host-specific groups; `prune/1` removes only user-level skill dirs (each verified to contain `SKILL.md`). Shadowed copies are never removed.
- `POST /api/v1/skills/prune-duplicates`: dry-run preview by default; executes only with `confirm` truthy (`true`, `"true"`, `"1"`).
- LiveView: `Prune user-level duplicates` button → **preview modal** (removal list in red; kept project groups with "Keep your primary host + .agents/skills/" guidance) → confirm → flash + catalog re-render with reduced identical count.
- CLI `skills doctor --prune-duplicates` now delegates to the same Pruner. **Bug fix:** the old private helper was broken — it grouped paths by the literal `"SKILL.md"` and joined a _file_ path with `"SKILL.md"` for the existence check, so user-level removal was a silent no-op. The web/API flow and the CLI now share one correct implementation.

### Slice 3 — Token Audit Studio

- New **Token Audit** section in Skills Studio with `Full / Skills / Rules / Tools` mode buttons (default Full, runs on click).
- Renders per-mode: sortable token tables (click any column header; arrows indicate direction), duplicate skill groups with wasted tokens, rule-file breakdown with oversized flags, tool-schema table, **group savings** table (`CK_TOOL_GROUPS=core,governance …` with tokens/percent saved), per-mode summary chips, and recommendations. Reuses `CkTokenAudit.call/1` server-side — no reimplementation of token estimation.
- `GET/POST /api/v1/skills/token-audit` returns the exact `CkTokenAudit` payload (shape-identical to CLI `token audit --format json`); `download=1` sets an attachment header. LiveView's **Download JSON** link uses it.
- Accepts explicit `project_root` like the existing `export_skills` endpoint.

### Slice 4 — Install/export UX polish

- **Dynamic scope selector:** unsupported scopes render disabled (`User (unsupported)`, …) and the selection server-side normalizes to the target's `default_scope` on every change/export/install — tampered disabled options can't sneak an unsupported scope through. Export-only targets (`claude-plugin`, `claude-sdk`, …) restrict to `export`.
- **Bundle labels:** dropdown suffixes `· Marketplace bundle` (`*-plugin` targets) vs `· Skills bundle`; new **Bundle** column with pills in the Target availability table; install flash renders `marketplace_destination` when present.
- **Selected-skill pane:** collapsible **Locations** checklist (green ✓ per native location) and collapsible per-target **Export manifests** with inline `[kind] path` writes and instructions.
- **Download bundle:** after export, a link streams an in-memory zip of `controlkeel/dist/<target>` via `GET /api/v1/skills/download-bundle` (`:zip`, no temp files).
- **Bootstrap affordance:** gated projects show an explanation and a `Bootstrap project` button (`Local.load_or_bootstrap/3`); the card flips to `allowed` after click.

## New API endpoints

| Endpoint                               | Purpose                                                             |
| -------------------------------------- | ------------------------------------------------------------------- |
| `GET /api/v1/skills`                   | existing; response extended (see review notes)                      |
| `GET/POST /api/v1/skills/token-audit`  | token audit payload; `download=1` → attachment; invalid mode → 422  |
| `GET /api/v1/skills/download-bundle`   | zip of an exported bundle; unknown target → 422, not exported → 404 |
| `POST /api/v1/skills/prune-duplicates` | dry-run by default; `confirm` truthy → executes                     |

## Reviewer notes / behavior changes

- **`GET /api/v1/skills` diagnostics array can grow:** validation now runs with `report_identical_duplicates: true`, so info-level `duplicate_skill_copy` entries appear for identical copies (this powers `identical_count`). Additive; flagging for any downstream consumers that count diagnostics.
- **Export manifests persist `"instructions"`** (`.controlkeel-manifest.json`); older manifests simply lack the key and the UI falls back gracefully.
- **CLI prune output text is unchanged**, but it now actually deletes user-level copies (previous silent no-op, fixed here).

## Security & safety

- **Path traversal blocked:** `download-bundle` whitelists `target` against `SkillTarget.get/1` (regression test: `target=../..` → 422), mirroring `export_skills`/`install_skills`.
- **Prune blast radius is bounded:** identical copies only (never shadowed/differing content), only under the user home, never inside the project root, each dir must contain `SKILL.md`. Project `.claude/skills` etc. are listed, never deleted.
- **Preview→confirm integrity:** the prune modal pins the project root it previewed; if the root changes while the modal is open, confirm refuses ("Project root changed since the preview") and deletes nothing (TOCTOU guard, tested).
- **Destructive API is confirm-gated** with a truthy check shared with the codebase (`Utils.truthy?/1`), so form-encoded callers can't fall into a silent dry-run.
- Arbitrary `project_root` on mutating endpoints matches the pre-existing `export/install` posture; cloud workspace-root validation is the issue doc's tracked follow-up.

## Testing

- `test/controlkeel_web/live/skills_live_test.exs` — 6 tests: catalog/export/install regression, prune dry-run+confirm (asserts only user-level removed), stale-preview refusal, per-mode audit tables + sorting + download link, dynamic scopes + download + bootstrap flow.
- `test/controlkeel_web/controllers/api_controller_test.exs` — new: prune preview/confirm (boolean + string), token-audit per-mode payloads + download headers + 422, bundle zip round-trip (`:zip.unzip` verifies contents) + 404/422/traversal.
- `mix precommit`: full suite green (the single intermittent failure, `server_test.exs:51` MCP-stdout, is a pre-existing flake on the base branch; passes standalone and in `mix test`).
