### PR TITLE
⚡ Bolt: Optimize Elixir list operations with Enum.frequencies_by

### DIFF
--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -1452,11 +1452,11 @@ defmodule ControlKeel.Benchmark do
   defp percentage(_count, 0), do: 0.0
   defp percentage(count, total), do: Float.round(count / total * 100, 1)
 
+  # ⚡ Bolt: Replace Enum.group_by/2 |> Enum.reject/2 |> Enum.into/2 (with length/1) with Enum.frequencies_by/2 and Map.delete/2 to avoid intermediate list allocations
   defp count_by(values, mapper) do
     values
-    |> Enum.group_by(mapper)
-    |> Enum.reject(fn {key, _rows} -> is_nil(key) end)
-    |> Enum.into(%{}, fn {key, rows} -> {key, length(rows)} end)
+    |> Enum.frequencies_by(mapper)
+    |> Map.delete(nil)
   end
 
   defp maybe_channel(channels, true, channel), do: [channel | channels]

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -3208,10 +3208,10 @@ defmodule ControlKeel.Mission do
     skipped =
       Enum.count(regression_runs, &(get_in(&1.metadata, ["regression", "outcome"]) == "skipped"))
 
+    # ⚡ Bolt: Replace Enum.group_by/2 |> Enum.into/2 (with length/1) with Enum.frequencies_by/2 to avoid intermediate list allocations
     engines =
       regression_runs
-      |> Enum.group_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
-      |> Enum.into(%{}, fn {engine, rows} -> {engine, length(rows)} end)
+      |> Enum.frequencies_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
 
     latest_failures =
       regression_runs
@@ -4395,13 +4395,12 @@ defmodule ControlKeel.Mission do
     %{
       "total" => length(invocations),
       "providers" =>
+        # ⚡ Bolt: Replace Enum.group_by/2 |> Enum.into/2 (with length/1) with Enum.frequencies_by/2 to avoid intermediate list allocations
         invocations
-        |> Enum.group_by(&(&1.provider || "unknown"))
-        |> Enum.into(%{}, fn {provider, rows} -> {provider, length(rows)} end),
+        |> Enum.frequencies_by(&(&1.provider || "unknown")),
       "tools" =>
         invocations
-        |> Enum.group_by(&(&1.tool || "unknown"))
-        |> Enum.into(%{}, fn {tool, rows} -> {tool, length(rows)} end),
+        |> Enum.frequencies_by(&(&1.tool || "unknown")),
       "cost_cents" => total_cost,
       "latest_run_at" =>
         invocations

--- a/lib/controlkeel/mission/decomposition.ex
+++ b/lib/controlkeel/mission/decomposition.ex
@@ -225,11 +225,11 @@ defmodule ControlKeel.Mission.Decomposition do
     end
   end
 
+  # ⚡ Bolt: Replace Enum.group_by/2 |> Enum.reject/2 |> Enum.into/2 (with length/1) with Enum.frequencies_by/2 and Map.delete/2 to avoid intermediate list allocations
   defp count_by(entries, key) do
     entries
-    |> Enum.group_by(&Map.get(&1, key))
-    |> Enum.reject(fn {value, _rows} -> is_nil(value) end)
-    |> Enum.into(%{}, fn {value, rows} -> {value, length(rows)} end)
+    |> Enum.frequencies_by(&Map.get(&1, key))
+    |> Map.delete(nil)
   end
 
   defp normalize_string(value) when is_binary(value) do


### PR DESCRIPTION
💡 **What**: Replaced `Enum.group_by/2 |> Enum.into/2` (with `length/1`) and `Enum.group_by/2 |> Enum.reject/2 |> Enum.into/2` with `Enum.frequencies_by/2` and `Map.delete(nil)` in `lib/controlkeel/mission.ex`, `lib/controlkeel/mission/decomposition.ex`, and `lib/controlkeel/benchmark.ex`.
🎯 **Why**: Using `Enum.group_by` followed by mapping lengths forces intermediate list allocations for each grouping, adding unnecessary GC pressure and reducing performance. `Enum.frequencies_by` computes the counts directly during a single iteration, skipping these allocations entirely.
📊 **Impact**: Eliminates unneeded list allocations during grouping, reducing memory overhead and garbage collection time, especially when parsing large datasets.
🔬 **Measurement**: Observe lower GC cycles, reduced memory spikes during `benchmark` / `decomposition` processes, and a faster grouping operation.

---
*PR created automatically by Jules for task [6802422147181051118](https://jules.google.com/task/6802422147181051118) started by @aryaminus*