### PR TITLE
⚡ Bolt: [performance improvement] Optimize group_by length into frequencies_by

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-08-19 - Elixir List Allocation Overhead
 **Learning:** Chaining `Enum.map/2` into `Enum.uniq/1` then `length/1` (or `Enum.filter/2` into `length/1`) forces unnecessary intermediate list allocations in Elixir, adding hidden overhead.
 **Action:** Use `MapSet.new/2 |> MapSet.size()` and `Enum.count/2` to skip intermediate lists and reduce GC pressure.
+## 2026-08-19 - Elixir Group By Allocation Overhead
+**Learning:** Chaining `Enum.group_by/2` into `Enum.into(%{}, fn {k, v} -> {k, length(v)} end)` allocates memory for intermediate lists containing all grouped elements, adding hidden memory overhead.
+**Action:** Use `Enum.frequencies_by/2` which increments integer counts during a single traversal without allocating intermediate lists.

--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -1453,10 +1453,10 @@ defmodule ControlKeel.Benchmark do
   defp percentage(count, total), do: Float.round(count / total * 100, 1)
 
   defp count_by(values, mapper) do
+    # Bolt: Optimize list allocation by using frequencies_by instead of group_by |> length
     values
-    |> Enum.group_by(mapper)
-    |> Enum.reject(fn {key, _rows} -> is_nil(key) end)
-    |> Enum.into(%{}, fn {key, rows} -> {key, length(rows)} end)
+    |> Enum.frequencies_by(mapper)
+    |> Map.drop([nil])
   end
 
   defp maybe_channel(channels, true, channel), do: [channel | channels]

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -3209,9 +3209,8 @@ defmodule ControlKeel.Mission do
       Enum.count(regression_runs, &(get_in(&1.metadata, ["regression", "outcome"]) == "skipped"))
 
     engines =
-      regression_runs
-      |> Enum.group_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
-      |> Enum.into(%{}, fn {engine, rows} -> {engine, length(rows)} end)
+      # Bolt: Optimize list allocation by using frequencies_by instead of group_by |> length
+      Enum.frequencies_by(regression_runs, &(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
 
     latest_failures =
       regression_runs
@@ -4395,13 +4394,11 @@ defmodule ControlKeel.Mission do
     %{
       "total" => length(invocations),
       "providers" =>
-        invocations
-        |> Enum.group_by(&(&1.provider || "unknown"))
-        |> Enum.into(%{}, fn {provider, rows} -> {provider, length(rows)} end),
+        # Bolt: Optimize list allocation by using frequencies_by instead of group_by |> length
+        Enum.frequencies_by(invocations, &(&1.provider || "unknown")),
       "tools" =>
-        invocations
-        |> Enum.group_by(&(&1.tool || "unknown"))
-        |> Enum.into(%{}, fn {tool, rows} -> {tool, length(rows)} end),
+        # Bolt: Optimize list allocation by using frequencies_by instead of group_by |> length
+        Enum.frequencies_by(invocations, &(&1.tool || "unknown")),
       "cost_cents" => total_cost,
       "latest_run_at" =>
         invocations

--- a/lib/controlkeel/mission/decomposition.ex
+++ b/lib/controlkeel/mission/decomposition.ex
@@ -226,10 +226,10 @@ defmodule ControlKeel.Mission.Decomposition do
   end
 
   defp count_by(entries, key) do
+    # Bolt: Optimize list allocation by using frequencies_by instead of group_by |> length
     entries
-    |> Enum.group_by(&Map.get(&1, key))
-    |> Enum.reject(fn {value, _rows} -> is_nil(value) end)
-    |> Enum.into(%{}, fn {value, rows} -> {value, length(rows)} end)
+    |> Enum.frequencies_by(&Map.get(&1, key))
+    |> Map.drop([nil])
   end
 
   defp normalize_string(value) when is_binary(value) do


### PR DESCRIPTION
💡 **What**: Replaced instances of `Enum.group_by/2 |> Enum.into(%{}, fn {k, v} -> {k, length(v)} end)` with `Enum.frequencies_by/2`. Also updated `Enum.reject/1` to `Map.drop([nil])` for nil-key removal.
🎯 **Why**: To avoid intermediate list allocations and reduce GC pressure as outlined in `.jules/bolt.md`.
📊 **Impact**: Faster count aggregation and less memory usage during grouping in large collections (e.g. `mission`, `decomposition`, `benchmark`).
🔬 **Measurement**: Observe lower GC cycles during data aggregation in the relevant areas.

---
*PR created automatically by Jules for task [9390826052493007351](https://jules.google.com/task/9390826052493007351) started by @aryaminus*