### PR TITLE
⚡ Bolt: [performance improvement] Optimize Enum.group_by in benchmark.ex

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-08-19 - Elixir List Allocation Overhead
 **Learning:** Chaining `Enum.map/2` into `Enum.uniq/1` then `length/1` (or `Enum.filter/2` into `length/1`) forces unnecessary intermediate list allocations in Elixir, adding hidden overhead.
 **Action:** Use `MapSet.new/2 |> MapSet.size()` and `Enum.count/2` to skip intermediate lists and reduce GC pressure.
+## 2023-11-20 - Map grouping overhead
+**Learning:** `Enum.group_by(mapper) |> Enum.reject(nil) |> Enum.into(%{}, count)` creates intermediate lists for all matched values.
+**Action:** Use `Enum.frequencies_by(mapper) |> Map.delete(nil)` for faster processing and lower memory allocation.

--- a/lib/controlkeel/benchmark.ex
+++ b/lib/controlkeel/benchmark.ex
@@ -1453,10 +1453,11 @@ defmodule ControlKeel.Benchmark do
   defp percentage(count, total), do: Float.round(count / total * 100, 1)
 
   defp count_by(values, mapper) do
+    # Bolt: Replaced Enum.group_by |> Enum.reject |> Enum.into with Enum.frequencies_by
+    # to skip intermediate list allocations and reduce GC pressure.
     values
-    |> Enum.group_by(mapper)
-    |> Enum.reject(fn {key, _rows} -> is_nil(key) end)
-    |> Enum.into(%{}, fn {key, rows} -> {key, length(rows)} end)
+    |> Enum.frequencies_by(mapper)
+    |> Map.delete(nil)
   end
 
   defp maybe_channel(channels, true, channel), do: [channel | channels]


### PR DESCRIPTION
**What:**
Replaced `Enum.group_by |> Enum.reject |> Enum.into` with `Enum.frequencies_by |> Map.delete` in `count_by/2` within `lib/controlkeel/benchmark.ex`.

**Why:**
The original implementation grouped elements into lists before counting them. This created intermediate lists for every grouped element, adding unnecessary memory allocation and garbage collection overhead when the only goal was to count them. `Enum.frequencies_by` increments a counter directly, which is significantly faster and more memory-efficient.

**Impact:**
Reduces intermediate list allocations and garbage collection pressure when executing benchmarks and evaluating their scenarios.

**Measurement:**
Observe memory allocations when running `count_by/2`. The resulting values remain identical, as `Map.delete(..., nil)` accurately mimics `Enum.reject` filtering out `nil` keys.

---
*PR created automatically by Jules for task [222838858914275449](https://jules.google.com/task/222838858914275449) started by @aryaminus*