### PR TITLE
⚡ Bolt: Use Enum.frequencies_by for performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
-## 2026-08-19 - Elixir List Allocation Overhead
-**Learning:** Chaining `Enum.map/2` into `Enum.uniq/1` then `length/1` (or `Enum.filter/2` into `length/1`) forces unnecessary intermediate list allocations in Elixir, adding hidden overhead.
-**Action:** Use `MapSet.new/2 |> MapSet.size()` and `Enum.count/2` to skip intermediate lists and reduce GC pressure.
+## 2024-05-24 - Elixir Enum.frequencies_by vs Enum.group_by
+**Learning:** Using `Enum.group_by/2` followed by `Enum.into(%{}, fn {k, v} -> {k, length(v)} end)` creates unnecessary intermediate list allocations for the grouped items, which increases GC pressure.
+**Action:** Use `Enum.frequencies_by/2` directly to count occurrences more efficiently without creating intermediate lists.

--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -1453,10 +1453,10 @@ defmodule ControlKeel.Benchmark do
   defp percentage(count, total), do: Float.round(count / total * 100, 1)
 
   defp count_by(values, mapper) do
+    # Bolt: Replaced Enum.group_by |> Enum.reject |> Enum.into with Enum.frequencies_by |> Map.delete to avoid intermediate list allocations.
     values
-    |> Enum.group_by(mapper)
-    |> Enum.reject(fn {key, _rows} -> is_nil(key) end)
-    |> Enum.into(%{}, fn {key, rows} -> {key, length(rows)} end)
+    |> Enum.frequencies_by(mapper)
+    |> Map.delete(nil)
   end
 
   defp maybe_channel(channels, true, channel), do: [channel | channels]

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -3208,10 +3208,10 @@ defmodule ControlKeel.Mission do
     skipped =
       Enum.count(regression_runs, &(get_in(&1.metadata, ["regression", "outcome"]) == "skipped"))
 
+    # Bolt: Replaced Enum.group_by |> Enum.into with Enum.frequencies_by to avoid intermediate list allocations and reduce GC pressure.
     engines =
       regression_runs
-      |> Enum.group_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
-      |> Enum.into(%{}, fn {engine, rows} -> {engine, length(rows)} end)
+      |> Enum.frequencies_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
 
     latest_failures =
       regression_runs
@@ -4392,16 +4392,15 @@ defmodule ControlKeel.Mission do
   defp known_attr_key(_key), do: nil
 
   defp build_invocation_summary(invocations, total_cost) do
+    # Bolt: Replaced Enum.group_by |> Enum.into with Enum.frequencies_by to avoid intermediate list allocations and reduce GC pressure.
     %{
       "total" => length(invocations),
       "providers" =>
         invocations
-        |> Enum.group_by(&(&1.provider || "unknown"))
-        |> Enum.into(%{}, fn {provider, rows} -> {provider, length(rows)} end),
+        |> Enum.frequencies_by(&(&1.provider || "unknown")),
       "tools" =>
         invocations
-        |> Enum.group_by(&(&1.tool || "unknown"))
-        |> Enum.into(%{}, fn {tool, rows} -> {tool, length(rows)} end),
+        |> Enum.frequencies_by(&(&1.tool || "unknown")),
       "cost_cents" => total_cost,
       "latest_run_at" =>
         invocations

--- a/lib/controlkeel/mission/decomposition.ex
+++ b/lib/controlkeel/mission/decomposition.ex
@@ -226,10 +226,10 @@ defmodule ControlKeel.Mission.Decomposition do
   end
 
   defp count_by(entries, key) do
+    # Bolt: Replaced Enum.group_by |> Enum.reject |> Enum.into with Enum.frequencies_by |> Map.delete to avoid intermediate list allocations.
     entries
-    |> Enum.group_by(&Map.get(&1, key))
-    |> Enum.reject(fn {value, _rows} -> is_nil(value) end)
-    |> Enum.into(%{}, fn {value, rows} -> {value, length(rows)} end)
+    |> Enum.frequencies_by(&Map.get(&1, key))
+    |> Map.delete(nil)
   end
 
   defp normalize_string(value) when is_binary(value) do


### PR DESCRIPTION
💡 **What:** Replaced multiple instances of `Enum.group_by/2 |> Enum.into/2` and `Enum.group_by/2 |> Enum.reject/2 |> Enum.into/2` with `Enum.frequencies_by/2` and `Enum.frequencies_by/2 |> Map.delete(nil)`.

🎯 **Why:** The previous approach, utilizing `Enum.group_by/2`, allocated an intermediate list of grouped items in memory just to count their lengths using `Enum.into(%{}, fn {k, v} -> {k, length(v)} end)`.

📊 **Impact:** Reduces GC pressure and speeds up performance on datasets where multiple frequency summaries are computed by avoiding intermediate large list allocations altogether.

🔬 **Measurement:** This optimization can be verified through standard profiling around the replaced lines when grouping thousands of `invocation` or `regression_run` elements.

---
*PR created automatically by Jules for task [1297255903208104654](https://jules.google.com/task/1297255903208104654) started by @aryaminus*