### PR TITLE
⚡ Bolt: [performance improvement] Optimize group_by lengths to use frequencies_by

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
-## 2026-08-19 - Elixir List Allocation Overhead
-**Learning:** Chaining `Enum.map/2` into `Enum.uniq/1` then `length/1` (or `Enum.filter/2` into `length/1`) forces unnecessary intermediate list allocations in Elixir, adding hidden overhead.
-**Action:** Use `MapSet.new/2 |> MapSet.size()` and `Enum.count/2` to skip intermediate lists and reduce GC pressure.
+## 2024-06-11 - [Optimize group_by + length(rows) pattern]
+**Learning:** In Elixir, using `Enum.group_by` followed by mapping the groups to count their lengths `Enum.into(%{}, fn {k, rows} -> {k, length(rows)} end)` or `Enum.map(fn {k, v} -> {k, length(v)} end)` allocates intermediate lists for every group, which adds GC pressure. `Enum.frequencies_by/2` achieves this directly without allocating intermediate lists.
+**Action:** Always prefer `Enum.frequencies_by/2` over `Enum.group_by/2` combined with length counting. If the original pipeline rejected `nil` keys before counting, use `Map.delete(nil)` after `Enum.frequencies_by/2`.

--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -1454,9 +1454,9 @@ defmodule ControlKeel.Benchmark do
 
   defp count_by(values, mapper) do
     values
-    |> Enum.group_by(mapper)
-    |> Enum.reject(fn {key, _rows} -> is_nil(key) end)
-    |> Enum.into(%{}, fn {key, rows} -> {key, length(rows)} end)
+    # ⚡ Bolt: Use Enum.frequencies_by/2 + Map.delete/2 instead of Enum.group_by/2 + Enum.reject/2 + Enum.into/2 to reduce intermediate allocations
+    |> Enum.frequencies_by(mapper)
+    |> Map.delete(nil)
   end
 
   defp maybe_channel(channels, true, channel), do: [channel | channels]

--- a/lib/controlkeel/governance/session_digest.ex
+++ b/lib/controlkeel/governance/session_digest.ex
@@ -138,8 +138,8 @@ defmodule ControlKeel.Governance.SessionDigest do
 
   defp count_by_field(records, field) do
     records
-    |> Enum.group_by(&Map.get(&1, field))
-    |> Enum.map(fn {k, v} -> {k, length(v)} end)
+    # ⚡ Bolt: Use Enum.frequencies_by/2 instead of Enum.group_by/2 + Enum.map/2 to reduce intermediate allocations
+    |> Enum.frequencies_by(&Map.get(&1, field))
     |> Enum.sort_by(fn {_k, v} -> v end, :desc)
     |> Enum.take(5)
     |> Map.new()

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -3210,8 +3210,8 @@ defmodule ControlKeel.Mission do
 
     engines =
       regression_runs
-      |> Enum.group_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
-      |> Enum.into(%{}, fn {engine, rows} -> {engine, length(rows)} end)
+      # ⚡ Bolt: Use Enum.frequencies_by/2 instead of Enum.group_by/2 + length/1 to reduce intermediate allocations
+      |> Enum.frequencies_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
 
     latest_failures =
       regression_runs
@@ -4396,12 +4396,12 @@ defmodule ControlKeel.Mission do
       "total" => length(invocations),
       "providers" =>
         invocations
-        |> Enum.group_by(&(&1.provider || "unknown"))
-        |> Enum.into(%{}, fn {provider, rows} -> {provider, length(rows)} end),
+        # ⚡ Bolt: Use Enum.frequencies_by/2 instead of Enum.group_by/2 + length/1 to reduce intermediate allocations
+        |> Enum.frequencies_by(&(&1.provider || "unknown")),
       "tools" =>
         invocations
-        |> Enum.group_by(&(&1.tool || "unknown"))
-        |> Enum.into(%{}, fn {tool, rows} -> {tool, length(rows)} end),
+        # ⚡ Bolt: Use Enum.frequencies_by/2 instead of Enum.group_by/2 + length/1 to reduce intermediate allocations
+        |> Enum.frequencies_by(&(&1.tool || "unknown")),
       "cost_cents" => total_cost,
       "latest_run_at" =>
         invocations

--- a/lib/controlkeel/mission/decomposition.ex
+++ b/lib/controlkeel/mission/decomposition.ex
@@ -227,9 +227,9 @@ defmodule ControlKeel.Mission.Decomposition do
 
   defp count_by(entries, key) do
     entries
-    |> Enum.group_by(&Map.get(&1, key))
-    |> Enum.reject(fn {value, _rows} -> is_nil(value) end)
-    |> Enum.into(%{}, fn {value, rows} -> {value, length(rows)} end)
+    # ⚡ Bolt: Use Enum.frequencies_by/2 + Map.delete/2 instead of Enum.group_by/2 + Enum.reject/2 + Enum.into/2 to reduce intermediate allocations
+    |> Enum.frequencies_by(&Map.get(&1, key))
+    |> Map.delete(nil)
   end
 
   defp normalize_string(value) when is_binary(value) do


### PR DESCRIPTION
💡 What: Refactored multiple occurrences where `Enum.group_by/2` was followed by a mapping function (like `Enum.into` or `Enum.map`) to calculate the length of the groups to use `Enum.frequencies_by/2` directly instead. When `nil` groups were ignored, `Map.delete(nil)` was appended.

🎯 Why: The previous pattern allocates intermediate lists for each group, adding memory overhead and garbage collection pressure, especially for large collections. `Enum.frequencies_by/2` performs the counting iteratively in a single pass without allocating lists for the groups.

📊 Impact: Reduces memory allocations and intermediate data structures during list processing (e.g., in regression runs, invocation summaries, task decomposition, and digests). This improves CPU efficiency and lessens GC pressure.

🔬 Measurement: Review memory usage or execution time of affected functions (like `ControlKeel.Mission.get_regression_runs/1` or `ControlKeel.Benchmark.summarize/1`) under high load using `:timer.tc/1` or Erlang's memory profiling tools. Ensure the returned map structure is identical to the previous implementation.

---
*PR created automatically by Jules for task [9546053078610243942](https://jules.google.com/task/9546053078610243942) started by @aryaminus*