### PR TITLE
fix(migration-test): pin FK setup to single connection

### DIFF
--- a/test/controlkeel/repo/add_org_fk_to_workspaces_migration_test.exs
+++ b/test/controlkeel/repo/add_org_fk_to_workspaces_migration_test.exs
@@ -15,7 +15,7 @@ defmodule ControlKeel.Repo.AddOrgFkToWorkspacesMigrationTest do
     start_supervised!(
       {MigrationRepo,
        database: database,
-       pool_size: 2,
+       pool_size: 1,
        busy_timeout: 5_000,
        stacktrace: true,
        show_sensitive_data_on_connection_error: true}
@@ -23,10 +23,14 @@ defmodule ControlKeel.Repo.AddOrgFkToWorkspacesMigrationTest do
 
     repo = MigrationRepo
 
-    query!(repo, "PRAGMA foreign_keys = OFF")
-    create_pre_migration_schema!(repo)
-    seed_pre_migration_data!(repo)
-    query!(repo, "PRAGMA foreign_keys = ON")
+    # PRAGMA foreign_keys is per-connection: keep OFF/seed/ON on the same
+    # checkout so the dangling seed row can't land on a guarded connection.
+    repo.checkout(fn ->
+      query!(repo, "PRAGMA foreign_keys = OFF")
+      create_pre_migration_schema!(repo)
+      seed_pre_migration_data!(repo)
+      query!(repo, "PRAGMA foreign_keys = ON")
+    end)
 
     assert :ok =
              Ecto.Migrator.up(repo, @migration_version, AddOrgFkToWorkspaces, log: false)


### PR DESCRIPTION
### Problem

`AddOrgFkToWorkspacesMigrationTest` flaked in merge CI: `Exqlite.Error FOREIGN KEY constraint failed` on the seed `INSERT ... org_id 999`
— before the migration even ran. Green on PR, red on merge.

### Root cause

`PRAGMA foreign_keys` is per-connection, but `MigrationRepo` ran with `pool_size: 2`. `PRAGMA OFF` hit one connection while the seed `INSERT` could check out the other (still guarded). Pool checkout order is nondeterministic, so it passed or failed by luck.

### Change

`test/controlkeel/repo/add_org_fk_to_workspaces_migration_test.exs` only:

- `pool_size: 2 → 1`
- wrapped `PRAGMA OFF → schema → seed → PRAGMA ON` in one `repo.checkout/1` so setup shares a single connection.

### Verification

- `mix test test/controlkeel/repo/add_org_fk_to_workspaces_migration_test.exs` → 1 passed
- repeated ×5 random seeds → all passed

### Risk

Test-only. No prod/migration code touched.
