### PR TITLE
⚡ Bolt: [performance improvement] Optimize group_by frequency counts

### DIFF
--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -1454,9 +1454,8 @@ defmodule ControlKeel.Benchmark do
 
   defp count_by(values, mapper) do
     values
-    |> Enum.group_by(mapper)
-    |> Enum.reject(fn {key, _rows} -> is_nil(key) end)
-    |> Enum.into(%{}, fn {key, rows} -> {key, length(rows)} end)
+    |> Enum.frequencies_by(mapper)
+    |> Map.delete(nil)
   end
 
   defp maybe_channel(channels, true, channel), do: [channel | channels]

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -3210,8 +3210,7 @@ defmodule ControlKeel.Mission do
 
     engines =
       regression_runs
-      |> Enum.group_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
-      |> Enum.into(%{}, fn {engine, rows} -> {engine, length(rows)} end)
+      |> Enum.frequencies_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
 
     latest_failures =
       regression_runs
@@ -4396,12 +4395,10 @@ defmodule ControlKeel.Mission do
       "total" => length(invocations),
       "providers" =>
         invocations
-        |> Enum.group_by(&(&1.provider || "unknown"))
-        |> Enum.into(%{}, fn {provider, rows} -> {provider, length(rows)} end),
+        |> Enum.frequencies_by(&(&1.provider || "unknown")),
       "tools" =>
         invocations
-        |> Enum.group_by(&(&1.tool || "unknown"))
-        |> Enum.into(%{}, fn {tool, rows} -> {tool, length(rows)} end),
+        |> Enum.frequencies_by(&(&1.tool || "unknown")),
       "cost_cents" => total_cost,
       "latest_run_at" =>
         invocations

--- a/lib/controlkeel/mission/decomposition.ex
+++ b/lib/controlkeel/mission/decomposition.ex
@@ -227,9 +227,8 @@ defmodule ControlKeel.Mission.Decomposition do
 
   defp count_by(entries, key) do
     entries
-    |> Enum.group_by(&Map.get(&1, key))
-    |> Enum.reject(fn {value, _rows} -> is_nil(value) end)
-    |> Enum.into(%{}, fn {value, rows} -> {value, length(rows)} end)
+    |> Enum.frequencies_by(&Map.get(&1, key))
+    |> Map.delete(nil)
   end
 
   defp normalize_string(value) when is_binary(value) do


### PR DESCRIPTION
💡 **What:** Replaced the `Enum.group_by/2 |> Enum.into/2` chain with `Enum.frequencies_by/2` across several reporting and benchmarking modules.
🎯 **Why:** The previous pattern allocated intermediate lists for every grouped element only to immediately compute their length and discard them. This creates unnecessary garbage collection pressure and CPU overhead.
📊 **Impact:** Significantly reduces memory allocation and execution time when generating reports over large numbers of `regression_runs`, `invocations`, and `benchmark` entries. Time complexity remains O(N), but the constant factor and GC overhead are drastically lowered.
🔬 **Measurement:** Verify by ensuring that reporting functions (like `latest_run_at`, mission aggregations) continue to return the exact same frequency distributions and handle `nil` values appropriately.

---
*PR created automatically by Jules for task [8400830344769699334](https://jules.google.com/task/8400830344769699334) started by @aryaminus*