### PR TITLE
perf(elixir): replace group_by+length with frequencies_by in count paths

### DIFF
--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -1454,9 +1454,8 @@ defmodule ControlKeel.Benchmark do
 
   defp count_by(values, mapper) do
     values
-    |> Enum.group_by(mapper)
-    |> Enum.reject(fn {key, _rows} -> is_nil(key) end)
-    |> Enum.into(%{}, fn {key, rows} -> {key, length(rows)} end)
+    |> Enum.frequencies_by(mapper)
+    |> Map.delete(nil)
   end
 
   defp maybe_channel(channels, true, channel), do: [channel | channels]

--- a/lib/controlkeel/governance/session_digest.ex
+++ b/lib/controlkeel/governance/session_digest.ex
@@ -138,8 +138,7 @@ defmodule ControlKeel.Governance.SessionDigest do
 
   defp count_by_field(records, field) do
     records
-    |> Enum.group_by(&Map.get(&1, field))
-    |> Enum.map(fn {k, v} -> {k, length(v)} end)
+    |> Enum.frequencies_by(&Map.get(&1, field))
     |> Enum.sort_by(fn {_k, v} -> v end, :desc)
     |> Enum.take(5)
     |> Map.new()

--- a/lib/controlkeel/mission.ex
+++ b/lib/controlkeel/mission.ex
@@ -3210,8 +3210,7 @@ defmodule ControlKeel.Mission do
 
     engines =
       regression_runs
-      |> Enum.group_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
-      |> Enum.into(%{}, fn {engine, rows} -> {engine, length(rows)} end)
+      |> Enum.frequencies_by(&(get_in(&1.metadata, ["regression", "engine"]) || "unknown"))
 
     latest_failures =
       regression_runs
@@ -4396,12 +4395,10 @@ defmodule ControlKeel.Mission do
       "total" => length(invocations),
       "providers" =>
         invocations
-        |> Enum.group_by(&(&1.provider || "unknown"))
-        |> Enum.into(%{}, fn {provider, rows} -> {provider, length(rows)} end),
+        |> Enum.frequencies_by(&(&1.provider || "unknown")),
       "tools" =>
         invocations
-        |> Enum.group_by(&(&1.tool || "unknown"))
-        |> Enum.into(%{}, fn {tool, rows} -> {tool, length(rows)} end),
+        |> Enum.frequencies_by(&(&1.tool || "unknown")),
       "cost_cents" => total_cost,
       "latest_run_at" =>
         invocations

--- a/lib/controlkeel/mission/decomposition.ex
+++ b/lib/controlkeel/mission/decomposition.ex
@@ -227,9 +227,8 @@ defmodule ControlKeel.Mission.Decomposition do
 
   defp count_by(entries, key) do
     entries
-    |> Enum.group_by(&Map.get(&1, key))
-    |> Enum.reject(fn {value, _rows} -> is_nil(value) end)
-    |> Enum.into(%{}, fn {value, rows} -> {value, length(rows)} end)
+    |> Enum.frequencies_by(&Map.get(&1, key))
+    |> Map.delete(nil)
   end
 
   defp normalize_string(value) when is_binary(value) do


### PR DESCRIPTION
## Summary

One clean `Enum.frequencies_by/2` sweep replacing seven overlapping Bolt drafts (#155, #157, #158, #161, #163, #165, #167 — all still open) with a single commit, no journal files, no inline annotations.

`Enum.frequencies_by/2` counts in one pass without building per-group lists; nil keys are dropped with `Map.delete(nil)`, preserving the old reject semantics:

- `Benchmark.count_by/2` (benchmark.ex:1455)
- `Mission` regression-engine counts + invocation providers/tools summary (mission.ex)
- `Decomposition.count_by/2`
- `SessionDigest.count_by_field/1` (keeps the sort/take-5/top-map shape)

## Verify

- Equivalence confirmed by construction (`group_by |> reject-nil |> length == frequencies_by |> drop-nil`) plus a runtime spot-check.
- Existing suites green: benchmark, mission, decomposition callers, session_digest tests.
- `mix compile --warnings-as-errors` clean; `mix format` clean.

## Notes

- After this merges, #155, #157, #158, #161, #163, #165, and #167 should be closed as duplicates (their hunks are all covered here; #158/#165's extra `session_digest` hunk included).
