### PR TITLE
⚡ Bolt: Optimize `Enum.group_by` memory allocations

### DIFF
--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -1453,10 +1453,10 @@ defmodule ControlKeel.Benchmark do
   defp percentage(count, total), do: Float.round(count / total * 100, 1)
 
   defp count_by(values, mapper) do
+    # ⚡ Bolt: Use Enum.frequencies_by/2 to avoid intermediate list allocations
     values
-    |> Enum.group_by(mapper)
-    |> Enum.reject(fn {key, _rows} -> is_nil(key) end)
-    |> Enum.into(%{}, fn {key, rows} -> {key, length(rows)} end)
+    |> Enum.frequencies_by(mapper)
+    |> Map.delete(nil)
   end
 
   defp maybe_channel(channels, true, channel), do: [channel | channels]

--- a/lib/controlkeel/governance/session_digest.ex
+++ b/lib/controlkeel/governance/session_digest.ex
@@ -137,9 +137,9 @@ defmodule ControlKeel.Governance.SessionDigest do
   end
 
   defp count_by_field(records, field) do
+    # ⚡ Bolt: Use Enum.frequencies_by/2 to avoid intermediate list allocations
     records
-    |> Enum.group_by(&Map.get(&1, field))
-    |> Enum.map(fn {k, v} -> {k, length(v)} end)
+    |> Enum.frequencies_by(&Map.get(&1, field))
     |> Enum.sort_by(fn {_k, v} -> v end, :desc)
     |> Enum.take(5)
     |> Map.new()

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -3209,9 +3209,9 @@ defmodule ControlKeel.Mission do
       Enum.count(regression_runs, &(get_in(&1.metadata, ["regression", "outcome"]) == "skipped"))
 
     engines =
+      # ⚡ Bolt: Use Enum.frequencies_by/2 to avoid intermediate list allocations
       regression_runs
-      |> Enum.group_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
-      |> Enum.into(%{}, fn {engine, rows} -> {engine, length(rows)} end)
+      |> Enum.frequencies_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
 
     latest_failures =
       regression_runs
@@ -4395,13 +4395,13 @@ defmodule ControlKeel.Mission do
     %{
       "total" => length(invocations),
       "providers" =>
+        # ⚡ Bolt: Use Enum.frequencies_by/2 to avoid intermediate list allocations
         invocations
-        |> Enum.group_by(&(&1.provider || "unknown"))
-        |> Enum.into(%{}, fn {provider, rows} -> {provider, length(rows)} end),
+        |> Enum.frequencies_by(&(&1.provider || "unknown")),
       "tools" =>
+        # ⚡ Bolt: Use Enum.frequencies_by/2 to avoid intermediate list allocations
         invocations
-        |> Enum.group_by(&(&1.tool || "unknown"))
-        |> Enum.into(%{}, fn {tool, rows} -> {tool, length(rows)} end),
+        |> Enum.frequencies_by(&(&1.tool || "unknown")),
       "cost_cents" => total_cost,
       "latest_run_at" =>
         invocations

--- a/lib/controlkeel/mission/decomposition.ex
+++ b/lib/controlkeel/mission/decomposition.ex
@@ -226,10 +226,10 @@ defmodule ControlKeel.Mission.Decomposition do
   end
 
   defp count_by(entries, key) do
+    # ⚡ Bolt: Use Enum.frequencies_by/2 to avoid intermediate list allocations
     entries
-    |> Enum.group_by(&Map.get(&1, key))
-    |> Enum.reject(fn {value, _rows} -> is_nil(value) end)
-    |> Enum.into(%{}, fn {value, rows} -> {value, length(rows)} end)
+    |> Enum.frequencies_by(&Map.get(&1, key))
+    |> Map.delete(nil)
   end
 
   defp normalize_string(value) when is_binary(value) do


### PR DESCRIPTION
💡 **What:** Replaced the `Enum.group_by(collection, key_fn) |> Enum.into(%{}, fn {key, rows} -> {key, length(rows)} end)` pattern (and variants) with the more direct `Enum.frequencies_by(collection, key_fn)`.

🎯 **Why:** `Enum.group_by/2` works by allocating a new list in memory for each distinct key to hold the elements before they are mapped to lengths via `Enum.into`. When we only care about the count/frequency, this creates unnecessary intermediate list allocations, increasing memory overhead and garbage collection pressure.

📊 **Impact:** Reduces memory allocations and intermediate list creations for these specific aggregation pathways. It operates in a single pass directly populating the map counters, thereby reducing memory and execution time overhead, especially for larger collections. Additionally, the code is much shorter, cleaner, and more readable.

🔬 **Measurement:** While micro-benchmarking might not reveal enormous numbers for small lists, reducing large intermediate garbage allocation keeps BEAM node health higher during scale. Verify memory allocation via `:erts_debug.size/1` differences for large sequences or simply observe the correctness via unit tests (the result type is identical, mapping keys to integer counts).

---
*PR created automatically by Jules for task [9868460834190572229](https://jules.google.com/task/9868460834190572229) started by @aryaminus*