### PR TITLE
Refactor organization navigation and enhance sidebar functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,9 @@ RUN mix deps.compile
 
 COPY lib lib
 COPY priv priv
+COPY assets assets
 RUN mix compile
+RUN mix assets.setup && mix assets.deploy
 
 COPY config/runtime.exs config/
 RUN mix release

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -106,8 +106,19 @@ defmodule ControlKeel.Mission do
   def list_workspaces_for_org(org_id),
     do: Repo.all(from w in Workspace, where: w.org_id == ^org_id)
 
+  def list_workspaces_for_orgs(org_ids) when is_list(org_ids),
+    do: Repo.all(from w in Workspace, where: w.org_id in ^org_ids, order_by: w.name)
+
   def list_sessions_for_workspace(workspace_id),
     do: Repo.all(from s in Session, where: s.workspace_id == ^workspace_id)
+
+  def list_sessions_for_workspaces(workspace_ids) when is_list(workspace_ids),
+    do:
+      Repo.all(
+        from s in Session,
+          where: s.workspace_id in ^workspace_ids,
+          order_by: [desc: s.inserted_at]
+      )
 
   @doc """
   Returns true when a session (mission) already uses `name` as its title,

--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -261,21 +261,11 @@ defmodule ControlKeelWeb.Layouts do
 
   def user_menu(assigns) do
     ~H"""
-    <div
-      {@rest}
-      class={"relative #{@class}"}
-      id={@id}
-      phx-click-away={
-        JS.hide(to: "##{@id}-popover")
-        |> JS.remove_class("rotate-180", to: "##{@id}-chevron")
-        |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id} button")
-      }
-    >
+    <div {@rest} class={"relative #{@class}"} id={@id}>
       <button
         type="button"
         phx-click={
           JS.toggle(to: "##{@id}-popover")
-          |> JS.toggle_class("rotate-180", to: "##{@id}-chevron")
           |> JS.toggle_attribute({"aria-expanded", "true", "false"})
         }
         aria-haspopup="menu"
@@ -302,13 +292,15 @@ defmodule ControlKeelWeb.Layouts do
               {@current_user.name || @current_user.email}
             </span>
           </span>
-          <span id={"#{@id}-chevron"} class="transition-transform duration-200">
-            <.icon name="hero-chevron-down" class="size-4 shrink-0 text-muted-foreground" />
-          </span>
+          <.icon name="hero-chevron-down" class="size-4 shrink-0 text-muted-foreground" />
         <% end %>
       </button>
       <div
         id={"#{@id}-popover"}
+        phx-click-away={
+          JS.hide(to: "##{@id}-popover")
+          |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id} button")
+        }
         class={"hidden absolute #{@popover_class} z-50 w-56 rounded-xl border bg-card p-3 shadow-2xl shadow-black/50 backdrop-blur-md"}
       >
         <p class="text-sm font-semibold text-foreground">
@@ -317,38 +309,17 @@ defmodule ControlKeelWeb.Layouts do
         <p class="mt-0.5 text-xs text-muted-foreground">{@current_user.email}</p>
         <div class="my-2 border-t"></div>
         <%= if @show_dashboard do %>
-          <.link
-            navigate={~p"/"}
+          <a
+            href={~p"/dashboard"}
             phx-click={
               JS.hide(to: "##{@id}-popover")
               |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id} button")
             }
             class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
           >
-            <.icon name="hero-home" class="size-4" /> Home
-          </.link>
+            <.icon name="hero-squares-2x2" class="size-4" /> Dashboard
+          </a>
         <% end %>
-
-        <a
-          href={~p"/getting-started"}
-          target="_blank"
-          rel="noopener"
-          class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
-        >
-          <.icon name="hero-book-open" class="size-4" /> Docs
-        </a>
-
-        <a
-          href="https://github.com/aryaminus/controlkeel"
-          target="_blank"
-          rel="noopener"
-          class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
-        >
-          <.icon name="hero-code-bracket" class="size-4" /> GitHub
-        </a>
-
-        <div class="my-2 border-t"></div>
-
         <%!-- TODO: Settings button disabled — it was a no-op that only closed the
              popover. Re-enable and wire to a user settings modal/dialog when functional.
         <button

--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -261,11 +261,21 @@ defmodule ControlKeelWeb.Layouts do
 
   def user_menu(assigns) do
     ~H"""
-    <div {@rest} class={"relative #{@class}"} id={@id}>
+    <div
+      {@rest}
+      class={"relative #{@class}"}
+      id={@id}
+      phx-click-away={
+        JS.hide(to: "##{@id}-popover")
+        |> JS.remove_class("rotate-180", to: "##{@id}-chevron")
+        |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id} button")
+      }
+    >
       <button
         type="button"
         phx-click={
           JS.toggle(to: "##{@id}-popover")
+          |> JS.toggle_class("rotate-180", to: "##{@id}-chevron")
           |> JS.toggle_attribute({"aria-expanded", "true", "false"})
         }
         aria-haspopup="menu"
@@ -292,15 +302,13 @@ defmodule ControlKeelWeb.Layouts do
               {@current_user.name || @current_user.email}
             </span>
           </span>
-          <.icon name="hero-chevron-down" class="size-4 shrink-0 text-muted-foreground" />
+          <span id={"#{@id}-chevron"} class="transition-transform duration-200">
+            <.icon name="hero-chevron-down" class="size-4 shrink-0 text-muted-foreground" />
+          </span>
         <% end %>
       </button>
       <div
         id={"#{@id}-popover"}
-        phx-click-away={
-          JS.hide(to: "##{@id}-popover")
-          |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id} button")
-        }
         class={"hidden absolute #{@popover_class} z-50 w-56 rounded-xl border bg-card p-3 shadow-2xl shadow-black/50 backdrop-blur-md"}
       >
         <p class="text-sm font-semibold text-foreground">
@@ -309,17 +317,38 @@ defmodule ControlKeelWeb.Layouts do
         <p class="mt-0.5 text-xs text-muted-foreground">{@current_user.email}</p>
         <div class="my-2 border-t"></div>
         <%= if @show_dashboard do %>
-          <a
-            href={~p"/dashboard"}
+          <.link
+            navigate={~p"/"}
             phx-click={
               JS.hide(to: "##{@id}-popover")
               |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id} button")
             }
             class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
           >
-            <.icon name="hero-squares-2x2" class="size-4" /> Dashboard
-          </a>
+            <.icon name="hero-home" class="size-4" /> Home
+          </.link>
         <% end %>
+
+        <a
+          href={~p"/getting-started"}
+          target="_blank"
+          rel="noopener"
+          class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
+        >
+          <.icon name="hero-book-open" class="size-4" /> Docs
+        </a>
+
+        <a
+          href="https://github.com/aryaminus/controlkeel"
+          target="_blank"
+          rel="noopener"
+          class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
+        >
+          <.icon name="hero-code-bracket" class="size-4" /> GitHub
+        </a>
+
+        <div class="my-2 border-t"></div>
+
         <%!-- TODO: Settings button disabled — it was a no-op that only closed the
              popover. Re-enable and wire to a user settings modal/dialog when functional.
         <button

--- a/lib/controlkeel_web/components/organization_layouts.ex
+++ b/lib/controlkeel_web/components/organization_layouts.ex
@@ -128,19 +128,6 @@ defmodule ControlKeelWeb.OrganizationLayouts do
                 </.link>
               <% end %>
             </div>
-
-            <div class="my-1 border-t"></div>
-
-            <.link
-              navigate={~p"/organizations"}
-              phx-click={
-                JS.hide(to: "#sidebar-org-switcher-popover")
-                |> JS.set_attribute({"aria-expanded", "false"}, to: "#org-switcher-button")
-              }
-              class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
-            >
-              <.icon name="hero-squares-2x2" class="size-3.5" /> All organizations
-            </.link>
           </div>
         </div>
       </div>
@@ -236,7 +223,7 @@ defmodule ControlKeelWeb.OrganizationLayouts do
           <% end %>
         </ol>
       </nav>
-      <div :if={@actions != []} class="flex items-center gap-2" id="dashboard-page-action">
+      <div :if={@actions != []} class="flex items-center gap-2" id="organization-page-action">
         <%= for action <- @actions do %>
           <a
             :if={action[:to]}

--- a/lib/controlkeel_web/components/organization_layouts.ex
+++ b/lib/controlkeel_web/components/organization_layouts.ex
@@ -1,0 +1,129 @@
+defmodule ControlKeelWeb.OrganizationLayouts do
+  @moduledoc """
+  Framework layouts for organization-scoped pages.
+  """
+
+  use ControlKeelWeb, :html
+
+  import ControlKeelWeb.Layouts, only: [dashboard_header: 1, flash_group: 1, user_menu: 1]
+
+  embed_templates "organization_layouts/*"
+
+  attr :current_user, :any, default: nil
+  attr :current_path, :string, default: nil
+  attr :current_query, :string, default: nil
+  attr :nav_org, :map, required: true
+
+  def organization_sidebar(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:mode, fn -> ControlKeel.Runtime.Mode.current() end)
+      |> assign(:nav_items, organization_nav_items(assigns.nav_org))
+
+    ~H"""
+    <aside
+      id="app-sidebar"
+      class="hidden h-screen w-64 flex-col border-r bg-sidebar shadow-2xl shadow-black/30 lg:flex"
+    >
+      <.link navigate={~p"/dashboard"} class="flex items-center gap-3 px-3 pt-3 pb-2">
+        <span class="flex size-10 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-lg shadow-primary/20">
+          <.icon name="hero-bolt-solid" class="size-5" />
+        </span>
+        <span class="block text-sm font-semibold tracking-wide text-foreground">ControlKeel</span>
+      </.link>
+
+      <nav id="sidebar-org-nav" class="mt-2 flex flex-1 flex-col gap-1 px-3 text-sm">
+        <div class="flex items-center gap-3 px-3 py-4 text-foreground">
+          <.icon name="hero-building-office-2" class={organization_nav_icon_class(true)} />
+          <span class="min-w-0 truncate text-sm text-foreground">
+            {@nav_org.name}
+          </span>
+        </div>
+
+        <%= for item <- @nav_items do %>
+          <% active = organization_nav_active?(@current_path, @current_query, item) %>
+          <.link
+            navigate={item.href}
+            aria-current={active && "page"}
+            class={organization_nav_link_class(active)}
+          >
+            <.icon name={item.icon} class={organization_nav_icon_class(active)} /> {item.label}
+          </.link>
+        <% end %>
+      </nav>
+
+      <div class="flex flex-col justify-end border-t mt-2 px-3 py-2">
+        <a
+          href={~p"/getting-started"}
+          target="_blank"
+          rel="noopener"
+          class="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
+        >
+          <.icon name="hero-book-open" class="size-4" /> Docs
+        </a>
+        <a
+          href="https://github.com/aryaminus/controlkeel"
+          target="_blank"
+          rel="noopener"
+          class="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
+        >
+          <.icon name="hero-code-bracket" class="size-4" /> GitHub
+        </a>
+
+        <.user_menu
+          :if={@current_user != nil and @mode != :local}
+          id="sidebar-user-menu"
+          current_user={@current_user}
+          class="mt-3 border-t pt-3"
+          popover_class="bottom-20 right-4"
+        />
+      </div>
+    </aside>
+    """
+  end
+
+  defp organization_nav_items(org) do
+    [
+      %{
+        label: "Overview",
+        href: ~p"/organizations/#{org.slug}",
+        tab: nil,
+        icon: "hero-squares-2x2"
+      },
+      %{
+        label: "Settings",
+        href: ~p"/organizations/#{org.slug}/settings",
+        tab: "settings",
+        icon: "hero-cog-6-tooth"
+      }
+    ]
+  end
+
+  defp organization_nav_active?(current_path, current_query, item) do
+    query_tab = current_query && URI.decode_query(current_query)["tab"]
+
+    cond do
+      item.tab == "settings" ->
+        is_binary(current_path) && current_path == item.href
+
+      item.tab == nil ->
+        is_binary(current_path) && current_path == item.href && query_tab in [nil, "workspaces"]
+
+      true ->
+        query_tab == item.tab
+    end
+  end
+
+  defp organization_nav_link_class(true) do
+    "group flex items-center gap-3 rounded-xl bg-muted px-3 py-2.5 font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted"
+  end
+
+  defp organization_nav_link_class(false) do
+    "group flex items-center gap-3 rounded-xl px-3 py-2.5 font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+  end
+
+  defp organization_nav_icon_class(true), do: "size-4 text-primary"
+
+  defp organization_nav_icon_class(false),
+    do: "size-4 text-muted-foreground group-hover:text-primary"
+end

--- a/lib/controlkeel_web/components/organization_layouts.ex
+++ b/lib/controlkeel_web/components/organization_layouts.ex
@@ -5,8 +5,6 @@ defmodule ControlKeelWeb.OrganizationLayouts do
 
   use ControlKeelWeb, :html
 
-  import ControlKeelWeb.Layouts, only: [flash_group: 1, user_menu: 1]
-
   alias ControlKeel.Accounts
 
   embed_templates "organization_layouts/*"
@@ -47,107 +45,104 @@ defmodule ControlKeelWeb.OrganizationLayouts do
       class="hidden h-screen w-64 flex-col border-r bg-sidebar shadow-2xl shadow-black/30 lg:flex"
     >
       <div class="p-3">
-        <%= if @current_user != nil and @mode != :local do %>
-          <div class="relative" id="sidebar-org-switcher">
-            <div class="flex w-full items-center justify-between rounded-xl p-1.5">
-              <div class="flex items-center gap-3 min-w-0">
-                <span class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-lg shadow-primary/20">
-                  <.icon name="hero-bolt-solid" class="size-5" />
-                </span>
-                <div class="flex flex-col gap-0.5 min-w-0">
-                  <span class="block text-sm font-semibold tracking-wide text-foreground">
-                    ControlKeel
-                  </span>
-                  <span class="block text-xs font-medium text-muted-foreground truncate">
-                    {@nav_org.name}
-                  </span>
-                </div>
-              </div>
-
-              <button
-                type="button"
-                id="org-switcher-button"
-                phx-click={
-                  JS.toggle(to: "#sidebar-org-switcher-popover")
-                  |> JS.toggle_attribute({"aria-expanded", "true", "false"})
-                }
-                aria-haspopup="menu"
-                aria-expanded="false"
-                aria-label="Switch organization"
-                class="group rounded-lg p-1 transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-              >
-                <.icon
-                  name="hero-chevron-up-down"
-                  class="size-6 shrink-0 text-muted-foreground transition group-hover:text-foreground"
-                />
-              </button>
-            </div>
-
-            <div
-              id="sidebar-org-switcher-popover"
-              phx-click-away={
-                JS.hide(to: "#sidebar-org-switcher-popover")
-                |> JS.set_attribute({"aria-expanded", "false"}, to: "#org-switcher-button")
-              }
-              class="hidden absolute left-0 right-0 top-full mt-1.5 z-50 rounded-xl border bg-card p-1.5 shadow-2xl shadow-black/50 backdrop-blur-md"
-            >
-              <div class="px-2.5 py-1.5 text-xs font-semibold text-muted-foreground">
-                Organizations
-              </div>
-              <div class="max-h-60 overflow-y-auto space-y-0.5">
-                <%= for org <- @user_orgs do %>
-                  <% active = org.id == @nav_org.id %>
-                  <.link
-                    navigate={~p"/#{org.slug}"}
-                    phx-click={
-                      JS.hide(to: "#sidebar-org-switcher-popover")
-                      |> JS.set_attribute({"aria-expanded", "false"}, to: "#org-switcher-button")
-                    }
-                    class={[
-                      "flex items-center justify-between gap-2 rounded-lg px-2.5 py-2 text-sm transition",
-                      active && "bg-muted font-medium text-foreground",
-                      !active && "text-muted-foreground hover:bg-muted hover:text-foreground"
-                    ]}
-                  >
-                    <div class="flex items-center gap-2 min-w-0">
-                      <.icon
-                        name="hero-building-office-2"
-                        class="size-4 shrink-0 text-muted-foreground"
-                      />
-                      <span class="truncate">{org.name}</span>
-                    </div>
-                    <.icon :if={active} name="hero-check" class="size-4 shrink-0 text-primary" />
-                  </.link>
-                <% end %>
-              </div>
-
-              <div class="my-1 border-t"></div>
-
-              <.link
-                navigate={~p"/organizations"}
-                phx-click={
-                  JS.hide(to: "#sidebar-org-switcher-popover")
-                  |> JS.set_attribute({"aria-expanded", "false"}, to: "#org-switcher-button")
-                }
-                class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
-              >
-                <.icon name="hero-squares-2x2" class="size-3.5" /> All organizations
-              </.link>
-            </div>
-          </div>
-        <% else %>
-          <div class="flex items-center gap-3 p-1.5">
-            <span class="flex size-10 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-lg shadow-primary/20">
+        <div
+          id="sidebar-org-switcher"
+          class={[
+            "relative flex items-center gap-3 rounded-xl p-1.5",
+            (@current_user != nil and @mode != :local) && "justify-between"
+          ]}
+          phx-click-away={
+            JS.hide(to: "#sidebar-org-switcher-popover")
+            |> JS.set_attribute({"aria-expanded", "false"}, to: "#org-switcher-button")
+          }
+        >
+          <.link
+            navigate={~p"/#{@nav_org.slug}"}
+            aria-label={"#{@nav_org.name} home"}
+            class="flex min-w-0 flex-1 items-center gap-3 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          >
+            <span class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-lg shadow-primary/20">
               <.icon name="hero-bolt-solid" class="size-5" />
             </span>
-            <div class="flex flex-col gap-0.5">
+            <div class="flex min-w-0 flex-col gap-0.5">
               <span class="block text-sm font-semibold tracking-wide text-foreground">
                 ControlKeel
               </span>
-              <span class="block text-xs font-medium text-muted-foreground">{@nav_org.name}</span>
+              <span class="block truncate text-xs font-medium text-muted-foreground">
+                {@nav_org.name}
+              </span>
             </div>
+          </.link>
+
+          <button
+            :if={@current_user != nil and @mode != :local}
+            type="button"
+            id="org-switcher-button"
+            aria-label="Switch organization"
+            aria-haspopup="menu"
+            aria-expanded="false"
+            aria-controls="sidebar-org-switcher-popover"
+            phx-click={
+              JS.toggle(to: "#sidebar-org-switcher-popover")
+              |> JS.toggle_attribute({"aria-expanded", "true", "false"})
+            }
+            class="group rounded-lg p-1 transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          >
+            <.icon
+              name="hero-chevron-up-down"
+              class="size-4 shrink-0 text-muted-foreground transition group-hover:text-foreground"
+            />
+          </button>
+
+          <div
+            :if={@current_user != nil and @mode != :local}
+            id="sidebar-org-switcher-popover"
+            class="hidden absolute left-0 right-0 top-full z-50 mt-1.5 rounded-xl border bg-card p-1.5 shadow-2xl shadow-black/50 backdrop-blur-md"
+          >
+            <div class="px-2.5 py-1.5 text-xs font-semibold text-muted-foreground">
+              Organizations
+            </div>
+            <div class="max-h-60 space-y-0.5 overflow-y-auto">
+              <%= for org <- @user_orgs do %>
+                <% active = org.id == @nav_org.id %>
+                <.link
+                  navigate={~p"/#{org.slug}"}
+                  phx-click={
+                    JS.hide(to: "#sidebar-org-switcher-popover")
+                    |> JS.set_attribute({"aria-expanded", "false"}, to: "#org-switcher-button")
+                  }
+                  class={[
+                    "flex items-center justify-between gap-2 rounded-lg px-2.5 py-2 text-sm transition",
+                    active && "bg-muted font-medium text-foreground",
+                    !active && "text-muted-foreground hover:bg-muted hover:text-foreground"
+                  ]}
+                >
+                  <div class="flex min-w-0 items-center gap-2">
+                    <.icon
+                      name="hero-building-office-2"
+                      class="size-4 shrink-0 text-muted-foreground"
+                    />
+                    <span class="truncate">{org.name}</span>
+                  </div>
+                  <.icon :if={active} name="hero-check" class="size-4 shrink-0 text-primary" />
+                </.link>
+              <% end %>
+            </div>
+
+            <div class="my-1 border-t"></div>
+
+            <.link
+              navigate={~p"/organizations"}
+              phx-click={
+                JS.hide(to: "#sidebar-org-switcher-popover")
+                |> JS.set_attribute({"aria-expanded", "false"}, to: "#org-switcher-button")
+              }
+              class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+            >
+              <.icon name="hero-squares-2x2" class="size-3.5" /> All organizations
+            </.link>
           </div>
-        <% end %>
+        </div>
       </div>
 
       <nav id="sidebar-org-nav" class="mt-4 flex flex-1 flex-col gap-1 px-3 text-sm">
@@ -386,4 +381,177 @@ defmodule ControlKeelWeb.OrganizationLayouts do
 
   defp organization_nav_icon_class(false),
     do: "size-4 text-muted-foreground group-hover:text-primary"
+
+  # NOTE: `user_menu/1` and `flash_group/1` are intentionally duplicated here
+  # (forked from `ControlKeelWeb.Layouts` on 2026-09-11) so organization pages
+  # stay self-contained with no import from `Layouts`. Apply future fixes in
+  # both modules.
+  attr :id, :string, required: true
+  attr :current_user, :any, required: true
+  attr :compact, :boolean, default: false
+  attr :show_dashboard, :boolean, default: false
+  attr :class, :string, default: ""
+  attr :popover_class, :string, default: "right-0 top-full mt-2"
+  attr :rest, :global
+
+  def user_menu(assigns) do
+    ~H"""
+    <div
+      {@rest}
+      class={"relative #{@class}"}
+      id={@id}
+      phx-click-away={
+        JS.hide(to: "##{@id}-popover")
+        |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id} button")
+      }
+    >
+      <%= if @compact do %>
+        <button
+          type="button"
+          aria-label="User menu"
+          aria-haspopup="menu"
+          aria-expanded="false"
+          aria-controls={"#{@id}-popover"}
+          phx-click={
+            JS.toggle(to: "##{@id}-popover")
+            |> JS.toggle_attribute({"aria-expanded", "true", "false"}, to: "##{@id} button")
+          }
+          class="flex cursor-pointer size-9 shrink-0 items-center justify-center rounded-full bg-primary/20 px-1 py-1 text-sm font-semibold text-primary ring-1 ring-primary/30 transition hover:bg-primary/30 hover:ring-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+        >
+          {String.at(@current_user.name || @current_user.email, 0) |> String.upcase()}
+        </button>
+      <% else %>
+        <div class="flex items-center gap-2 rounded-xl px-2 py-1.5">
+          <span class="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/20 text-sm font-semibold text-primary ring-1 ring-primary/30">
+            {String.at(@current_user.name || @current_user.email, 0) |> String.upcase()}
+          </span>
+
+          <span class="min-w-0 flex-1 leading-tight">
+            <span class="block truncate text-sm font-semibold text-foreground">
+              {@current_user.name || @current_user.email}
+            </span>
+          </span>
+          <button
+            type="button"
+            aria-label="User menu"
+            aria-haspopup="menu"
+            aria-expanded="false"
+            aria-controls={"#{@id}-popover"}
+            phx-click={
+              JS.toggle(to: "##{@id}-popover")
+              |> JS.toggle_attribute({"aria-expanded", "true", "false"}, to: "##{@id} button")
+            }
+            class="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg text-muted-foreground transition hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          >
+            <.icon name="hero-ellipsis-horizontal" class="size-4" />
+          </button>
+        </div>
+      <% end %>
+
+      <div
+        id={"#{@id}-popover"}
+        class={"hidden absolute #{@popover_class} z-50 w-56 rounded-xl border bg-card p-3 shadow-2xl shadow-black/50 backdrop-blur-md"}
+      >
+        <p class="text-sm font-semibold text-foreground">
+          {@current_user.name || @current_user.email}
+        </p>
+        <p class="mt-0.5 text-xs text-muted-foreground">{@current_user.email}</p>
+        <div class="my-2 border-t"></div>
+        <%= if @show_dashboard do %>
+          <.link
+            navigate={~p"/"}
+            phx-click={
+              JS.hide(to: "##{@id}-popover")
+              |> JS.set_attribute({"aria-expanded", "false"}, to: "##{@id} button")
+            }
+            class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
+          >
+            <.icon name="hero-home" class="size-4" /> Home
+          </.link>
+        <% end %>
+
+        <a
+          href={~p"/getting-started"}
+          target="_blank"
+          rel="noopener"
+          class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
+        >
+          <.icon name="hero-book-open" class="size-4" /> Docs
+        </a>
+
+        <a
+          href="https://github.com/aryaminus/controlkeel"
+          target="_blank"
+          rel="noopener"
+          class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
+        >
+          <.icon name="hero-code-bracket" class="size-4" /> GitHub
+        </a>
+
+        <div class="my-2 border-t"></div>
+
+        <%!-- TODO: Settings button disabled — it was a no-op that only closed the
+             popover. Re-enable and wire to a user settings modal/dialog when functional.
+        <button
+          type="button"
+          phx-click={JS.hide(to: "##{@id}-popover")}
+          class="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground"
+        >
+          <.icon name="hero-cog-6-tooth" class="size-4" /> Settings
+        </button>
+         <hr class="my-2 border-t" />
+        --%>
+        <a
+          href={~p"/auth/logout"}
+          class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-muted-foreground transition hover:bg-muted hover:text-[var(--ck-danger)]"
+        >
+          <.icon name="hero-arrow-right-on-rectangle" class="size-4" /> Sign out
+        </a>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Shows the flash group with standard titles and content.
+
+  ## Examples
+
+      <.flash_group flash={@flash} />
+  """
+  attr :flash, :map, required: true, doc: "the map of flash messages"
+  attr :id, :string, default: "flash-group", doc: "the optional id of flash container"
+
+  def flash_group(assigns) do
+    ~H"""
+    <div id={@id} aria-live="polite">
+      <.flash kind={:info} flash={@flash} />
+      <.flash kind={:error} flash={@flash} />
+
+      <.flash
+        id="client-error"
+        kind={:error}
+        title={gettext("We can't find the internet")}
+        phx-disconnected={show(".phx-client-error #client-error") |> JS.remove_attribute("hidden")}
+        phx-connected={hide("#client-error") |> JS.set_attribute({"hidden", ""})}
+        hidden
+      >
+        {gettext("Attempting to reconnect")}
+        <.icon name="hero-arrow-path" class="ml-1 size-3 motion-safe:animate-spin" />
+      </.flash>
+
+      <.flash
+        id="server-error"
+        kind={:error}
+        title={gettext("Something went wrong!")}
+        phx-disconnected={show(".phx-server-error #server-error") |> JS.remove_attribute("hidden")}
+        phx-connected={hide("#server-error") |> JS.set_attribute({"hidden", ""})}
+        hidden
+      >
+        {gettext("Attempting to reconnect")}
+        <.icon name="hero-arrow-path" class="ml-1 size-3 motion-safe:animate-spin" />
+      </.flash>
+    </div>
+    """
+  end
 end

--- a/lib/controlkeel_web/components/organization_layouts.ex
+++ b/lib/controlkeel_web/components/organization_layouts.ex
@@ -86,13 +86,13 @@ defmodule ControlKeelWeb.OrganizationLayouts do
     [
       %{
         label: "Overview",
-        href: ~p"/organizations/#{org.slug}",
+        href: ~p"/#{org.slug}",
         tab: nil,
         icon: "hero-squares-2x2"
       },
       %{
         label: "Settings",
-        href: ~p"/organizations/#{org.slug}/settings",
+        href: ~p"/#{org.slug}/settings",
         tab: "settings",
         icon: "hero-cog-6-tooth"
       }

--- a/lib/controlkeel_web/components/organization_layouts.ex
+++ b/lib/controlkeel_web/components/organization_layouts.ex
@@ -7,6 +7,8 @@ defmodule ControlKeelWeb.OrganizationLayouts do
 
   import ControlKeelWeb.Layouts, only: [flash_group: 1, user_menu: 1]
 
+  alias ControlKeel.Accounts
+
   embed_templates "organization_layouts/*"
 
   attr :current_user, :any, default: nil
@@ -15,24 +17,137 @@ defmodule ControlKeelWeb.OrganizationLayouts do
   attr :nav_org, :map, required: true
 
   def organization_sidebar(assigns) do
+    mode = ControlKeel.Runtime.Mode.current()
+
     assigns =
       assigns
-      |> assign_new(:mode, fn -> ControlKeel.Runtime.Mode.current() end)
+      |> assign_new(:mode, fn -> mode end)
       |> assign(:nav_items, organization_nav_items(assigns.nav_org))
+      |> assign_new(:user_orgs, fn ->
+        case assigns[:current_user] do
+          %{id: user_id} when is_integer(user_id) and mode != :local ->
+            orgs =
+              Accounts.list_orgs_for_user(user_id)
+              |> Enum.map(& &1.org)
+
+            if assigns[:nav_org] && not Enum.any?(orgs, &(&1.id == assigns.nav_org.id)) do
+              [assigns.nav_org | orgs]
+            else
+              orgs
+            end
+
+          _ ->
+            if assigns[:nav_org], do: [assigns.nav_org], else: []
+        end
+      end)
 
     ~H"""
     <aside
       id="app-sidebar"
       class="hidden h-screen w-64 flex-col border-r bg-sidebar shadow-2xl shadow-black/30 lg:flex"
     >
-      <div class="flex items-center gap-3 p-3">
-        <span class="flex size-10 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-lg shadow-primary/20">
-          <.icon name="hero-bolt-solid" class="size-5" />
-        </span>
-        <div class="flex flex-col gap-0.5">
-          <span class="block text-sm font-semibold tracking-wide text-foreground">ControlKeel</span>
-          <span class="block text-xs font-medium text-muted-foreground">{@nav_org.name}</span>
-        </div>
+      <div class="p-3">
+        <%= if @current_user != nil and @mode != :local do %>
+          <div class="relative" id="sidebar-org-switcher">
+            <div class="flex w-full items-center justify-between rounded-xl p-1.5">
+              <div class="flex items-center gap-3 min-w-0">
+                <span class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-lg shadow-primary/20">
+                  <.icon name="hero-bolt-solid" class="size-5" />
+                </span>
+                <div class="flex flex-col gap-0.5 min-w-0">
+                  <span class="block text-sm font-semibold tracking-wide text-foreground">
+                    ControlKeel
+                  </span>
+                  <span class="block text-xs font-medium text-muted-foreground truncate">
+                    {@nav_org.name}
+                  </span>
+                </div>
+              </div>
+
+              <button
+                type="button"
+                id="org-switcher-button"
+                phx-click={
+                  JS.toggle(to: "#sidebar-org-switcher-popover")
+                  |> JS.toggle_attribute({"aria-expanded", "true", "false"})
+                }
+                aria-haspopup="menu"
+                aria-expanded="false"
+                aria-label="Switch organization"
+                class="group rounded-lg p-1 transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              >
+                <.icon
+                  name="hero-chevron-up-down"
+                  class="size-6 shrink-0 text-muted-foreground transition group-hover:text-foreground"
+                />
+              </button>
+            </div>
+
+            <div
+              id="sidebar-org-switcher-popover"
+              phx-click-away={
+                JS.hide(to: "#sidebar-org-switcher-popover")
+                |> JS.set_attribute({"aria-expanded", "false"}, to: "#org-switcher-button")
+              }
+              class="hidden absolute left-0 right-0 top-full mt-1.5 z-50 rounded-xl border bg-card p-1.5 shadow-2xl shadow-black/50 backdrop-blur-md"
+            >
+              <div class="px-2.5 py-1.5 text-xs font-semibold text-muted-foreground">
+                Organizations
+              </div>
+              <div class="max-h-60 overflow-y-auto space-y-0.5">
+                <%= for org <- @user_orgs do %>
+                  <% active = org.id == @nav_org.id %>
+                  <.link
+                    navigate={~p"/#{org.slug}"}
+                    phx-click={
+                      JS.hide(to: "#sidebar-org-switcher-popover")
+                      |> JS.set_attribute({"aria-expanded", "false"}, to: "#org-switcher-button")
+                    }
+                    class={[
+                      "flex items-center justify-between gap-2 rounded-lg px-2.5 py-2 text-sm transition",
+                      active && "bg-muted font-medium text-foreground",
+                      !active && "text-muted-foreground hover:bg-muted hover:text-foreground"
+                    ]}
+                  >
+                    <div class="flex items-center gap-2 min-w-0">
+                      <.icon
+                        name="hero-building-office-2"
+                        class="size-4 shrink-0 text-muted-foreground"
+                      />
+                      <span class="truncate">{org.name}</span>
+                    </div>
+                    <.icon :if={active} name="hero-check" class="size-4 shrink-0 text-primary" />
+                  </.link>
+                <% end %>
+              </div>
+
+              <div class="my-1 border-t"></div>
+
+              <.link
+                navigate={~p"/organizations"}
+                phx-click={
+                  JS.hide(to: "#sidebar-org-switcher-popover")
+                  |> JS.set_attribute({"aria-expanded", "false"}, to: "#org-switcher-button")
+                }
+                class="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+              >
+                <.icon name="hero-squares-2x2" class="size-3.5" /> All organizations
+              </.link>
+            </div>
+          </div>
+        <% else %>
+          <div class="flex items-center gap-3 p-1.5">
+            <span class="flex size-10 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-lg shadow-primary/20">
+              <.icon name="hero-bolt-solid" class="size-5" />
+            </span>
+            <div class="flex flex-col gap-0.5">
+              <span class="block text-sm font-semibold tracking-wide text-foreground">
+                ControlKeel
+              </span>
+              <span class="block text-xs font-medium text-muted-foreground">{@nav_org.name}</span>
+            </div>
+          </div>
+        <% end %>
       </div>
 
       <nav id="sidebar-org-nav" class="mt-4 flex flex-1 flex-col gap-1 px-3 text-sm">
@@ -48,7 +163,10 @@ defmodule ControlKeelWeb.OrganizationLayouts do
         <% end %>
       </nav>
 
-      <div class="flex flex-col justify-end border-t mt-2 px-3 py-2">
+      <div
+        :if={@mode == :local or @current_user == nil}
+        class="flex flex-col justify-end border-t mt-2 px-3 py-2"
+      >
         <a
           href={~p"/getting-started"}
           target="_blank"
@@ -65,15 +183,15 @@ defmodule ControlKeelWeb.OrganizationLayouts do
         >
           <.icon name="hero-code-bracket" class="size-4" /> GitHub
         </a>
-
-        <.user_menu
-          :if={@current_user != nil and @mode != :local}
-          id="sidebar-user-menu"
-          current_user={@current_user}
-          class="mt-3 border-t pt-3"
-          popover_class="bottom-20 right-4"
-        />
       </div>
+
+      <.user_menu
+        :if={@current_user != nil and @mode != :local}
+        id="sidebar-user-menu"
+        current_user={@current_user}
+        class="border-t p-3"
+        popover_class="bottom-20 right-4"
+      />
     </aside>
     """
   end

--- a/lib/controlkeel_web/components/organization_layouts.ex
+++ b/lib/controlkeel_web/components/organization_layouts.ex
@@ -256,8 +256,6 @@ defmodule ControlKeelWeb.OrganizationLayouts do
     """
   end
 
-  def breadcums_header(assigns), do: breadcrumbs_header(assigns)
-
   @label_map %{
     "dashboard" => "Dashboard",
     "sessions" => "Sessions",

--- a/lib/controlkeel_web/components/organization_layouts.ex
+++ b/lib/controlkeel_web/components/organization_layouts.ex
@@ -5,7 +5,7 @@ defmodule ControlKeelWeb.OrganizationLayouts do
 
   use ControlKeelWeb, :html
 
-  import ControlKeelWeb.Layouts, only: [dashboard_header: 1, flash_group: 1, user_menu: 1]
+  import ControlKeelWeb.Layouts, only: [flash_group: 1, user_menu: 1]
 
   embed_templates "organization_layouts/*"
 
@@ -25,21 +25,17 @@ defmodule ControlKeelWeb.OrganizationLayouts do
       id="app-sidebar"
       class="hidden h-screen w-64 flex-col border-r bg-sidebar shadow-2xl shadow-black/30 lg:flex"
     >
-      <.link navigate={~p"/dashboard"} class="flex items-center gap-3 px-3 pt-3 pb-2">
+      <div class="flex items-center gap-3 p-3">
         <span class="flex size-10 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-lg shadow-primary/20">
           <.icon name="hero-bolt-solid" class="size-5" />
         </span>
-        <span class="block text-sm font-semibold tracking-wide text-foreground">ControlKeel</span>
-      </.link>
-
-      <nav id="sidebar-org-nav" class="mt-2 flex flex-1 flex-col gap-1 px-3 text-sm">
-        <div class="flex items-center gap-3 px-3 py-4 text-foreground">
-          <.icon name="hero-building-office-2" class={organization_nav_icon_class(true)} />
-          <span class="min-w-0 truncate text-sm text-foreground">
-            {@nav_org.name}
-          </span>
+        <div class="flex flex-col gap-0.5">
+          <span class="block text-sm font-semibold tracking-wide text-foreground">ControlKeel</span>
+          <span class="block text-xs font-medium text-muted-foreground">{@nav_org.name}</span>
         </div>
+      </div>
 
+      <nav id="sidebar-org-nav" class="mt-4 flex flex-1 flex-col gap-1 px-3 text-sm">
         <%= for item <- @nav_items do %>
           <% active = organization_nav_active?(@current_path, @current_query, item) %>
           <.link
@@ -80,6 +76,152 @@ defmodule ControlKeelWeb.OrganizationLayouts do
       </div>
     </aside>
     """
+  end
+
+  attr :current_path, :string, default: nil
+  attr :page_action, :any, default: nil
+
+  attr :breadcrumbs, :list,
+    default: nil,
+    doc: """
+    Explicit crumbs (`%{label: ..., to: ...}`, `to: nil` renders plain text).
+    Overrides the path-derived trail — use when path segments are opaque ids
+    or have no route.
+    """
+
+  def breadcrumbs_header(assigns) do
+    actions =
+      cond do
+        is_nil(assigns.page_action) -> []
+        is_list(assigns.page_action) -> assigns.page_action
+        true -> [assigns.page_action]
+      end
+
+    assigns =
+      assigns
+      |> assign(:actions, actions)
+      |> assign(:trail, breadcrumb_items(assigns))
+
+    ~H"""
+    <div class="flex w-full items-center justify-between border-b p-4">
+      <nav :if={@current_path && @current_path != "/"} aria-label="Breadcrumb">
+        <ol class="flex items-center gap-1.5 text-sm">
+          <%= for {{label, path}, idx} <- Enum.with_index(@trail) do %>
+            <li class="flex items-center gap-1.5">
+              <.icon :if={idx > 0} name="hero-chevron-right" class="size-3 text-muted-foreground" />
+              <%= if path do %>
+                <.link
+                  navigate={path}
+                  class="text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-sm"
+                >
+                  {label}
+                </.link>
+              <% else %>
+                <span class="font-medium text-muted-foreground">{label}</span>
+              <% end %>
+            </li>
+          <% end %>
+        </ol>
+      </nav>
+      <div :if={@actions != []} class="flex items-center gap-2" id="dashboard-page-action">
+        <%= for action <- @actions do %>
+          <a
+            :if={action[:to]}
+            href={action.to}
+            class="inline-flex items-center gap-2 rounded-3xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 cursor-pointer"
+          >
+            <.icon :if={action[:icon]} name={action.icon} class="size-4" /> {action.label}
+          </a>
+
+          <button
+            :if={action[:form]}
+            type="submit"
+            form={action.form}
+            class="inline-flex items-center gap-2 rounded-3xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 cursor-pointer"
+          >
+            <.icon :if={action[:icon]} name={action.icon} class="size-4" /> {action.label}
+          </button>
+
+          <button
+            :if={action[:event]}
+            type="button"
+            phx-click={action.event}
+            class="inline-flex items-center gap-2 rounded-3xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 cursor-pointer"
+          >
+            <.icon :if={action[:icon]} name={action.icon} class="size-4" /> {action.label}
+          </button>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  def breadcums_header(assigns), do: breadcrumbs_header(assigns)
+
+  @label_map %{
+    "dashboard" => "Dashboard",
+    "sessions" => "Sessions",
+    "findings" => "Findings",
+    "benchmarks" => "Benchmarks",
+    "proofs" => "Proofs",
+    "reviews" => "Reviews",
+    "organizations" => "Organizations",
+    "workspaces" => "Workspaces",
+    "policies" => "Policy Studio",
+    "skills" => "Skills",
+    "cloud" => "Cloud",
+    "observability" => "Observability",
+    "repos" => "Repos",
+    "service-accounts" => "Service Accounts",
+    "webhooks" => "Webhooks",
+    "tool-policy" => "Tool Policy",
+    "start" => "New Session",
+    "runs" => "Runs",
+    "telemetry" => "Telemetry",
+    "projects" => "Projects",
+    "settings" => "Settings"
+  }
+
+  defp breadcrumb_items(%{breadcrumbs: [_ | _] = crumbs}) do
+    Enum.map(crumbs, fn
+      %{label: label, to: to} -> {label, to}
+      %{label: label} -> {label, nil}
+    end)
+  end
+
+  defp breadcrumb_items(assigns) do
+    Enum.map(breadcrumb_trail(assigns.current_path), fn
+      {label, _path, true} -> {label, nil}
+      {label, path, false} -> {label, path}
+    end)
+  end
+
+  defp breadcrumb_trail(nil), do: []
+
+  defp breadcrumb_trail(current_path) do
+    segments = String.split(current_path, "/", trim: true)
+
+    segments
+    |> Enum.with_index()
+    |> Enum.map(fn {segment, idx} ->
+      path = "/" <> Enum.join(Enum.take(segments, idx + 1), "/")
+      label = Map.get(@label_map, segment, segment_name(segment))
+      is_final = idx == length(segments) - 1
+      {label, path, is_final}
+    end)
+  end
+
+  defp segment_name(segment) do
+    segment
+    |> String.replace("-", " ")
+    |> title_case()
+  end
+
+  defp title_case(string) do
+    string
+    |> String.split(" ")
+    |> Enum.map(&String.capitalize/1)
+    |> Enum.join(" ")
   end
 
   defp organization_nav_items(org) do

--- a/lib/controlkeel_web/components/organization_layouts/organization.html.heex
+++ b/lib/controlkeel_web/components/organization_layouts/organization.html.heex
@@ -7,7 +7,7 @@
   />
 
   <div class="flex flex-1 flex-col overflow-hidden">
-    <.dashboard_header
+    <.breadcrumbs_header
       current_path={@current_path}
       page_action={@page_action}
       breadcrumbs={@breadcrumbs}

--- a/lib/controlkeel_web/components/organization_layouts/organization.html.heex
+++ b/lib/controlkeel_web/components/organization_layouts/organization.html.heex
@@ -1,0 +1,24 @@
+<div class="h-screen flex overflow-hidden">
+  <.organization_sidebar
+    current_user={@current_user}
+    current_path={@current_path}
+    current_query={@current_query}
+    nav_org={@nav_org}
+  />
+
+  <div class="flex flex-1 flex-col overflow-hidden">
+    <.dashboard_header
+      current_path={@current_path}
+      page_action={@page_action}
+      breadcrumbs={@breadcrumbs}
+    />
+
+    <main class="flex-1 overflow-y-auto">
+      <div class="px-4 pt-6 pb-12 sm:px-8 lg:px-8 container mx-auto">
+        {@inner_content}
+      </div>
+    </main>
+  </div>
+</div>
+
+<.flash_group flash={@flash} />

--- a/lib/controlkeel_web/controllers/oauth_login_controller.ex
+++ b/lib/controlkeel_web/controllers/oauth_login_controller.ex
@@ -64,7 +64,7 @@ defmodule ControlKeelWeb.OAuthLoginController do
           if invitation_token do
             ~p"/invitations/#{invitation_token}"
           else
-            ~p"/dashboard"
+            ~p"/"
           end
       )
     else

--- a/lib/controlkeel_web/controllers/page_controller.ex
+++ b/lib/controlkeel_web/controllers/page_controller.ex
@@ -1,6 +1,10 @@
 defmodule ControlKeelWeb.PageController do
   use ControlKeelWeb, :controller
 
+  alias ControlKeel.Accounts
+  alias ControlKeel.Bootstrap.LocalDefaults
+  alias ControlKeel.Mission
+  alias ControlKeel.Runtime.Mode
   alias ControlKeel.Skills
 
   # Public marketing pages render inside the `:public` framework layout
@@ -9,7 +13,52 @@ defmodule ControlKeelWeb.PageController do
   plug :put_layout, html: {ControlKeelWeb.Layouts, :public}
 
   def home(conn, _params) do
-    render(conn, :home)
+    cond do
+      # Local mode has no marketing surface — `/` goes straight to the
+      # default org. ensure/0 is idempotent (find-or-create), so a fresh
+      # local install provisions the org on first visit.
+      Mode.current() == :local ->
+        _ = LocalDefaults.ensure()
+        redirect(conn, to: ~p"/organizations/#{LocalDefaults.default_org_slug()}")
+
+      # Signed-in cloud/self_hosted users get their org → workspace →
+      # session selector tree instead of the marketing landing.
+      user = conn.assigns[:current_user] ->
+        render(conn, :selector_tree, tree: selector_tree(user))
+
+      true ->
+        render(conn, :home)
+    end
+  end
+
+  defp selector_tree(user) do
+    orgs =
+      user.id
+      |> Accounts.list_orgs_for_user()
+      |> Enum.map(& &1.org)
+      |> Enum.sort_by(& &1.name)
+
+    workspaces =
+      orgs
+      |> Enum.map(& &1.id)
+      |> Mission.list_workspaces_for_orgs()
+
+    sessions_by_workspace =
+      workspaces
+      |> Enum.map(& &1.id)
+      |> Mission.list_sessions_for_workspaces()
+      |> Enum.group_by(& &1.workspace_id)
+
+    workspaces_by_org = Enum.group_by(workspaces, & &1.org_id)
+
+    Enum.map(orgs, fn org ->
+      workspaces =
+        Enum.map(workspaces_by_org[org.id] || [], fn workspace ->
+          %{workspace: workspace, sessions: sessions_by_workspace[workspace.id] || []}
+        end)
+
+      %{org: org, workspaces: workspaces}
+    end)
   end
 
   def getting_started(conn, _params) do

--- a/lib/controlkeel_web/controllers/page_controller.ex
+++ b/lib/controlkeel_web/controllers/page_controller.ex
@@ -83,4 +83,18 @@ defmodule ControlKeelWeb.PageController do
   def developers(conn, _params) do
     render(conn, :developers)
   end
+
+  # Legacy /organizations/:slug URLs (removed when org routes were simplified
+  # to /:slug). Single action serves both routes; the /settings suffix is
+  # detected from the request path. `slug` is a single router segment (no
+  # slashes), and the target is always same-origin via the "/#{slug}" prefix,
+  # so this cannot become an open redirect.
+  def org_legacy_redirect(conn, %{"slug" => slug}) do
+    target =
+      if String.ends_with?(conn.request_path, "/settings"),
+        do: "/#{slug}/settings",
+        else: "/#{slug}"
+
+    redirect(conn, to: target)
+  end
 end

--- a/lib/controlkeel_web/controllers/page_controller.ex
+++ b/lib/controlkeel_web/controllers/page_controller.ex
@@ -19,7 +19,7 @@ defmodule ControlKeelWeb.PageController do
       # local install provisions the org on first visit.
       Mode.current() == :local ->
         _ = LocalDefaults.ensure()
-        redirect(conn, to: ~p"/organizations/#{LocalDefaults.default_org_slug()}")
+        redirect(conn, to: ~p"/#{LocalDefaults.default_org_slug()}")
 
       # Signed-in cloud/self_hosted users get their org → workspace →
       # session selector tree instead of the marketing landing.

--- a/lib/controlkeel_web/controllers/page_html/selector_tree.html.heex
+++ b/lib/controlkeel_web/controllers/page_html/selector_tree.html.heex
@@ -1,0 +1,152 @@
+<section class="mx-auto w-full max-w-5xl px-4 py-12 sm:px-6 lg:px-16 space-y-4">
+  <.page_title title="Select organization workspace and sessions" />
+
+  <%= if @tree == [] do %>
+    <section class="rounded-2xl border bg-card p-12 text-center shadow-card">
+      <.icon name="hero-building-office-2" class="mx-auto size-10 text-muted-foreground" />
+      <p class="mt-4 text-base font-medium text-foreground">No organizations yet.</p>
+      <p class="mt-1 text-sm text-muted-foreground">
+        Create an organization to group workspaces, members, and budgets.
+      </p>
+      <div class="mt-6 flex items-center justify-center gap-3">
+        <.link
+          navigate={~p"/organizations"}
+          class="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground shadow-lg shadow-primary/20 transition hover:-translate-y-0.5 hover:bg-primary/90"
+        >
+          <.icon name="hero-plus" class="size-4" /> Create organization
+        </.link>
+        <.link
+          navigate={~p"/sessions/start"}
+          class="inline-flex items-center gap-2 rounded-full border bg-muted px-5 py-2 text-sm font-semibold transition hover:border-primary/40 hover:bg-accent"
+        >
+          <.icon name="hero-rocket-launch" class="size-4" /> Start a session
+        </.link>
+      </div>
+    </section>
+  <% else %>
+    <div class="flex flex-col gap-4">
+      <%= for node <- @tree do %>
+        <% session_count = Enum.sum(Enum.map(node.workspaces, &length(&1.sessions))) %>
+        <details
+          open
+          id={"home-org-#{node.org.id}"}
+          class="group rounded-2xl border bg-card shadow-card"
+        >
+          <summary class="flex cursor-pointer list-none items-center gap-3 p-5 [&::-webkit-details-marker]:hidden">
+            <span class="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <.icon name="hero-building-office-2" class="size-4" />
+            </span>
+            <span class="min-w-0 flex-1">
+              <span class="block truncate text-base font-semibold text-foreground">
+                <.link
+                  navigate={~p"/organizations/#{node.org.slug}"}
+                  class="rounded-sm transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
+                  {node.org.name}
+                </.link>
+              </span>
+            </span>
+            <span class="hidden shrink-0 text-xs text-muted-foreground sm:block">
+              {length(node.workspaces)}
+              {(length(node.workspaces) == 1 && "workspace") || "workspaces"} · {session_count} {(session_count ==
+                                                                                                    1 &&
+                                                                                                    "session") ||
+                "sessions"}
+            </span>
+            <span class={[
+              "shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1",
+              node.org.status == "active" && "bg-success/10 text-success ring-success/20",
+              node.org.status != "active" && "bg-muted text-muted-foreground ring-border"
+            ]}>
+              {node.org.status}
+            </span>
+            <.icon
+              name="hero-chevron-right"
+              class="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
+            />
+          </summary>
+
+          <div class="border-t px-5 py-4">
+            <%= if node.workspaces == [] do %>
+              <p class="px-1 text-sm text-muted-foreground">No workspaces yet.</p>
+            <% else %>
+              <div class="ml-2 flex flex-col gap-3 border-l border-border pl-4 sm:ml-4 sm:pl-6">
+                <%= for ws_node <- node.workspaces do %>
+                  <details
+                    id={"home-workspace-#{ws_node.workspace.id}"}
+                    class="group/ws rounded-xl border bg-background/40"
+                  >
+                    <summary class="flex cursor-pointer list-none items-center gap-3 p-4 [&::-webkit-details-marker]:hidden">
+                      <span class="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                        <.icon name="hero-squares-2x2" class="size-4" />
+                      </span>
+                      <span class="min-w-0 flex-1">
+                        <span class="block truncate text-sm font-semibold text-foreground">
+                          <.link
+                            navigate={
+                              ~p"/organizations/#{node.org.slug}/workspaces/#{ws_node.workspace.id}"
+                            }
+                            class="rounded-sm transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                          >
+                            {ws_node.workspace.name}
+                          </.link>
+                        </span>
+                      </span>
+                      <span class="hidden shrink-0 text-xs text-muted-foreground sm:block">
+                        {length(ws_node.sessions)}
+                        {(length(ws_node.sessions) == 1 && "session") || "sessions"}
+                      </span>
+                      <span class={[
+                        "shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1",
+                        ws_node.workspace.status == "active" &&
+                          "bg-success/10 text-success ring-success/20",
+                        ws_node.workspace.status != "active" &&
+                          "bg-muted text-muted-foreground ring-border"
+                      ]}>
+                        {ws_node.workspace.status}
+                      </span>
+                      <.icon
+                        name="hero-chevron-right"
+                        class="size-3.5 shrink-0 text-muted-foreground transition-transform group-open/ws:rotate-90"
+                      />
+                    </summary>
+
+                    <div class="border-t px-3 py-2">
+                      <%= if ws_node.sessions == [] do %>
+                        <p class="px-2 py-2 text-sm text-muted-foreground">No sessions yet.</p>
+                      <% else %>
+                        <%= for session <- ws_node.sessions do %>
+                          <.link
+                            navigate={~p"/sessions/#{session.id}"}
+                            class="group/session flex items-center gap-2.5 rounded-lg px-2 py-2 transition hover:bg-muted"
+                          >
+                            <.icon
+                              name="hero-rocket-launch"
+                              class="size-3.5 shrink-0 text-muted-foreground/70 group-hover/session:text-primary"
+                            />
+                            <span class="min-w-0 flex-1 truncate text-sm text-foreground/90">
+                              {session.title}
+                            </span>
+                            <span class={[
+                              "shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold capitalize ring-1",
+                              session.status == "active" &&
+                                "bg-success/10 text-success ring-success/20",
+                              session.status != "active" &&
+                                "bg-muted text-muted-foreground ring-border"
+                            ]}>
+                              {session.status}
+                            </span>
+                          </.link>
+                        <% end %>
+                      <% end %>
+                    </div>
+                  </details>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </details>
+      <% end %>
+    </div>
+  <% end %>
+</section>

--- a/lib/controlkeel_web/controllers/page_html/selector_tree.html.heex
+++ b/lib/controlkeel_web/controllers/page_html/selector_tree.html.heex
@@ -39,7 +39,7 @@
             <span class="min-w-0 flex-1">
               <span class="block truncate text-base font-semibold text-foreground">
                 <.link
-                  navigate={~p"/organizations/#{node.org.slug}"}
+                  navigate={~p"/#{node.org.slug}"}
                   class="rounded-sm transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 >
                   {node.org.name}

--- a/lib/controlkeel_web/controllers/page_html/selector_tree.html.heex
+++ b/lib/controlkeel_web/controllers/page_html/selector_tree.html.heex
@@ -27,12 +27,11 @@
     <div class="flex flex-col gap-4">
       <%= for node <- @tree do %>
         <% session_count = Enum.sum(Enum.map(node.workspaces, &length(&1.sessions))) %>
-        <details
-          open
+        <div
           id={"home-org-#{node.org.id}"}
-          class="group rounded-2xl border bg-card shadow-card"
+          class="rounded-2xl border bg-card shadow-card"
         >
-          <summary class="flex cursor-pointer list-none items-center gap-3 p-5 [&::-webkit-details-marker]:hidden">
+          <div class="flex items-center gap-3 p-5">
             <span class="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
               <.icon name="hero-building-office-2" class="size-4" />
             </span>
@@ -47,10 +46,8 @@
               </span>
             </span>
             <span class="hidden shrink-0 text-xs text-muted-foreground sm:block">
-              {length(node.workspaces)}
-              {(length(node.workspaces) == 1 && "workspace") || "workspaces"} · {session_count} {(session_count ==
-                                                                                                    1 &&
-                                                                                                    "session") ||
+              {length(node.workspaces)} {(length(node.workspaces) == 1 && "workspace") ||
+                "workspaces"} · {session_count} {(session_count == 1 && "session") ||
                 "sessions"}
             </span>
             <span class={[
@@ -60,23 +57,38 @@
             ]}>
               {node.org.status}
             </span>
-            <.icon
-              name="hero-chevron-right"
-              class="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
-            />
-          </summary>
+            <button
+              type="button"
+              aria-expanded="true"
+              aria-controls={"home-org-body-#{node.org.id}"}
+              aria-label={"Toggle #{node.org.name} workspaces"}
+              phx-click={
+                JS.toggle(to: "#home-org-body-#{node.org.id}")
+                |> JS.toggle_class("rotate-90", to: "#home-org-chevron-#{node.org.id}")
+                |> JS.toggle_attribute({"aria-expanded", "true", "false"})
+              }
+              class="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              <span
+                id={"home-org-chevron-#{node.org.id}"}
+                class="flex size-4 shrink-0 rotate-90 text-muted-foreground transition-transform"
+              >
+                <.icon name="hero-chevron-right" class="size-4" />
+              </span>
+            </button>
+          </div>
 
-          <div class="border-t px-5 py-4">
+          <div id={"home-org-body-#{node.org.id}"} class="border-t px-5 py-4">
             <%= if node.workspaces == [] do %>
               <p class="px-1 text-sm text-muted-foreground">No workspaces yet.</p>
             <% else %>
               <div class="ml-2 flex flex-col gap-3 border-l border-border pl-4 sm:ml-4 sm:pl-6">
                 <%= for ws_node <- node.workspaces do %>
-                  <details
+                  <div
                     id={"home-workspace-#{ws_node.workspace.id}"}
-                    class="group/ws rounded-xl border bg-background/40"
+                    class="rounded-xl border bg-background/40"
                   >
-                    <summary class="flex cursor-pointer list-none items-center gap-3 p-4 [&::-webkit-details-marker]:hidden">
+                    <div class="flex items-center gap-3 p-4">
                       <span class="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
                         <.icon name="hero-squares-2x2" class="size-4" />
                       </span>
@@ -105,13 +117,34 @@
                       ]}>
                         {ws_node.workspace.status}
                       </span>
-                      <.icon
-                        name="hero-chevron-right"
-                        class="size-3.5 shrink-0 text-muted-foreground transition-transform group-open/ws:rotate-90"
-                      />
-                    </summary>
+                      <button
+                        type="button"
+                        aria-expanded="false"
+                        aria-controls={"home-workspace-body-#{ws_node.workspace.id}"}
+                        aria-label={"Toggle #{ws_node.workspace.name} sessions"}
+                        phx-click={
+                          JS.toggle(to: "#home-workspace-body-#{ws_node.workspace.id}")
+                          |> JS.toggle_class(
+                            "rotate-90",
+                            to: "#home-workspace-chevron-#{ws_node.workspace.id}"
+                          )
+                          |> JS.toggle_attribute({"aria-expanded", "true", "false"})
+                        }
+                        class="flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                      >
+                        <span
+                          id={"home-workspace-chevron-#{ws_node.workspace.id}"}
+                          class="flex size-3.5 shrink-0 text-muted-foreground transition-transform"
+                        >
+                          <.icon name="hero-chevron-right" class="size-3.5" />
+                        </span>
+                      </button>
+                    </div>
 
-                    <div class="border-t px-3 py-2">
+                    <div
+                      id={"home-workspace-body-#{ws_node.workspace.id}"}
+                      class="hidden border-t px-3 py-2"
+                    >
                       <%= if ws_node.sessions == [] do %>
                         <p class="px-2 py-2 text-sm text-muted-foreground">No sessions yet.</p>
                       <% else %>
@@ -140,12 +173,12 @@
                         <% end %>
                       <% end %>
                     </div>
-                  </details>
+                  </div>
                 <% end %>
               </div>
             <% end %>
           </div>
-        </details>
+        </div>
       <% end %>
     </div>
   <% end %>

--- a/lib/controlkeel_web/live/invitation_live.ex
+++ b/lib/controlkeel_web/live/invitation_live.ex
@@ -55,7 +55,7 @@ defmodule ControlKeelWeb.InvitationLive do
          socket.assigns.state == :ready do
       case Accounts.accept_invitation(socket.assigns.token, socket.assigns.current_user.id) do
         {:ok, _membership} ->
-          {:noreply, redirect(socket, to: ~p"/organizations/#{socket.assigns.org.slug}")}
+          {:noreply, redirect(socket, to: ~p"/#{socket.assigns.org.slug}")}
 
         {:error, :invalid_token} ->
           {:noreply, assign(socket, :state, :invalid)}

--- a/lib/controlkeel_web/live/onboarding_live.ex
+++ b/lib/controlkeel_web/live/onboarding_live.ex
@@ -870,7 +870,7 @@ defmodule ControlKeelWeb.OnboardingLive do
         %{
           text:
             "This organization has no workspaces yet. Create a workspace before starting a session.",
-          link: ~p"/organizations/#{selected_org_slug(assigns)}",
+          link: ~p"/#{selected_org_slug(assigns)}",
           link_text: "Manage workspaces"
         }
 

--- a/lib/controlkeel_web/live/organization_detail_live.ex
+++ b/lib/controlkeel_web/live/organization_detail_live.ex
@@ -1,6 +1,6 @@
 defmodule ControlKeelWeb.OrganizationDetailLive do
   @moduledoc """
-  Member management for an org at `/organizations/:slug`.
+  Member management for an org at `/:org_slug`.
 
   Admin+owner only. Allows:
     - List active and pending memberships (preloaded with the user)
@@ -29,7 +29,7 @@ defmodule ControlKeelWeb.OrganizationDetailLive do
   @valid_roles ~w(owner admin member viewer)
 
   @impl true
-  def mount(%{"slug" => slug}, _session, socket) do
+  def mount(%{"org_slug" => slug}, _session, socket) do
     case Accounts.get_org_by_slug(slug) do
       nil ->
         {:ok, redirect_with_flash(socket, :error, "Organization not found.", ~p"/organizations")}
@@ -446,7 +446,7 @@ defmodule ControlKeelWeb.OrganizationDetailLive do
 
       <div class="flex border-b border-border">
         <.link
-          patch={~p"/organizations/#{@org.slug}"}
+          patch={~p"/#{@org.slug}"}
           class={tab_class(@active_tab == :workspaces)}
         >
           Workspaces
@@ -992,9 +992,6 @@ defmodule ControlKeelWeb.OrganizationDetailLive do
       {"Finance", "finance"}
     ]
   end
-
-  defp org_tab_path(slug, :workspaces), do: ~p"/organizations/#{slug}"
-  defp org_tab_path(slug, tab), do: ~p"/organizations/#{slug}?tab=#{tab}"
 
   defp normalize_tab(tab) when tab in ["members"], do: :members
   defp normalize_tab(_tab), do: :workspaces

--- a/lib/controlkeel_web/live/organization_detail_live.ex
+++ b/lib/controlkeel_web/live/organization_detail_live.ex
@@ -80,6 +80,7 @@ defmodule ControlKeelWeb.OrganizationDetailLive do
      socket
      |> assign(:page_title, "Organization Detail — #{org.name}")
      |> assign(:org, org)
+     |> assign(:nav_org, org)
      |> assign(:local_mode, local_mode)
      |> assign(:budget_cents, budget_cents)
      |> assign(:member_count, member_count)
@@ -109,29 +110,17 @@ defmodule ControlKeelWeb.OrganizationDetailLive do
      |> assign(:show_invite_modal, false)
      |> assign(:show_revoke_modal, false)
      |> assign(:revoke_target, nil)
-     |> assign(:is_owner, !!(local_mode || (membership && membership.role == "owner")))
-     |> assign(:show_settings_modal, false)
-     |> assign(:settings_form, settings_form(org, budget_cents))
-     |> assign(:settings_error, nil)
      |> assign(:page_action, page_actions(local_mode, can_manage))
      |> assign(:current_user, socket.assigns[:current_user])}
   end
 
   @impl true
   def handle_params(params, _uri, socket) do
-    {:noreply, assign(socket, :active_tab, normalize_tab(params["tab"]))}
-  end
+    socket =
+      socket
+      |> assign(:active_tab, normalize_tab(params["tab"]))
 
-  @impl true
-  def handle_event("open_settings", _params, socket) do
-    {:noreply, assign(socket, :show_settings_modal, true)}
-  end
-
-  def handle_event("close_settings", _params, socket) do
-    {:noreply,
-     socket
-     |> assign(:show_settings_modal, false)
-     |> assign(:settings_error, nil)}
+    {:noreply, socket}
   end
 
   def handle_event("new_workspace", _params, socket) do
@@ -183,51 +172,6 @@ defmodule ControlKeelWeb.OrganizationDetailLive do
         {:error, reason} ->
           {:noreply, assign(socket, :new_workspace_error, inspect(reason))}
       end
-    end
-  end
-
-  def handle_event("save_settings", %{"settings" => params}, socket) do
-    org = socket.assigns.org
-    is_owner = socket.assigns.is_owner
-
-    # The Settings button is only rendered for can_manage/local_mode, but
-    # re-check server-side. Members/viewers can mount this LiveView, so without
-    # this guard they could forge a `save_settings` event and rename the org
-    # (the name field has no other server-side authz; Accounts.update_org/2
-    # does not check the actor). Status/budget stay owner-locked via is_owner.
-    if socket.assigns.can_manage || socket.assigns.local_mode do
-      org_attrs =
-        %{name: params["name"]}
-        |> maybe_add_owner_field("status", params["status"], is_owner)
-
-      with {:ok, org} <- Accounts.update_org(org, org_attrs),
-           {:ok, org} <- maybe_set_budget(org, params["budget_cents"], is_owner) do
-        budget_cents = Accounts.org_budget_cents(org) || 0
-
-        {:noreply,
-         socket
-         |> assign(:org, org)
-         |> assign(:budget_cents, budget_cents)
-         |> assign(:settings_form, settings_form(org, budget_cents))
-         |> assign(:settings_error, nil)
-         |> assign(:show_settings_modal, false)
-         |> put_flash(:info, "Settings saved.")}
-      else
-        {:error, %Ecto.Changeset{} = cs} ->
-          msg =
-            cs.errors
-            |> Enum.map_join(", ", fn {f, {m, _}} -> "#{f}: #{m}" end)
-
-          {:noreply, assign(socket, :settings_error, msg)}
-
-        {:error, reason} ->
-          {:noreply, assign(socket, :settings_error, inspect(reason))}
-      end
-    else
-      {:noreply,
-       socket
-       |> assign(:show_settings_modal, false)
-       |> put_flash(:error, "You don't have permission to change organization settings.")}
     end
   end
 
@@ -704,14 +648,6 @@ defmodule ControlKeelWeb.OrganizationDetailLive do
         role_options={invite_role_options(@current_role)}
       />
 
-      <.settings_modal
-        :if={@show_settings_modal}
-        form={@settings_form}
-        org={@org}
-        is_owner={@is_owner}
-        error={@settings_error}
-      />
-
       <.new_workspace_modal
         :if={@show_new_workspace}
         local_mode={@local_mode}
@@ -881,105 +817,6 @@ defmodule ControlKeelWeb.OrganizationDetailLive do
     """
   end
 
-  attr :form, :map, required: true
-  attr :org, :map, required: true
-  attr :is_owner, :boolean, default: false
-  attr :error, :string, default: nil
-
-  defp settings_modal(assigns) do
-    ~H"""
-    <div
-      id="org-settings-modal"
-      class="relative z-50"
-      phx-mounted={Phoenix.LiveView.JS.show(to: "#org-settings-modal")}
-      phx-remove={Phoenix.LiveView.JS.hide(to: "#org-settings-modal")}
-    >
-      <div
-        class="fixed inset-0 bg-overlay/70 backdrop-blur-sm transition-opacity"
-        phx-click="close_settings"
-        aria-label="Close modal"
-      />
-
-      <div class="fixed inset-0 flex items-center justify-center p-4">
-        <div class="w-full max-w-md rounded-2xl border bg-card/95 p-6 shadow-card">
-          <div class="mb-5 flex items-center justify-between">
-            <h2 class="text-lg font-semibold text-foreground">Settings</h2>
-            <button
-              type="button"
-              phx-click="close_settings"
-              class="rounded-md text-muted-foreground transition hover:text-foreground"
-              aria-label="Close"
-            >
-              <.icon name="hero-x-mark" class="size-5" />
-            </button>
-          </div>
-
-          <.form for={@form} phx-submit="save_settings" id="org-settings-form" class="space-y-4">
-            <.input
-              field={@form[:name]}
-              type="text"
-              label="Organization name"
-              required
-              class="w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-            />
-
-            <div>
-              <.input
-                field={@form[:status]}
-                type="select"
-                label="Status"
-                options={[{"active", "active"}, {"disabled", "disabled"}]}
-                disabled={!@is_owner}
-                class="w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-              />
-              <%= unless @is_owner do %>
-                <p class="mt-1 text-xs text-muted-foreground">Only owners can change status.</p>
-              <% end %>
-            </div>
-
-            <div>
-              <.input
-                field={@form[:budget_cents]}
-                type="number"
-                label="Monthly budget (cents)"
-                disabled={!@is_owner}
-                class="w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-              />
-              <%= unless @is_owner do %>
-                <p class="mt-1 text-xs text-muted-foreground">Only owners can change budget.</p>
-              <% end %>
-            </div>
-
-            <p class="text-xs text-muted-foreground">
-              Slug <code class="text-muted-foreground">{@org.slug}</code> cannot be changed.
-            </p>
-
-            <%= if @error do %>
-              <p class="rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive">{@error}</p>
-            <% end %>
-
-            <div class="flex items-center justify-end gap-3 pt-4">
-              <button
-                type="button"
-                phx-click="close_settings"
-                class="rounded-full px-4 py-2 text-sm font-medium text-muted-foreground transition hover:text-foreground"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                class="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground shadow-lg shadow-primary/20 transition hover:-translate-y-0.5 hover:bg-primary"
-              >
-                Save
-              </button>
-            </div>
-          </.form>
-        </div>
-      </div>
-    </div>
-    """
-  end
-
   attr :local_mode, :boolean, default: false
   attr :form, :map, required: true
   attr :error, :string, default: nil
@@ -1097,10 +934,7 @@ defmodule ControlKeelWeb.OrganizationDetailLive do
   # ── Private ─────────────────────────────────────────────────────────
 
   defp page_actions(local_mode, can_manage) do
-    actions =
-      []
-      |> maybe_add_action(settings_page_action(local_mode, can_manage))
-      |> maybe_add_action(invite_page_action(local_mode, can_manage))
+    actions = maybe_add_action([], invite_page_action(local_mode, can_manage))
 
     if actions == [], do: nil, else: actions
   end
@@ -1108,52 +942,11 @@ defmodule ControlKeelWeb.OrganizationDetailLive do
   defp maybe_add_action(actions, nil), do: actions
   defp maybe_add_action(actions, action), do: actions ++ [action]
 
-  defp settings_page_action(local_mode, can_manage) do
-    if local_mode || can_manage do
-      %{label: "Settings", event: "open_settings", icon: "hero-cog-6-tooth"}
-    else
-      nil
-    end
-  end
-
   defp invite_page_action(local_mode, can_manage) do
     if local_mode || not can_manage do
       nil
     else
       %{label: "Invite member", event: "open_invite", icon: "hero-plus"}
-    end
-  end
-
-  defp settings_form(org, budget_cents) do
-    to_form(
-      %{
-        "name" => org.name,
-        "status" => org.status,
-        "budget_cents" => Integer.to_string(budget_cents)
-      },
-      as: :settings
-    )
-  end
-
-  defp maybe_add_owner_field(attrs, _key, _value, false), do: attrs
-  defp maybe_add_owner_field(attrs, _key, nil, _is_owner), do: attrs
-
-  defp maybe_add_owner_field(attrs, key, value, true),
-    do: Map.put(attrs, String.to_existing_atom(key), value)
-
-  defp maybe_set_budget(org, _value, false), do: {:ok, org}
-  defp maybe_set_budget(org, nil, _), do: {:ok, org}
-
-  defp maybe_set_budget(org, value, true) when is_binary(value) do
-    case Integer.parse(value) do
-      {cents, ""} when cents >= 0 ->
-        case Accounts.set_org_budget_cents(org.id, cents) do
-          {:ok, updated} -> {:ok, updated}
-          {:error, _} = err -> err
-        end
-
-      _ ->
-        {:error, "Budget must be a non-negative integer (in cents)."}
     end
   end
 
@@ -1199,6 +992,9 @@ defmodule ControlKeelWeb.OrganizationDetailLive do
       {"Finance", "finance"}
     ]
   end
+
+  defp org_tab_path(slug, :workspaces), do: ~p"/organizations/#{slug}"
+  defp org_tab_path(slug, tab), do: ~p"/organizations/#{slug}?tab=#{tab}"
 
   defp normalize_tab(tab) when tab in ["members"], do: :members
   defp normalize_tab(_tab), do: :workspaces

--- a/lib/controlkeel_web/live/organization_detail_live.ex
+++ b/lib/controlkeel_web/live/organization_detail_live.ex
@@ -452,7 +452,7 @@ defmodule ControlKeelWeb.OrganizationDetailLive do
           Workspaces
         </.link>
         <.link
-          patch={~p"/organizations/#{@org.slug}?tab=members"}
+          patch={~p"/#{@org.slug}?tab=members"}
           class={tab_class(@active_tab == :members)}
         >
           Members

--- a/lib/controlkeel_web/live/organization_layout_defaults.ex
+++ b/lib/controlkeel_web/live/organization_layout_defaults.ex
@@ -1,0 +1,32 @@
+defmodule ControlKeelWeb.OrganizationLayoutDefaults do
+  @moduledoc """
+  Provides assigns consumed by the organization framework layout.
+
+  Organization LiveViews assign `nav_org` after mounting. This hook supplies
+  the shared URL, header-action, and breadcrumb assigns independently from the
+  dashboard layout defaults.
+  """
+
+  import Phoenix.Component, only: [assign: 3, assign_new: 3]
+  import Phoenix.LiveView, only: [attach_hook: 4]
+
+  def on_mount(_arg, _params, _session, socket) do
+    socket =
+      socket
+      |> assign(:current_path, nil)
+      |> assign(:current_query, nil)
+      |> assign_new(:nav_org, fn -> nil end)
+      |> assign_new(:page_action, fn -> nil end)
+      |> assign_new(:breadcrumbs, fn -> nil end)
+      |> attach_hook(:__organization_current_path__, :handle_params, fn _params, uri, socket ->
+        parsed = URI.parse(uri)
+
+        {:cont,
+         socket
+         |> assign(:current_path, parsed.path)
+         |> assign(:current_query, parsed.query)}
+      end)
+
+    {:cont, socket}
+  end
+end

--- a/lib/controlkeel_web/live/organization_settings_live.ex
+++ b/lib/controlkeel_web/live/organization_settings_live.ex
@@ -1,0 +1,230 @@
+defmodule ControlKeelWeb.OrganizationSettingsLive do
+  @moduledoc """
+  Organization settings at `/organizations/:slug/settings`.
+
+  Local mode is unrestricted. Cloud and self-hosted mode require an active
+  admin or owner membership for the organization.
+  """
+
+  use ControlKeelWeb, :live_view
+
+  alias ControlKeel.Accounts
+  alias ControlKeel.Runtime.Mode
+
+  @impl true
+  def mount(%{"slug" => slug}, _session, socket) do
+    case Accounts.get_org_by_slug(slug) do
+      nil ->
+        {:ok, redirect_with_flash(socket, :error, "Organization not found.", ~p"/organizations")}
+
+      org ->
+        mode = Mode.current()
+        user = socket.assigns[:current_user]
+
+        cond do
+          mode == :local ->
+            mount_ok(socket, org)
+
+          is_nil(user) ->
+            {:ok,
+             redirect_with_flash(
+               socket,
+               :error,
+               "Sign in to view this organization.",
+               ~p"/auth/login"
+             )}
+
+          true ->
+            case Accounts.get_active_membership(user.id, org.id) do
+              nil ->
+                {:ok,
+                 redirect_with_flash(
+                   socket,
+                   :error,
+                   "You're not a member of that organization.",
+                   ~p"/organizations"
+                 )}
+
+              membership ->
+                if Accounts.role_at_least?(membership.role, "admin") do
+                  mount_ok(socket, org, membership)
+                else
+                  {:ok,
+                   redirect_with_flash(
+                     socket,
+                     :error,
+                     "You don't have permission to change organization settings.",
+                     ~p"/organizations/#{org.slug}"
+                   )}
+                end
+            end
+        end
+    end
+  end
+
+  defp mount_ok(socket, org, membership \\ nil) do
+    local_mode = Mode.current() == :local
+    budget_cents = Accounts.org_budget_cents(org) || 0
+    is_owner = local_mode || (membership && membership.role == "owner")
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Organization Settings - #{org.name}")
+     |> assign(:org, org)
+     |> assign(:nav_org, org)
+     |> assign(:local_mode, local_mode)
+     |> assign(:is_owner, !!is_owner)
+     |> assign(:settings_form, settings_form(org, budget_cents))
+     |> assign(:settings_error, nil)
+     |> assign(:page_action, nil)}
+  end
+
+  @impl true
+  def handle_event("save_settings", %{"settings" => params}, socket) do
+    org = socket.assigns.org
+    is_owner = socket.assigns.is_owner
+
+    org_attrs =
+      %{name: params["name"]}
+      |> maybe_add_owner_field("status", params["status"], is_owner)
+
+    with {:ok, org} <- Accounts.update_org(org, org_attrs),
+         {:ok, org} <- maybe_set_budget(org, params["budget_cents"], is_owner) do
+      budget_cents = Accounts.org_budget_cents(org) || 0
+
+      {:noreply,
+       socket
+       |> assign(:org, org)
+       |> assign(:settings_form, settings_form(org, budget_cents))
+       |> assign(:settings_error, nil)
+       |> put_flash(:info, "Settings saved.")}
+    else
+      {:error, %Ecto.Changeset{} = changeset} ->
+        message =
+          changeset.errors
+          |> Enum.map_join(", ", fn {field, {detail, _}} -> "#{field}: #{detail}" end)
+
+        {:noreply, assign(socket, :settings_error, message)}
+
+      {:error, reason} ->
+        {:noreply, assign(socket, :settings_error, inspect(reason))}
+    end
+  end
+
+  defp settings_form(org, budget_cents) do
+    to_form(
+      %{
+        "name" => org.name,
+        "status" => org.status,
+        "budget_cents" => Integer.to_string(budget_cents)
+      },
+      as: :settings
+    )
+  end
+
+  defp maybe_add_owner_field(attrs, _key, _value, false), do: attrs
+  defp maybe_add_owner_field(attrs, _key, nil, _is_owner), do: attrs
+
+  defp maybe_add_owner_field(attrs, key, value, true),
+    do: Map.put(attrs, String.to_existing_atom(key), value)
+
+  defp maybe_set_budget(org, _value, false), do: {:ok, org}
+  defp maybe_set_budget(org, nil, _), do: {:ok, org}
+
+  defp maybe_set_budget(org, value, true) when is_binary(value) do
+    case Integer.parse(value) do
+      {cents, ""} when cents >= 0 ->
+        case Accounts.set_org_budget_cents(org.id, cents) do
+          {:ok, updated} -> {:ok, updated}
+          {:error, _} = error -> error
+        end
+
+      _ ->
+        {:error, "Budget must be a non-negative integer in cents."}
+    end
+  end
+
+  defp redirect_with_flash(socket, kind, message, path) do
+    socket
+    |> Phoenix.LiveView.put_flash(kind, message)
+    |> Phoenix.LiveView.push_navigate(to: path)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="mx-auto max-w-3xl space-y-8">
+      <div>
+        <p class="text-sm font-medium text-primary">Organization</p>
+        <h1 class="mt-1 text-2xl font-semibold tracking-tight text-foreground">Settings</h1>
+        <p class="mt-2 text-sm text-muted-foreground">
+          Manage the name, status, and monthly budget for {@org.name}.
+        </p>
+      </div>
+
+      <section class="rounded-2xl border bg-card p-6 shadow-card">
+        <.form
+          for={@settings_form}
+          phx-submit="save_settings"
+          id="org-settings-form"
+          class="space-y-5"
+        >
+          <.input
+            field={@settings_form[:name]}
+            type="text"
+            label="Organization name"
+            required
+            class="w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+
+          <div>
+            <.input
+              field={@settings_form[:status]}
+              type="select"
+              label="Status"
+              options={[{"active", "active"}, {"disabled", "disabled"}]}
+              disabled={!@is_owner}
+              class="w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+            <%= unless @is_owner do %>
+              <p class="mt-1 text-xs text-muted-foreground">Only owners can change status.</p>
+            <% end %>
+          </div>
+
+          <div>
+            <.input
+              field={@settings_form[:budget_cents]}
+              type="number"
+              label="Monthly budget (cents)"
+              disabled={!@is_owner}
+              class="w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+            <%= unless @is_owner do %>
+              <p class="mt-1 text-xs text-muted-foreground">Only owners can change budget.</p>
+            <% end %>
+          </div>
+
+          <p class="text-xs text-muted-foreground">
+            Slug <code class="text-muted-foreground">{@org.slug}</code> cannot be changed.
+          </p>
+
+          <%= if @settings_error do %>
+            <p class="rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {@settings_error}
+            </p>
+          <% end %>
+
+          <div class="flex justify-end pt-2">
+            <button
+              type="submit"
+              class="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground shadow-lg shadow-primary/20 transition hover:-translate-y-0.5 hover:bg-primary"
+            >
+              Save changes
+            </button>
+          </div>
+        </.form>
+      </section>
+    </div>
+    """
+  end
+end

--- a/lib/controlkeel_web/live/organization_settings_live.ex
+++ b/lib/controlkeel_web/live/organization_settings_live.ex
@@ -1,6 +1,6 @@
 defmodule ControlKeelWeb.OrganizationSettingsLive do
   @moduledoc """
-  Organization settings at `/organizations/:slug/settings`.
+  Organization settings at `/:org_slug/settings`.
 
   Local mode is unrestricted. Cloud and self-hosted mode require an active
   admin or owner membership for the organization.
@@ -12,7 +12,7 @@ defmodule ControlKeelWeb.OrganizationSettingsLive do
   alias ControlKeel.Runtime.Mode
 
   @impl true
-  def mount(%{"slug" => slug}, _session, socket) do
+  def mount(%{"org_slug" => slug}, _session, socket) do
     case Accounts.get_org_by_slug(slug) do
       nil ->
         {:ok, redirect_with_flash(socket, :error, "Organization not found.", ~p"/organizations")}
@@ -54,7 +54,7 @@ defmodule ControlKeelWeb.OrganizationSettingsLive do
                      socket,
                      :error,
                      "You don't have permission to change organization settings.",
-                     ~p"/organizations/#{org.slug}"
+                     ~p"/#{org.slug}"
                    )}
                 end
             end

--- a/lib/controlkeel_web/live/organization_settings_live.ex
+++ b/lib/controlkeel_web/live/organization_settings_live.ex
@@ -95,6 +95,8 @@ defmodule ControlKeelWeb.OrganizationSettingsLive do
       {:noreply,
        socket
        |> assign(:org, org)
+       |> assign(:nav_org, org)
+       |> assign(:page_title, "Organization Settings - #{org.name}")
        |> assign(:settings_form, settings_form(org, budget_cents))
        |> assign(:settings_error, nil)
        |> put_flash(:info, "Settings saved.")}

--- a/lib/controlkeel_web/live/organizations_live.ex
+++ b/lib/controlkeel_web/live/organizations_live.ex
@@ -203,7 +203,7 @@ defmodule ControlKeelWeb.OrganizationsLive do
         <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
           <%= for row <- @orgs do %>
             <.link
-              navigate={~p"/organizations/#{row.org.slug}"}
+              navigate={~p"/#{row.org.slug}"}
               class="group block rounded-2xl border bg-card p-5 shadow-card transition hover:border-primary/40 hover:shadow-card"
             >
               <div class="flex items-start justify-between gap-3">

--- a/lib/controlkeel_web/live/workspace_detail_live.ex
+++ b/lib/controlkeel_web/live/workspace_detail_live.ex
@@ -37,7 +37,7 @@ defmodule ControlKeelWeb.WorkspaceDetailLive do
          :breadcrumbs,
          [
            %{label: "Organizations", to: ~p"/organizations"},
-           %{label: workspace.org.name, to: ~p"/organizations/#{workspace.org.slug}"},
+           %{label: workspace.org.name, to: ~p"/#{workspace.org.slug}"},
            %{label: workspace.name, to: nil}
          ]
        )

--- a/lib/controlkeel_web/live/workspace_settings_live.ex
+++ b/lib/controlkeel_web/live/workspace_settings_live.ex
@@ -38,7 +38,7 @@ defmodule ControlKeelWeb.WorkspaceSettingsLive do
          :breadcrumbs,
          [
            %{label: "Organizations", to: ~p"/organizations"},
-           %{label: workspace.org.name, to: ~p"/organizations/#{workspace.org.slug}"},
+           %{label: workspace.org.name, to: ~p"/#{workspace.org.slug}"},
            %{
              label: workspace.name,
              to: ~p"/organizations/#{workspace.org.slug}/workspaces/#{workspace.id}"

--- a/lib/controlkeel_web/plugs/require_cloud_mode.ex
+++ b/lib/controlkeel_web/plugs/require_cloud_mode.ex
@@ -3,12 +3,12 @@ defmodule ControlKeelWeb.Plugs.RequireCloudMode do
   Redirects users away from routes that are not useful in the current mode.
 
   Three cases:
-    * Already-signed-in users visiting `/auth/login` are redirected to
-      `/dashboard` to avoid re-login loops (any mode).
+    * Already-signed-in users visiting `/auth/login` are redirected to `/`
+      to avoid re-login loops (any mode).
     * In local mode (no OAuth/SSO), any `/auth/*` path is a dead end and
-      redirects to `/dashboard` with an informational flash.
+      redirects to `/` with an informational flash.
     * In local mode, `/invitations/*` paths are cloud-only features and
-      redirect to `/dashboard`.
+      redirect to `/`.
   """
 
   import Plug.Conn
@@ -26,13 +26,13 @@ defmodule ControlKeelWeb.Plugs.RequireCloudMode do
     cond do
       signed_in_visiting_login?(conn) ->
         conn
-        |> redirect(to: "/dashboard")
+        |> redirect(to: "/")
         |> halt()
 
       local_mode_blocked_path?(conn) ->
         conn
         |> put_flash(:info, "This feature is not available in local mode.")
-        |> redirect(to: "/dashboard")
+        |> redirect(to: "/")
         |> halt()
 
       true ->

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -112,7 +112,7 @@ defmodule ControlKeelWeb.Router do
       live "/cloud/projects", CloudProjectsLive, :index
       live "/cloud/projects/:ws_id", CloudProjectsLive, :show
       live "/organizations", OrganizationsLive, :index
-      live "/organizations/:slug", OrganizationDetailLive, :index
+
       live "/organizations/:slug/workspaces/:id", WorkspaceDetailLive, :index
       live "/organizations/:slug/workspaces/:id/settings", WorkspaceSettingsLive, :show
       live "/workspaces/:id/repos", WorkspaceReposLive, :index
@@ -121,6 +121,16 @@ defmodule ControlKeelWeb.Router do
       live "/workspaces/:id/tool-policy", WorkspaceToolPolicyLive, :edit
       live "/policies", PolicyStudioLive, :index
       live "/skills", SkillsLive, :index
+    end
+
+    live_session :organization,
+      layout: {ControlKeelWeb.OrganizationLayouts, :organization},
+      on_mount: [
+        {ControlKeelWeb.LiveAuth, :require_cloud_auth},
+        ControlKeelWeb.OrganizationLayoutDefaults
+      ] do
+      live "/organizations/:slug", OrganizationDetailLive, :index
+      live "/organizations/:slug/settings", OrganizationSettingsLive, :edit
     end
 
     # Observability section routes use the shared :dashboard framework layout;

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -163,6 +163,8 @@ defmodule ControlKeelWeb.Router do
       live "/observability/sessions/:id", ObservabilityLive, :show
     end
 
+    # NB: keep this block last in the scope — ":org_slug" matches any single
+    # segment, so routes added below it would be silently swallowed.
     live_session :organization,
       layout: {ControlKeelWeb.OrganizationLayouts, :organization},
       on_mount: [

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -123,16 +123,6 @@ defmodule ControlKeelWeb.Router do
       live "/skills", SkillsLive, :index
     end
 
-    live_session :organization,
-      layout: {ControlKeelWeb.OrganizationLayouts, :organization},
-      on_mount: [
-        {ControlKeelWeb.LiveAuth, :require_cloud_auth},
-        ControlKeelWeb.OrganizationLayoutDefaults
-      ] do
-      live "/organizations/:slug", OrganizationDetailLive, :index
-      live "/organizations/:slug/settings", OrganizationSettingsLive, :edit
-    end
-
     # Observability section routes use the shared :dashboard framework layout;
     # each page renders its own heading. LayoutDefaults sets shared layout
     # assigns (@current_path, @page_action) for active-link highlighting.
@@ -171,6 +161,16 @@ defmodule ControlKeelWeb.Router do
       live "/observability/sessions/:id/memory", ObservabilityMemoryLive, :show
       live "/observability/sessions/:id/timeline", ObservabilityTimelineLive, :show
       live "/observability/sessions/:id", ObservabilityLive, :show
+    end
+
+    live_session :organization,
+      layout: {ControlKeelWeb.OrganizationLayouts, :organization},
+      on_mount: [
+        {ControlKeelWeb.LiveAuth, :require_cloud_auth},
+        ControlKeelWeb.OrganizationLayoutDefaults
+      ] do
+      live "/:org_slug", OrganizationDetailLive, :index
+      live "/:org_slug/settings", OrganizationSettingsLive, :edit
     end
   end
 

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -55,6 +55,23 @@ defmodule ControlKeelWeb.Router do
   pipeline :proxy_api do
   end
 
+  # Protocol endpoints live above the browser scope on purpose: the
+  # ":org_slug" live route below matches any single-segment GET, so scopes
+  # defined after it (like this one) would lose "GET /mcp" to it. Keep
+  # single-segment protocol GETs ahead of the browser scope.
+  scope "/", ControlKeelWeb do
+    pipe_through :protocol_api
+
+    get "/.well-known/oauth-protected-resource/mcp", ProtocolController, :protected_resource_mcp
+    get "/.well-known/oauth-protected-resource", ProtocolController, :protected_resource_alias
+    get "/.well-known/oauth-authorization-server", ProtocolController, :authorization_server
+    get "/.well-known/agent-card.json", ProtocolController, :a2a_card
+    get "/.well-known/agent.json", ProtocolController, :a2a_card
+    post "/oauth/token", OAuthController, :token
+    get "/mcp", ProtocolController, :mcp_get
+    delete "/mcp", ProtocolController, :mcp_delete
+  end
+
   scope "/", ControlKeelWeb do
     pipe_through :browser
 
@@ -164,7 +181,9 @@ defmodule ControlKeelWeb.Router do
     end
 
     # NB: keep this block last in the scope — ":org_slug" matches any single
-    # segment, so routes added below it would be silently swallowed.
+    # segment, so routes added below it would be silently swallowed. For the
+    # same reason, single-segment protocol GETs must stay ahead of the
+    # browser scope (see above).
     live_session :organization,
       layout: {ControlKeelWeb.OrganizationLayouts, :organization},
       on_mount: [
@@ -280,19 +299,6 @@ defmodule ControlKeelWeb.Router do
     post "/gemini/:proxy_token/v1beta/chat/completions", ProxyController, :gemini_chat_completions
     get "/gemini/:proxy_token/v1beta/openai/models", ProxyController, :gemini_models
     get "/openai/:proxy_token/v1/realtime", ProxySocketController, :openai_realtime
-  end
-
-  scope "/", ControlKeelWeb do
-    pipe_through :protocol_api
-
-    get "/.well-known/oauth-protected-resource/mcp", ProtocolController, :protected_resource_mcp
-    get "/.well-known/oauth-protected-resource", ProtocolController, :protected_resource_alias
-    get "/.well-known/oauth-authorization-server", ProtocolController, :authorization_server
-    get "/.well-known/agent-card.json", ProtocolController, :a2a_card
-    get "/.well-known/agent.json", ProtocolController, :a2a_card
-    post "/oauth/token", OAuthController, :token
-    get "/mcp", ProtocolController, :mcp_get
-    delete "/mcp", ProtocolController, :mcp_delete
   end
 
   scope "/", ControlKeelWeb do

--- a/lib/controlkeel_web/router.ex
+++ b/lib/controlkeel_web/router.ex
@@ -180,6 +180,13 @@ defmodule ControlKeelWeb.Router do
       live "/observability/sessions/:id", ObservabilityLive, :show
     end
 
+    # Legacy org URLs (pre-/:org_slug simplification): the /organizations/:slug
+    # shape is the most-shared URL in docs/Slack/CI, so keep it as a redirect
+    # rather than a 404. Two-segment, so the single-segment ":org_slug" live
+    # route below does not swallow it — kept above that block for readability.
+    get "/organizations/:slug", PageController, :org_legacy_redirect
+    get "/organizations/:slug/settings", PageController, :org_legacy_redirect
+
     # NB: keep this block last in the scope — ":org_slug" matches any single
     # segment, so routes added below it would be silently swallowed. For the
     # same reason, single-segment protocol GETs must stay ahead of the

--- a/test/controlkeel_web/controllers/oauth_login_controller_test.exs
+++ b/test/controlkeel_web/controllers/oauth_login_controller_test.exs
@@ -81,7 +81,7 @@ defmodule ControlKeelWeb.OAuthLoginControllerTest do
         |> init_test_session(%{oauth_provider: "github", oauth_session_params: %{}})
         |> get("/auth/github/callback", %{"code" => "good"})
 
-      assert redirected_to(conn, 302) == "/dashboard"
+      assert redirected_to(conn, 302) == "/"
       assert get_session(conn, "phoenix_flash")["info"] == "Signed in with GitHub."
       assert Accounts.get_user_by_email("user@example.com")
       assert get_session(conn, :current_user_id)

--- a/test/controlkeel_web/controllers/page_controller_test.exs
+++ b/test/controlkeel_web/controllers/page_controller_test.exs
@@ -43,7 +43,7 @@ defmodule ControlKeelWeb.PageControllerTest do
     test "redirects to the default organization page", %{conn: conn} do
       conn = get(conn, ~p"/")
 
-      assert redirected_to(conn) == ~p"/organizations/#{LocalDefaults.default_org_slug()}"
+      assert redirected_to(conn) == ~p"/#{LocalDefaults.default_org_slug()}"
     end
 
     test "provisions the default org on first visit", %{conn: conn} do
@@ -107,7 +107,7 @@ defmodule ControlKeelWeb.PageControllerTest do
       assert body =~ "Acme Corp"
       assert body =~ "Platform"
       assert body =~ "Launch checklist"
-      assert body =~ ~p"/organizations/#{org.slug}"
+      assert body =~ ~p"/#{org.slug}"
       assert body =~ ~p"/organizations/#{org.slug}/workspaces/#{workspace.id}"
       assert body =~ ~p"/sessions/#{session.id}"
       refute body =~ "Turn team knowledge into"

--- a/test/controlkeel_web/controllers/page_controller_test.exs
+++ b/test/controlkeel_web/controllers/page_controller_test.exs
@@ -188,4 +188,18 @@ defmodule ControlKeelWeb.PageControllerTest do
     assert body =~ "Other supported agents"
     assert body =~ "Project rescue"
   end
+
+  describe "legacy org redirects" do
+    test "GET /organizations/:slug redirects to /:slug", %{conn: conn} do
+      conn = get(conn, "/organizations/acme-corp")
+
+      assert redirected_to(conn, 302) == "/acme-corp"
+    end
+
+    test "GET /organizations/:slug/settings redirects to /:slug/settings", %{conn: conn} do
+      conn = get(conn, "/organizations/acme-corp/settings")
+
+      assert redirected_to(conn, 302) == "/acme-corp/settings"
+    end
+  end
 end

--- a/test/controlkeel_web/controllers/page_controller_test.exs
+++ b/test/controlkeel_web/controllers/page_controller_test.exs
@@ -1,17 +1,173 @@
 defmodule ControlKeelWeb.PageControllerTest do
-  use ControlKeelWeb.ConnCase
+  use ControlKeelWeb.ConnCase, async: false
 
-  test "GET / renders the landing page", %{conn: conn} do
-    conn = get(conn, ~p"/")
-    body = html_response(conn, 200)
+  alias ControlKeel.Accounts
+  alias ControlKeel.Bootstrap.LocalDefaults
+  alias ControlKeel.Mission
 
-    assert body =~ "Turn team knowledge into"
-    assert body =~ "Install ControlKeel"
-    assert body =~ "Policy gates for agents"
-    assert body =~ "Evidence, not vibes"
-    assert body =~ "Host-agnostic control"
-    assert body =~ "How it works"
-    assert body =~ "Ready to govern"
+  defp create_workspace(org, name) do
+    slug = String.replace(String.downcase(name), " ", "-")
+
+    {:ok, workspace} =
+      Mission.create_workspace(%{
+        name: name,
+        slug: slug,
+        industry: "general",
+        agent: "claude",
+        budget_cents: 0,
+        compliance_profile: "general",
+        status: "active",
+        org_id: org.id
+      })
+
+    workspace
+  end
+
+  defp create_session(workspace, title) do
+    {:ok, session} =
+      Mission.create_session(%{
+        title: title,
+        objective: "Ship the thing",
+        risk_tier: "medium",
+        status: "planned",
+        budget_cents: 0,
+        daily_budget_cents: 0,
+        spent_cents: 0,
+        workspace_id: workspace.id
+      })
+
+    session
+  end
+
+  describe "local mode GET /" do
+    test "redirects to the default organization page", %{conn: conn} do
+      conn = get(conn, ~p"/")
+
+      assert redirected_to(conn) == ~p"/organizations/#{LocalDefaults.default_org_slug()}"
+    end
+
+    test "provisions the default org on first visit", %{conn: conn} do
+      assert Accounts.get_org_by_slug(LocalDefaults.default_org_slug()) == nil
+
+      get(conn, ~p"/")
+
+      assert Accounts.get_org_by_slug(LocalDefaults.default_org_slug()) != nil
+    end
+  end
+
+  describe "cloud mode GET /" do
+    setup do
+      original = Application.get_env(:controlkeel, :runtime_mode)
+      Application.put_env(:controlkeel, :runtime_mode, :cloud)
+
+      on_exit(fn ->
+        if is_nil(original) do
+          Application.delete_env(:controlkeel, :runtime_mode)
+        else
+          Application.put_env(:controlkeel, :runtime_mode, original)
+        end
+      end)
+
+      {:ok, user} = Accounts.create_user(%{email: "home@example.com", name: "Home"})
+
+      {:ok, user: user}
+    end
+
+    test "renders the landing page for anonymous visitors", %{conn: conn} do
+      conn = get(conn, ~p"/")
+      body = html_response(conn, 200)
+
+      assert body =~ "Turn team knowledge into"
+      assert body =~ "Install ControlKeel"
+      assert body =~ "Policy gates for agents"
+      assert body =~ "Evidence, not vibes"
+      assert body =~ "Host-agnostic control"
+      assert body =~ "How it works"
+      assert body =~ "Ready to govern"
+    end
+
+    test "renders the org → workspace → session tree for signed-in users", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, org} =
+        Accounts.create_org_with_owner(user.id, %{name: "Acme Corp", slug: "acme-corp"})
+
+      workspace = create_workspace(org, "Platform")
+      session = create_session(workspace, "Launch checklist")
+
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{"current_user_id" => user.id})
+        |> get(~p"/")
+
+      body = html_response(conn, 200)
+
+      assert body =~ "Home"
+      assert body =~ "Acme Corp"
+      assert body =~ "Platform"
+      assert body =~ "Launch checklist"
+      assert body =~ ~p"/organizations/#{org.slug}"
+      assert body =~ ~p"/organizations/#{org.slug}/workspaces/#{workspace.id}"
+      assert body =~ ~p"/sessions/#{session.id}"
+      refute body =~ "Turn team knowledge into"
+    end
+
+    test "tree shows only orgs where the user has an active membership", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, mine} = Accounts.create_org_with_owner(user.id, %{name: "Mine Co", slug: "mine-co"})
+      workspace = create_workspace(mine, "Core")
+      session = create_session(workspace, "My session")
+
+      {:ok, other} = Accounts.create_user(%{email: "other@example.com"})
+      {:ok, _} = Accounts.create_org_with_owner(other.id, %{name: "Theirs Co", slug: "theirs-co"})
+
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{"current_user_id" => user.id})
+        |> get(~p"/")
+
+      body = html_response(conn, 200)
+
+      assert body =~ "Mine Co"
+      assert body =~ "My session"
+      assert body =~ ~p"/sessions/#{session.id}"
+      refute body =~ "Theirs Co"
+    end
+
+    test "tree renders nested empty states for a member with an empty org", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, _} = Accounts.create_org_with_owner(user.id, %{name: "Empty Co", slug: "empty-co"})
+
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{"current_user_id" => user.id})
+        |> get(~p"/")
+
+      body = html_response(conn, 200)
+
+      assert body =~ "Empty Co"
+      assert body =~ "No workspaces yet."
+    end
+
+    test "tree renders the org-less empty state for a member with no orgs", %{conn: conn} do
+      {:ok, fresh} = Accounts.create_user(%{email: "fresh@example.com"})
+
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{"current_user_id" => fresh.id})
+        |> get(~p"/")
+
+      body = html_response(conn, 200)
+
+      assert body =~ "No organizations yet."
+      assert body =~ ~p"/organizations"
+      assert body =~ ~p"/sessions/start"
+    end
   end
 
   test "GET /getting-started renders the guide with install channels", %{conn: conn} do

--- a/test/controlkeel_web/live/organization_detail_live_test.exs
+++ b/test/controlkeel_web/live/organization_detail_live_test.exs
@@ -269,7 +269,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "non-admin members are redirected from settings", %{member: member} do
-      assert {:error, {:redirect, %{to: "/setco"}}} =
+      assert {:error, {:live_redirect, %{to: "/setco"}}} =
                live(conn_for(member), ~p"/setco/settings")
     end
   end
@@ -326,7 +326,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
       assert render(view) =~ "core-workspace"
 
       view
-      |> element("a[data-phx-link=\"patch\"][href=\"/organizations/tabco?tab=members\"]")
+      |> element("a[data-phx-link=\"patch\"][href=\"/tabco?tab=members\"]")
       |> render_click()
 
       html = render(view)

--- a/test/controlkeel_web/live/organization_detail_live_test.exs
+++ b/test/controlkeel_web/live/organization_detail_live_test.exs
@@ -62,7 +62,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "owner row is locked (disabled)", %{conn: conn, memberships: ms} do
-      {:ok, view, _html} = live(conn, ~p"/organizations/acme?tab=members")
+      {:ok, view, _html} = live(conn, ~p"/acme?tab=members")
 
       form = element(view, "#role-form-#{ms.owner.id}") |> render()
       assert form =~ "disabled"
@@ -75,7 +75,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
       conn: conn,
       memberships: ms
     } do
-      {:ok, view, _html} = live(conn, ~p"/organizations/acme?tab=members")
+      {:ok, view, _html} = live(conn, ~p"/acme?tab=members")
 
       form = element(view, "#role-form-#{ms.admin.id}") |> render()
       refute form =~ "disabled"
@@ -87,7 +87,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "admin can self-demit to viewer", %{conn: conn, memberships: ms} do
-      {:ok, view, _html} = live(conn, ~p"/organizations/acme?tab=members")
+      {:ok, view, _html} = live(conn, ~p"/acme?tab=members")
 
       view
       |> element("#role-form-#{ms.admin.id}")
@@ -102,7 +102,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
       conn: conn,
       memberships: ms
     } do
-      {:ok, view, _html} = live(conn, ~p"/organizations/acme?tab=members")
+      {:ok, view, _html} = live(conn, ~p"/acme?tab=members")
 
       for target <- [:member, :viewer] do
         form = element(view, "#role-form-#{ms[target].id}") |> render()
@@ -118,7 +118,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
       conn: conn,
       memberships: ms
     } do
-      {:ok, view, _html} = live(conn, ~p"/organizations/acme?tab=members")
+      {:ok, view, _html} = live(conn, ~p"/acme?tab=members")
 
       # Sanity: admin can manage before the change.
       assert render(view) =~ ~s(id="role-form-#{ms.member.id}")
@@ -142,7 +142,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
       conn: conn,
       memberships: ms
     } do
-      {:ok, view, _html} = live(conn, ~p"/organizations/acme?tab=members")
+      {:ok, view, _html} = live(conn, ~p"/acme?tab=members")
 
       view
       |> element("#role-form-#{ms.member.id}")
@@ -167,7 +167,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "sole owner cannot change their own role (locked)", %{conn: conn, owner_m: owner_m} do
-      {:ok, view, _html} = live(conn, ~p"/organizations/omega?tab=members")
+      {:ok, view, _html} = live(conn, ~p"/omega?tab=members")
 
       form = element(view, "#role-form-#{owner_m.id}") |> render()
       assert form =~ "disabled"
@@ -180,7 +180,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
       second = create_user!("owner-b@example.com")
       add_active_membership(second.id, org_id, "owner")
 
-      {:ok, view, _html} = live(conn, ~p"/organizations/omega?tab=members")
+      {:ok, view, _html} = live(conn, ~p"/omega?tab=members")
 
       form = element(view, "#role-form-#{owner_m.id}") |> render()
       refute form =~ "disabled"
@@ -197,7 +197,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
       second = create_user!("owner-c@example.com")
       add_active_membership(second.id, owner_m.org_id, "owner")
 
-      {:ok, view, _html} = live(conn, ~p"/organizations/omega?tab=members")
+      {:ok, view, _html} = live(conn, ~p"/omega?tab=members")
 
       # Sanity: management controls present before the change.
       html_before = render(view)
@@ -238,7 +238,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "settings page renders at the organization settings route", %{owner: owner} do
-      {:ok, _view, html} = live(conn_for(owner), ~p"/organizations/setco/settings")
+      {:ok, _view, html} = live(conn_for(owner), ~p"/setco/settings")
 
       assert html =~ "Organization Settings"
       assert html =~ "Organization name"
@@ -246,7 +246,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "owner saves the org name from the settings page", %{org: org, owner: owner} do
-      {:ok, view, _html} = live(conn_for(owner), ~p"/organizations/setco/settings")
+      {:ok, view, _html} = live(conn_for(owner), ~p"/setco/settings")
 
       view
       |> element("#org-settings-form")
@@ -259,7 +259,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "admin can view settings but status and budget are owner-locked", %{admin: admin} do
-      {:ok, view, html} = live(conn_for(admin), ~p"/organizations/setco/settings")
+      {:ok, view, html} = live(conn_for(admin), ~p"/setco/settings")
 
       assert html =~ "Organization Settings"
       html = render(view)
@@ -269,8 +269,8 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "non-admin members are redirected from settings", %{member: member} do
-      assert {:error, {:redirect, %{to: "/organizations/setco"}}} =
-               live(conn_for(member), ~p"/organizations/setco/settings")
+      assert {:error, {:redirect, %{to: "/setco"}}} =
+               live(conn_for(member), ~p"/setco/settings")
     end
   end
 
@@ -298,7 +298,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
       owner: owner,
       workspace: ws
     } do
-      {:ok, view, html} = live(conn_for(owner), ~p"/organizations/tabco")
+      {:ok, view, html} = live(conn_for(owner), ~p"/tabco")
 
       assert html =~ "Workspaces"
       assert html =~ "?tab=members"
@@ -314,7 +314,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "members tab lists memberships", %{owner: owner} do
-      {:ok, view, _html} = live(conn_for(owner), ~p"/organizations/tabco?tab=members")
+      {:ok, view, _html} = live(conn_for(owner), ~p"/tabco?tab=members")
 
       html = render(view)
       assert html =~ "tab-owner@example.com"
@@ -322,7 +322,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "clicking the Members tab switches content", %{owner: owner} do
-      {:ok, view, _html} = live(conn_for(owner), ~p"/organizations/tabco")
+      {:ok, view, _html} = live(conn_for(owner), ~p"/tabco")
       assert render(view) =~ "core-workspace"
 
       view
@@ -335,17 +335,17 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "unknown tab value falls back to workspaces", %{owner: owner} do
-      {:ok, view, _html} = live(conn_for(owner), ~p"/organizations/tabco?tab=wat")
+      {:ok, view, _html} = live(conn_for(owner), ~p"/tabco?tab=wat")
       assert render(view) =~ "core-workspace"
     end
 
     test "sidebar renders the org nav on the org page", %{owner: owner} do
-      {:ok, _view, html} = live(conn_for(owner), ~p"/organizations/tabco")
+      {:ok, _view, html} = live(conn_for(owner), ~p"/tabco")
 
       assert html =~ "sidebar-org-nav"
       assert html =~ "Tabco"
       refute html =~ ~s(href="/organizations/tabco?tab=sessions")
-      assert html =~ ~s(href="/organizations/tabco/settings")
+      assert html =~ ~s(href="/tabco/settings")
     end
   end
 
@@ -358,7 +358,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "cloud mode opens the create form", %{owner: owner} do
-      {:ok, view, html} = live(conn_for(owner), ~p"/organizations/wsco")
+      {:ok, view, html} = live(conn_for(owner), ~p"/wsco")
 
       refute html =~ "new-workspace-modal"
 
@@ -372,7 +372,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "cloud mode creates a workspace and lists it", %{org: org, owner: owner} do
-      {:ok, view, _html} = live(conn_for(owner), ~p"/organizations/wsco")
+      {:ok, view, _html} = live(conn_for(owner), ~p"/wsco")
 
       view |> render_click("new_workspace")
 
@@ -397,7 +397,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "blank slug is auto-generated from the name", %{owner: owner} do
-      {:ok, view, _html} = live(conn_for(owner), ~p"/organizations/wsco")
+      {:ok, view, _html} = live(conn_for(owner), ~p"/wsco")
 
       view |> render_click("new_workspace")
 
@@ -429,7 +429,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
           org_id: org.id
         })
 
-      {:ok, view, _html} = live(conn_for(owner), ~p"/organizations/wsco")
+      {:ok, view, _html} = live(conn_for(owner), ~p"/wsco")
 
       view |> render_click("new_workspace")
 
@@ -467,7 +467,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "modal shows the local-mode notice instead of the form", %{org: _org} do
-      {:ok, view, _html} = live(build_conn(), ~p"/organizations/local-ws-org")
+      {:ok, view, _html} = live(build_conn(), ~p"/local-ws-org")
 
       view |> render_click("new_workspace")
       modal = render(view)
@@ -479,7 +479,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "forged save_workspace event is rejected in local mode", %{org: org} do
-      {:ok, view, _html} = live(build_conn(), ~p"/organizations/local-ws-org")
+      {:ok, view, _html} = live(build_conn(), ~p"/local-ws-org")
 
       view
       |> render_click("save_workspace", %{
@@ -514,11 +514,11 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "workspaces is the default tab and members shows the local-mode notice", %{org: _org} do
-      {:ok, view, _html} = live(build_conn(), ~p"/organizations/local-org")
+      {:ok, view, _html} = live(build_conn(), ~p"/local-org")
       assert render(view) =~ "Workspaces"
       refute render(view) =~ "Member management is not available in local mode."
 
-      {:ok, view, _html} = live(build_conn(), ~p"/organizations/local-org?tab=members")
+      {:ok, view, _html} = live(build_conn(), ~p"/local-org?tab=members")
       html = render(view)
 
       assert html =~ "Member management is not available in local mode."

--- a/test/controlkeel_web/live/organization_detail_live_test.exs
+++ b/test/controlkeel_web/live/organization_detail_live_test.exs
@@ -237,27 +237,16 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
       {:ok, org: org, owner: owner, admin: admin, member: member}
     end
 
-    test "settings action appears in the dashboard header and opens the modal", %{owner: owner} do
-      {:ok, view, html} = live(conn_for(owner), ~p"/organizations/setco?tab=members")
+    test "settings page renders at the organization settings route", %{owner: owner} do
+      {:ok, _view, html} = live(conn_for(owner), ~p"/organizations/setco/settings")
 
+      assert html =~ "Organization Settings"
+      assert html =~ "Organization name"
       refute html =~ "org-settings-modal"
-      assert render(view) =~ ~s(id="dashboard-page-action")
-      assert render(view) =~ "phx-click=\"open_settings\""
-
-      view |> render_click("open_settings")
-      assert render(view) =~ "org-settings-modal"
-      assert render(view) =~ "Organization name"
     end
 
-    test "owner opens the modal and saves the org name", %{org: org, owner: owner} do
-      {:ok, view, html} = live(conn_for(owner), ~p"/organizations/setco?tab=members")
-
-      # Modal is absent until opened.
-      refute html =~ "org-settings-modal"
-
-      view |> render_click("open_settings")
-      assert render(view) =~ "org-settings-modal"
-      assert render(view) =~ "Organization name"
+    test "owner saves the org name from the settings page", %{org: org, owner: owner} do
+      {:ok, view, _html} = live(conn_for(owner), ~p"/organizations/setco/settings")
 
       view
       |> element("#org-settings-form")
@@ -269,41 +258,19 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
       assert Accounts.get_org(org.id).name == "Setco Renamed"
     end
 
-    test "admin can open the modal but status and budget are owner-locked", %{admin: admin} do
-      {:ok, view, _html} = live(conn_for(admin), ~p"/organizations/setco?tab=members")
+    test "admin can view settings but status and budget are owner-locked", %{admin: admin} do
+      {:ok, view, html} = live(conn_for(admin), ~p"/organizations/setco/settings")
 
-      view |> render_click("open_settings")
+      assert html =~ "Organization Settings"
       html = render(view)
 
-      assert html =~ "org-settings-modal"
       assert html =~ "Only owners can change status."
       assert html =~ "Only owners can change budget."
     end
 
-    test "non-admin members do not see the settings button", %{member: member} do
-      {:ok, _view, html} = live(conn_for(member), ~p"/organizations/setco?tab=members")
-
-      refute html =~ "open_settings"
-    end
-
-    test "non-admin member cannot save settings via a forged event", %{
-      org: org,
-      member: member
-    } do
-      # Members can mount the org detail LiveView; the button is hidden, but the
-      # server must still reject a forged `save_settings` event so they cannot
-      # rename the org or touch owner-only fields.
-      {:ok, view, _html} = live(conn_for(member), ~p"/organizations/setco?tab=members")
-
-      view
-      |> render_click("save_settings", %{
-        "settings" => %{"name" => "Hacked", "status" => "disabled", "budget_cents" => "999"}
-      })
-
-      refute render(view) =~ "Settings saved."
-      reloaded = Accounts.get_org(org.id)
-      assert reloaded.name == "Setco"
-      assert reloaded.status == "active"
+    test "non-admin members are redirected from settings", %{member: member} do
+      assert {:error, {:redirect, %{to: "/organizations/setco"}}} =
+               live(conn_for(member), ~p"/organizations/setco/settings")
     end
   end
 
@@ -359,7 +326,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
       assert render(view) =~ "core-workspace"
 
       view
-      |> element("a[href=\"/organizations/tabco?tab=members\"]")
+      |> element("a[data-phx-link=\"patch\"][href=\"/organizations/tabco?tab=members\"]")
       |> render_click()
 
       html = render(view)
@@ -370,6 +337,15 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     test "unknown tab value falls back to workspaces", %{owner: owner} do
       {:ok, view, _html} = live(conn_for(owner), ~p"/organizations/tabco?tab=wat")
       assert render(view) =~ "core-workspace"
+    end
+
+    test "sidebar renders the org nav on the org page", %{owner: owner} do
+      {:ok, _view, html} = live(conn_for(owner), ~p"/organizations/tabco")
+
+      assert html =~ "sidebar-org-nav"
+      assert html =~ "Tabco"
+      refute html =~ ~s(href="/organizations/tabco?tab=sessions")
+      assert html =~ ~s(href="/organizations/tabco/settings")
     end
   end
 

--- a/test/controlkeel_web/live/organization_detail_live_test.exs
+++ b/test/controlkeel_web/live/organization_detail_live_test.exs
@@ -357,7 +357,7 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
       assert html =~ "sidebar-org-switcher"
       assert html =~ ~s(href="/tabco")
       assert html =~ ~s(href="/second-org")
-      assert html =~ ~s(href="/organizations")
+      refute html =~ ~s(href="/organizations")
     end
   end
 

--- a/test/controlkeel_web/live/organization_detail_live_test.exs
+++ b/test/controlkeel_web/live/organization_detail_live_test.exs
@@ -349,7 +349,9 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
     end
 
     test "sidebar renders organization switcher with user's orgs in cloud mode", %{owner: owner} do
-      {:ok, _other_org} = Accounts.create_org_with_owner(owner.id, %{name: "Second Org", slug: "second-org"})
+      {:ok, _other_org} =
+        Accounts.create_org_with_owner(owner.id, %{name: "Second Org", slug: "second-org"})
+
       {:ok, _view, html} = live(conn_for(owner), ~p"/tabco")
 
       assert html =~ "sidebar-org-switcher"

--- a/test/controlkeel_web/live/organization_detail_live_test.exs
+++ b/test/controlkeel_web/live/organization_detail_live_test.exs
@@ -344,8 +344,18 @@ defmodule ControlKeelWeb.OrganizationDetailLiveTest do
 
       assert html =~ "sidebar-org-nav"
       assert html =~ "Tabco"
-      refute html =~ ~s(href="/organizations/tabco?tab=sessions")
+      refute html =~ ~s(href="/tabco?tab=sessions")
       assert html =~ ~s(href="/tabco/settings")
+    end
+
+    test "sidebar renders organization switcher with user's orgs in cloud mode", %{owner: owner} do
+      {:ok, _other_org} = Accounts.create_org_with_owner(owner.id, %{name: "Second Org", slug: "second-org"})
+      {:ok, _view, html} = live(conn_for(owner), ~p"/tabco")
+
+      assert html =~ "sidebar-org-switcher"
+      assert html =~ ~s(href="/tabco")
+      assert html =~ ~s(href="/second-org")
+      assert html =~ ~s(href="/organizations")
     end
   end
 

--- a/test/controlkeel_web/live/organizations_live_test.exs
+++ b/test/controlkeel_web/live/organizations_live_test.exs
@@ -109,7 +109,7 @@ defmodule ControlKeelWeb.OrganizationsLiveTest do
 
       assert html =~ "Mine"
       refute html =~ "Theirs"
-      assert html =~ ~p"/organizations/#{org.slug}"
+      assert html =~ ~p"/#{org.slug}"
     end
 
     test "cloud mode renders the user's role per org row", %{conn: conn, user: user} do

--- a/test/controlkeel_web/plugs/browser_auth_plugs_test.exs
+++ b/test/controlkeel_web/plugs/browser_auth_plugs_test.exs
@@ -38,7 +38,7 @@ defmodule ControlKeelWeb.Plugs.BrowserAuthPlugsTest do
       |> Map.put(:request_path, "/auth/login")
       |> RequireCloudMode.call([])
 
-    assert redirected_to(conn, 302) == "/dashboard"
+    assert redirected_to(conn, 302) == "/"
     assert conn.halted
   end
 
@@ -83,7 +83,7 @@ defmodule ControlKeelWeb.Plugs.BrowserAuthPlugsTest do
       |> Phoenix.Controller.fetch_flash()
       |> RequireCloudMode.call([])
 
-    assert redirected_to(conn, 302) == "/dashboard"
+    assert redirected_to(conn, 302) == "/"
     assert conn.halted
 
     assert get_session(conn, "phoenix_flash")["info"] ==


### PR DESCRIPTION
## Objective

Initial cleanup phase toward the #130 target state. This branch isolates the existing global dashboard and puts navigation on an org-scoped footing:

- `/` becomes a landing page: marketing for visitors, an organization → workspace → session selector tree for signed-in users. It is designed to disappear later — after onboarding / working-org selection the app will open `/:working_org_slug` directly. (Accepted: the tree loads all sessions uncapped; fine for a temporary page, revisit if it survives.)
- Org pages (`/:org_slug`, `/:org_slug/settings`) get their own framework layout (`OrganizationLayouts`) with org switcher, org-scoped nav, and local `user_menu` / `flash_group` — no dependency on the global `Layouts`.
- Global dashboard (`/dashboard`), its sidebar, and all session-scoped surfaces (findings, proofs, observability) are deliberately **untouched**; they are only meaningful in session context and move in a later phase.

Out of scope for this branch: #130 R2–R5 (session sidebar, re-scoped findings/proofs routes, legacy observability redirects, removal of global browsers), `/api/v1`, CLI changes.

## Route map

| Before                                                       | After                                                                                 |
| ------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
| `/` marketing home (everyone)                                | `/` local: redirect to default org; signed-in: selector tree; visitor: marketing home |
| `/organizations/:slug` (dashboard layout, settings in modal) | `/:org_slug` (org layout), `/:org_slug/settings` (dedicated route)                    |
| post-login → `/dashboard`                                    | post-login → `/`                                                                      |
| org cards → `/organizations/:slug`                           | org cards → `/:slug`                                                                  |

`/dashboard`, `/sessions`, `/findings`, `/proofs`, `/observability/*` unchanged.

## What changed

**Landing / entry (`PageController`, `selector_tree.html.heex`)**

- `home/2` branches: local mode ensures the default org and redirects to it; signed-in users get a preloaded org → workspace → session tree (`selector_tree/1`, batched via new `Mission.list_workspaces_for_orgs/1` and `Mission.list_sessions_for_workspaces/1`); visitors keep marketing.
- New `selector_tree.html.heex` renders the tree with empty states (no orgs / workspaces / sessions). Disclosure uses explicit toggle buttons + collapsible divs (the codebase's sidebar-popover pattern) with `aria-expanded`/`aria-controls` — not nested `<details>/<summary>` links, so org/workspace name links navigate without also toggling.
- `OAuthLoginController`, `RequireCloudMode` plug, invitation/onboarding redirects retargeted from `/dashboard` to `/` (or the new short org path).

**Org routes (`router.ex`, `organization_layout_defaults.ex`)**

- Removed `/organizations/:slug`; added `live_session :organization` with `layout: {OrganizationLayouts, :organization}` serving `/:org_slug` and `/:org_slug/settings`. Short links updated in `OrganizationsLive`, `InvitationLive`, `OnboardingLive`, workspace breadcrumbs.
- The `:organization` block carries a keep-last comment: `:org_slug` matches any single segment, so routes added below it would be silently swallowed.
- New `OrganizationLayoutDefaults` on_mount supplies `current_path`, `current_query`, `nav_org`, `page_action`, `breadcrumbs` independently of dashboard defaults.

**Org layout (`organization_layouts.ex`, `organization.html.heex`)**

- New `organization_sidebar/1`: brand block linking to org home, org switcher popover (user's orgs + active check), org-scoped nav (Overview/Settings), docs links, user menu.
- `user_menu/1` and `flash_group/1` duplicated into the module (fork-noted) so org pages import nothing from `Layouts`; `Layouts` itself reverted to its pre-branch state.
- Switcher toggle wired (`phx-click` + aria), `phx-click-away` on the wrapper (toggle-button clicks don't self-close), `relative` anchor restored.
- User menu trigger is 3-dot-only; hover lives on the button, not the row.
- Breadcrumb action slot renamed `organization-page-action`; switcher "All organizations" footer removed (switcher is for switching, org discovery stays on `/organizations`); dead `breadcums_header/1` shim deleted.

**Settings extraction (`organization_settings_live.ex`, `organization_detail_live.ex`)**

- Settings moved from modal-in-detail to a dedicated LiveView + route with persistent sidebar nav; detail view slimmed accordingly. Admin/owner gating preserved (owner-only status/budget enforced server-side); saving a rename refreshes sidebar (`nav_org`) and page title immediately.

**Docker (`Dockerfile`)**

- Image now `COPY assets` and runs `mix assets.setup && mix assets.deploy` before `mix release` — previously it baked in whatever stale `priv/static` the host had, so new `hero-*` icon classes were invisible in compose while working under `mix phx.server`.

**Tests**

- `page_controller_test.exs` (+178): landing branches (local redirect, selector tree, marketing fallback).
- `organization_detail_live_test.exs` (+122/−): switcher orgs, short slugs, settings route + auth matrix (owner save / admin locked / member redirected), `refute href="/organizations"`.
- Plug/OAuth/browser-auth expectations updated to `/`.

## Test plan

```bash
mix test test/controlkeel_web/controllers/page_controller_test.exs \
  test/controlkeel_web/live/organization_detail_live_test.exs \
  test/controlkeel_web/live/organizations_live_test.exs \
  test/controlkeel_web/controllers/oauth_login_controller_test.exs \
  test/controlkeel_web/plugs/browser_auth_plugs_test.exs
# Result on this branch: 53 passed
mix precommit   # run before merge
```

Manual: `/` as visitor / fresh local install / signed-in user with several orgs; selector chevrons collapse/expand; org switcher open → outside-click close → per-org navigation; settings rename reflects in sidebar; short slug URLs; `docker compose -f docker-cloud-compose.yml up --build` icon check (view-source CSS contains the `hero-*` classes in use).

## Follow-ups (later phases of #130)

-Workspace and Session sidebar and switcher