### PR TITLE
🎨 Palette: [UX improvement] Add focus styles to sidebar links

### DIFF
--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -201,11 +201,11 @@ defmodule ControlKeelWeb.Layouts do
   defp nav_active?(_current_path, _path, _exact), do: false
 
   defp sidebar_link_class(true) do
-    "group flex items-center gap-3 rounded-xl bg-muted px-3 py-2.5 font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted"
+    "group flex items-center gap-3 rounded-xl bg-muted px-3 py-2.5 font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
   end
 
   defp sidebar_link_class(false) do
-    "group flex items-center gap-3 rounded-xl px-3 py-2.5 font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+    "group flex items-center gap-3 rounded-xl px-3 py-2.5 font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
   end
 
   defp sidebar_icon_class(true), do: "size-4 text-primary"


### PR DESCRIPTION
### 💡 What
Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset` to the active and inactive sidebar link classes.

### 🎯 Why
Keyboard navigation through the sidebar was lacking visual feedback. Without an explicit focus state, users who rely on keyboard navigation (like hitting `Tab`) couldn't easily tell which sidebar item was currently focused.

### 📸 Before/After
**Before:** Tabbing through the sidebar links showed default, often unnoticeable or missing browser focus outlines.
**After:** Tabbing through the sidebar links now shows a clear, themed primary color ring, matching the application's focus style patterns.

### ♿ Accessibility
Improves keyboard navigation accessibility by providing a clear, visible focus indicator, satisfying WCAG 2.1 Success Criterion 2.4.7 Focus Visible.

---
*PR created automatically by Jules for task [3605365520746053385](https://jules.google.com/task/3605365520746053385) started by @aryaminus*