### PR TITLE
a11y(web): shared focus-ring + distinct aria-labels on sidebar controls

### DIFF
--- a/lib/controlkeel_web/components/layouts.ex
+++ b/lib/controlkeel_web/components/layouts.ex
@@ -16,6 +16,11 @@ defmodule ControlKeelWeb.Layouts do
 
   embed_templates "layouts/*"
 
+  # Keyboard focus visibility for sidebar controls. The toggle buttons also
+  # carry `aria-label="Toggle <label> menu"` so the icon-only chevrons
+  # announce distinctly inside the nav loop.
+  @focus_ring "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+
   @doc """
   The dashboard sidebar: logo, primary nav, and external links.
 
@@ -62,6 +67,7 @@ defmodule ControlKeelWeb.Layouts do
                 data-sidebar-toggle
                 aria-expanded={(opened && "true") || "false"}
                 aria-controls={collapse_id}
+                aria-label={"Toggle #{item.label} menu"}
                 class={["w-full text-left cursor-pointer", sidebar_link_class(active)]}
               >
                 <.icon name={item.icon} class={sidebar_icon_class(active)} />
@@ -201,11 +207,11 @@ defmodule ControlKeelWeb.Layouts do
   defp nav_active?(_current_path, _path, _exact), do: false
 
   defp sidebar_link_class(true) do
-    "group flex items-center gap-3 rounded-xl bg-muted px-3 py-2.5 font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted"
+    "group flex items-center gap-3 rounded-xl bg-muted px-3 py-2.5 font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted #{@focus_ring}"
   end
 
   defp sidebar_link_class(false) do
-    "group flex items-center gap-3 rounded-xl px-3 py-2.5 font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+    "group flex items-center gap-3 rounded-xl px-3 py-2.5 font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground #{@focus_ring}"
   end
 
   defp sidebar_icon_class(true), do: "size-4 text-primary"
@@ -239,11 +245,11 @@ defmodule ControlKeelWeb.Layouts do
   end
 
   defp subnav_link_class(true) do
-    "group flex items-center gap-2.5 rounded-lg bg-muted px-2.5 py-1.5 text-sm font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted"
+    "group flex items-center gap-2.5 rounded-lg bg-muted px-2.5 py-1.5 text-sm font-medium text-foreground shadow-sm ring-1 ring-border transition hover:bg-muted #{@focus_ring}"
   end
 
   defp subnav_link_class(false) do
-    "group flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+    "group flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground #{@focus_ring}"
   end
 
   defp subnav_icon_class(true), do: "size-3.5 shrink-0 text-primary"

--- a/test/controlkeel_web/components/layouts_test.exs
+++ b/test/controlkeel_web/components/layouts_test.exs
@@ -12,9 +12,17 @@ defmodule ControlKeelWeb.LayoutsTest do
     assert html =~ "sidebar-collapse-observability"
     assert html =~ "sidebar-chevron-observability"
     assert html =~ "aria-expanded=\"false\""
+    assert html =~ "aria-label=\"Toggle Observability menu\""
     assert html =~ "hidden"
     assert html =~ "Overview"
     assert html =~ "Learning loop"
+  end
+
+  test "sidebar links carry expected keyboard focus styles" do
+    html = render_component(&Layouts.sidebar/1, current_path: "/dashboard")
+
+    assert html =~ "focus-visible:ring-offset-2"
+    assert html =~ "focus-visible:ring-offset-background"
   end
 
   test "sidebar renders Observability section expanded when current path matches" do


### PR DESCRIPTION
## Summary

One-line-class a11y consolidation for the dashboard sidebar, replacing three overlapping Jules drafts (#140, #149, #152 — all still open) with a single focused commit:

- **Distinct `aria-label` on each section toggle button** (`Toggle <label> menu`, interpolated from the loop variable) — screen readers no longer hear duplicate generic labels.
- **Shared `@focus_ring` module attribute** applied to `sidebar_link_class/1` (active + inactive) and `subnav_link_class/1` — visible keyboard-focus ring with background offset, one source of truth.
- New tests: toggle label assertion added to the existing Observability section test; new focus-style test pinning the ring-offset classes.

## Verify

- `mix test test/controlkeel_web/components/layouts_test.exs` — 7/7 pass
- `mix compile --warnings-as-errors` — clean; `mix format` — clean

## Notes

- Builds on the sidebar ARIA already on main (aria-expanded/aria-controls from #88); adds only the missing label + focus ring.
- After this merges, #140, #149, and #152 should be closed as superseded (their test assertions were folded in here).
